### PR TITLE
Parse MPCO META so element results carry real component names

### DIFF
--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -64,7 +64,10 @@ er = ds.elements.get_element_results(
 The core data is in `er.df` — a pandas DataFrame with:
 
 - **Index**: MultiIndex `(element_id, step)`
-- **Columns**: `val_1`, `val_2`, ..., `val_N` (one per result component)
+- **Columns**: real component names parsed from each bucket's
+  `META/COMPONENTS`. The shape depends on the bucket topology — see
+  [Column naming](#column-naming) below. Falls back to
+  `val_1, val_2, ..., val_N` only when META is absent.
 
 Additional attributes:
 
@@ -77,13 +80,31 @@ er.results_name    # str — HDF5 result group name (e.g. "globalForces")
 er.model_stage     # str — model stage this data comes from
 ```
 
+## Column naming
+
+Names come straight from each bucket's `META/COMPONENTS`. The four
+patterns the parser produces:
+
+| Bucket shape | Example | Names |
+|---|---|---|
+| Closed-form beam (`force`, `localForce`) | `5-ElasticBeam3d` | `Px_1, Py_1, ..., Mz_2` (global) or `N_1, Vy_1, ..., Mz_2` (local) |
+| Closed-form continuum (`force` on solid) | `56-Brick`, 8 nodes × 3 DOFs | `P1_1, P2_1, P3_1, ..., P3_8` |
+| Line-stations (`section.force`, `section.deformation`) | force-/disp-based beam, 5 IPs × 4 section comps | `P_ip0, Mz_ip0, My_ip0, T_ip0, ..., T_ip4` |
+| Gauss-level continuum (`material.stress`, `material.strain`) | `56-Brick`, 8 IPs × 6 stress comps | `sigma11_ip0, sigma22_ip0, ..., sigma13_ip7` |
+| Compressed fibers (`section.fiber.stress`) | `MULTIPLICITY > 1`, 6 fibers × 2 IPs | `sigma11_f0_ip0, sigma11_f1_ip0, ..., sigma11_f5_ip1` |
+
+See [`docs/mpco_format_conventions.md`](mpco_format_conventions.md) for
+the underlying META layout, and `STKO_to_python/io/meta_parser.py` for
+the parser that produces these names.
+
 ## Introspection
 
 ```python
 er.list_components()
-# ('val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6')
+# ('Px_1', 'Py_1', 'Pz_1', 'Mx_1', 'My_1', 'Mz_1',
+#  'Px_2', 'Py_2', 'Pz_2', 'Mx_2', 'My_2', 'Mz_2')
 
-er.n_components    # 6
+er.n_components    # 12
 er.n_elements      # 150
 er.n_steps         # 2000
 er.empty           # False
@@ -97,11 +118,11 @@ er.empty           # False
 # All components, all elements
 df = er.fetch()
 
-# Single component
-s = er.fetch("val_1")
+# Single component (e.g., axial force at IP 2)
+s = er.fetch("P_ip2")
 
 # Filter by element IDs
-s = er.fetch("val_1", element_ids=[100, 101])
+s = er.fetch("Mz_1", element_ids=[100, 101])
 
 # All components, filtered elements
 df = er.fetch(element_ids=[100, 101])
@@ -112,13 +133,13 @@ df = er.fetch(element_ids=[100, 101])
 Each column is available as an attribute via `_ElementResultView`:
 
 ```python
-# Equivalent to er.fetch("val_1")
-s = er.val_1.series
+# Equivalent to er.fetch("Mz_1")
+s = er.Mz_1.series
 
 # Filter by element IDs
-s = er.val_1[100]          # single element
-s = er.val_1[[100, 101]]   # multiple elements
-s = er.val_1[:]            # all elements
+s = er.Mz_1[100]           # single element
+s = er.Mz_1[[100, 101]]    # multiple elements
+s = er.Mz_1[:]             # all elements
 ```
 
 ## Envelope
@@ -129,13 +150,52 @@ Compute min/max over all time steps for each element:
 # All components
 env = er.envelope()
 # Returns DataFrame indexed by element_id:
-#   val_1_min, val_1_max, val_2_min, val_2_max, ...
+#   Px_1_min, Px_1_max, Py_1_min, Py_1_max, ...
 
 # Single component
-env = er.envelope(component="val_1")
+env = er.envelope(component="Mz_1")
 # Returns DataFrame indexed by element_id:
-#   val_1_min, val_1_max
+#   Mz_1_min, Mz_1_max
 ```
+
+## Integration-point coordinates
+
+Line-station and gauss-level buckets that have a `GP_X` attribute on
+their connectivity dataset (force/disp-based beam-columns) expose the
+integration-point positions as `er.gp_xi` — a 1-D numpy array in
+**natural coordinates** ξ ∈ [-1, +1].
+
+```python
+er = ds.elements.get_element_results("section.force", "64-DispBeamColumn3d", element_ids=[1])
+er.n_ip       # 5  (number of integration points)
+er.gp_xi      # array([-1., -0.65, 0., 0.65, 1.])  — Lobatto 5-pt
+```
+
+To convert to physical coordinates [0, L] for plotting:
+
+```python
+x = er.physical_x(beam_length=2.0)
+# array([0., 0.345, 1., 1.655, 2.])
+```
+
+Per-IP slicing:
+
+```python
+sub = er.at_ip(2)                  # only columns ending '_ip2'
+# columns: ['P_ip2', 'Mz_ip2', 'My_ip2', 'T_ip2']
+moments_at_midspan = sub["Mz_ip2"]
+```
+
+Closed-form buckets (no integration points) have `er.gp_xi is None`,
+`er.n_ip == 0`, and calling `er.at_ip(...)` or `er.physical_x(...)`
+raises `ValueError`. Continuum classes like 8-IP brick `material.stress`
+also expose `n_ip == 0` for now (no `GP_X` on their connectivity);
+class-level catalog support is planned future work.
+
+For the underlying convention details, see
+[mpco_format_conventions.md §1, §7](mpco_format_conventions.md). The
+natural↔physical conversion utilities live at
+[`utilities/coords.py`](api/index.md).
 
 ## Time Snapshots
 
@@ -143,7 +203,7 @@ env = er.envelope(component="val_1")
 
 ```python
 df_step = er.at_step(100)
-# Returns DataFrame indexed by element_id with columns val_1, val_2, ...
+# Returns DataFrame indexed by element_id with the named columns.
 ```
 
 ### By time value
@@ -250,19 +310,20 @@ print(er)
 #   Elements: 150, Steps: 2000, Components: 6
 
 print(er.list_components())
-# ('val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6')
+# ('Px_1', 'Py_1', 'Pz_1', 'Mx_1', 'My_1', 'Mz_1',
+#  'Px_2', 'Py_2', 'Pz_2', 'Mx_2', 'My_2', 'Mz_2')
 
 # --- Force envelope ---
 env = er.envelope()
 print(env.head())
-#             val_1_min  val_1_max  val_2_min  val_2_max  ...
+#             Px_1_min  Px_1_max  Py_1_min  Py_1_max  ...
 
 # --- Snapshot at t=5s ---
 snap = er.at_time(5.0)
 print(snap.head())
 
 # --- Time history for specific element ---
-s = er.val_1[42]
+s = er.Mz_1[42]
 print(s)
 
 # --- Export with time column ---
@@ -286,9 +347,13 @@ results_by_type = ds.elements.get_element_results_by_selection_and_z(
 
 for etype, er in results_by_type.items():
     print(f"\n{etype}: {er.n_elements} elements")
-    env = er.envelope(component="val_1")
-    print(f"  Max val_1: {env['val_1_max'].max():.2f}")
-    print(f"  Min val_1: {env['val_1_min'].min():.2f}")
+    # Pick any component name from list_components(). Example for shell
+    # globalForce: er.list_components() yields ('P1','P2',...,'P24'),
+    # one per node-DOF.
+    comp = er.list_components()[0]
+    env = er.envelope(component=comp)
+    print(f"  Max {comp}: {env[f'{comp}_max'].max():.2f}")
+    print(f"  Min {comp}: {env[f'{comp}_min'].min():.2f}")
 
     # Save each type separately
     er.save_pickle(f"forces_{etype.replace('/', '_')}.pkl.gz")
@@ -296,6 +361,7 @@ for etype, er in results_by_type.items():
 
 ## Notes
 
-- Column names (`val_1`, `val_2`, ...) are generic. The physical meaning depends on the element type and result name in your OpenSees model (e.g., for `globalForces` on shell elements, these might correspond to Nx, Ny, Nxy, Mx, My, Mxy).
+- Column names come from each bucket's `META/COMPONENTS`. They reflect the actual physical components recorded by OpenSees — `Px_1` (global X-force at element node 1), `Mz_ip3` (bending moment about local z at the 4th integration point), `sigma11_f0_ip0` (axial stress in the first fiber at the first IP), etc. See [Column naming](#column-naming) for the patterns and [`docs/mpco_format_conventions.md`](mpco_format_conventions.md) for the underlying format details.
+- Files written with older recorder versions that lack META fall back to `val_1, val_2, ..., val_N`. The parser raises `MpcoFormatError` if META is present but malformed (NUM_COLUMNS mismatch, non-sequential GAUSS_IDS, etc.) — see `STKO_to_python/io/meta_parser.py`.
 - The `element_type` parameter uses the base type (before the bracket), e.g. `"203-ASDShellQ4"` not `"203-ASDShellQ4[some_detail]"`.
 - `at_time()` uses the closest step to the requested time. If the exact time is not found, no error is raised — it picks the nearest available step.

--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -158,6 +158,47 @@ env = er.envelope(component="Mz_1")
 #   Mz_1_min, Mz_1_max
 ```
 
+## Canonical (engineering-friendly) names
+
+The on-disk MPCO shortnames vary by element family — `P_ip0` for axial
+force at the first IP of a line-station beam, `N_1` for axial force at
+node 1 of a closed-form `localForce` bucket, `Fxx_ip0` for shell
+membrane Fxx, `sigma11_ip7` for the 11-stress at the 8th Gauss point
+of a brick. The canonical-name layer maps engineering quantities
+(`axial_force`, `bending_moment_z`, `stress_11`, `membrane_xx`, …) to
+whichever shortnames are present in the result:
+
+```python
+er = ds.elements.get_element_results("section.force", "64-DispBeamColumn3d", element_ids=[1])
+er.list_canonicals()
+# ('axial_force', 'bending_moment_y', 'bending_moment_z', 'torsion')
+
+er.canonical_columns("axial_force")
+# ('P_ip0', 'P_ip1', 'P_ip2', 'P_ip3', 'P_ip4')
+
+er.canonical("bending_moment_z")    # DataFrame view
+# columns: Mz_ip0, Mz_ip1, Mz_ip2, Mz_ip3, Mz_ip4
+```
+
+Asking for a quantity that doesn't apply to the result raises:
+
+```python
+er_shell = ds.elements.get_element_results("section.force", "203-ASDShellQ4", element_ids=[100])
+er_shell.canonical("axial_force")
+# ValueError: No columns matching canonical name 'axial_force'.
+# Present canonicals: ('membrane_xx', 'membrane_yy', ..., 'transverse_shear_yz')
+```
+
+The full canonical → MPCO-shortname map and the regex used to strip
+`_<int>` / `_ip<int>` / `_f<int>_ip<int>` suffixes live in
+[`elements/canonical.py`](api/index.md). Note: `My`/`Mz` and similar
+local↔global axis collisions (per
+[`mpco_format_conventions.md` §9](mpco_format_conventions.md)) are
+**disambiguated by which results bucket you fetched**, not by the
+canonical name. Fetch `localForce` for element-local moments, fetch
+`force` (globalForce) and access columns directly by shortname for
+global-axis moments.
+
 ## Integration-point coordinates
 
 Line-station and gauss-level buckets that have a `GP_X` attribute on

--- a/docs/mpco_format_conventions.md
+++ b/docs/mpco_format_conventions.md
@@ -1,0 +1,350 @@
+# MPCO format conventions & gotchas
+
+Lessons captured while wiring beam-element topologies into a sibling
+library's MPCO reader (apeGmsh Phase 11b: line-stations + nodal-forces).
+This document focuses on **format-level** findings — things STKO_to_python
+can use directly when extending its `.mpco` parsing.
+
+Each item is a discovery that would have saved time if known upfront.
+
+---
+
+## 1. `GP_X` lives on connectivity, not on results buckets
+
+Custom-rule (force-/disp-based beam-column) integration-point coordinates
+are an *attribute* on the connectivity dataset:
+
+```
+MODEL_STAGE[<n>]/MODEL/ELEMENTS/<class_tag>-<class_name>[<rule>:<cust>]
+    @GP_X         (n_IP,)   float64   — natural ξ in [-1, +1]
+    @INTEGRATION_RULE = [1000]
+    @CUSTOM_INTEGRATION_RULE = [1]
+    @CUSTOM_INTEGRATION_RULE_DIMENSION = [1]
+    @GEOMETRY = [1]   # line
+```
+
+Note the **2-field bracket** `[<rule>:<cust>]` on connectivity. Results
+buckets at `RESULTS/ON_ELEMENTS/section.force/<bracket>` use the **3-field**
+form `[<rule>:<cust>:<hdr>]`. The `<rule>:<cust>` pair is the common key
+linking them.
+
+`GP_X` values are in natural `[-1, +1]`, **not** physical `[0, L]`. This is
+counterintuitive because `ops.eleResponse(eid, "integrationPoints")` (live
+openseespy) returns physical `pts[i] * L` instead — see §7.
+
+---
+
+## 2. META/COMPONENTS string format
+
+A single byte-string per bucket. Two distinct shapes depending on topology:
+
+### Line-stations (force-/disp-based beams under `section.force`)
+
+```
+"<pathInts>.<compsCsv>;<pathInts>.<compsCsv>;..."
+```
+
+`;`-separated, **one segment per integration point**. Each segment is
+`<pathInts>.<compsCsv>`, where:
+
+- `<pathInts>` = dot-separated descriptor codes from
+  `ElementOutputDescriptorType` (`0=Element, 1=Gauss, 2=Section,
+  3=Fiber, 4=Material`). For `section.force` on beams it's `0.1.2`
+  (Element→Gauss→Section).
+- `<compsCsv>` = comma-separated section response component names
+  (`P`, `Mz`, `My`, `T`, `Vy`, `Vz`).
+
+Example for 5-IP Lobatto + aggregated 6-comp section:
+```
+"0.1.2.P,Mz,My,T,Vy,Vz;0.1.2.P,Mz,My,T,Vy,Vz;0.1.2.P,Mz,My,T,Vy,Vz;0.1.2.P,Mz,My,T,Vy,Vz;0.1.2.P,Mz,My,T,Vy,Vz"
+```
+
+To parse: split on `;`, then for each segment take the substring after the
+**last** `.` (path ints can be more than 3 deep for fibers — see §16). For
+homogeneous-section beams, every segment is identical.
+
+### Nodal forces (closed-form elastic beams under `globalForce`/`localForce`)
+
+A **single segment** with node-suffixed names, node-major:
+
+```
+globalForce 3D: "0.Px_1,Py_1,Pz_1,Mx_1,My_1,Mz_1,Px_2,Py_2,Pz_2,Mx_2,My_2,Mz_2"
+localForce  3D: "0.N_1,Vy_1,Vz_1,T_1,My_1,Mz_1,N_2,Vy_2,Vz_2,T_2,My_2,Mz_2"
+globalForce 2D: "0.Px_1,Py_1,Mz_1,Px_2,Py_2,Mz_2"
+localForce  2D: "0.N_1,Vy_1,Mz_1,N_2,Vy_2,Mz_2"
+```
+
+The `_1` / `_2` suffix is the element-node index. Path is just `0.` (no
+Gauss/Section level — closed-form means no integration points).
+
+---
+
+## 3. Closed-form META has a `GAUSS_IDS=[[-1]]` sentinel
+
+Distinct from gauss-level buckets where `GAUSS_IDS = [[0], [1], ..., [n-1]]`.
+For closed-form line elements:
+
+```
+META/MULTIPLICITY     = [[1]]
+META/GAUSS_IDS        = [[-1]]            ← sentinel: "no integration point"
+META/NUM_COMPONENTS   = [[<flat_size>]]   ← whole flat width in one block
+NUM_COLUMNS attribute = <flat_size>       ← n_nodes × n_components_per_node
+```
+
+So validation paths must accept `-1` as a valid GAUSS_ID for nodal-forces
+buckets, while still rejecting it for gauss-level buckets.
+
+---
+
+## 4. The `customRuleIdx` axis groups elements by `(rule_type, x_vector)` identity
+
+Two `forceBeamColumn` elements with the same `beamIntegration` AND the
+same length share a `customRuleIdx`. With different lengths or rules,
+they get different ones. So:
+
+- A given bucket's `GP_X` is **uniform across its elements**.
+- A model with heterogeneous beam-integrations spawns **multiple buckets per element class**.
+
+When stitching slabs, group by bucket, not by class — same class can land
+in multiple buckets.
+
+---
+
+## 5. `SECTION_RESPONSE_*` codes are stable ABI
+
+Fixed in `OpenSees/SRC/material/section/SectionForceDeformation.h:52–57`:
+
+```
+1 = SECTION_RESPONSE_MZ
+2 = SECTION_RESPONSE_P
+3 = SECTION_RESPONSE_VY
+4 = SECTION_RESPONSE_MY
+5 = SECTION_RESPONSE_VZ
+6 = SECTION_RESPONSE_T
+```
+
+Plus `15 = MYY`, `18 = VYZ` for warping/asymmetric sections (rarely used,
+worth flagging if encountered).
+
+The MPCO short names in META map 1:1:
+
+| MPCO name | Code | Meaning |
+|---|---|---|
+| `P` | 2 | Axial force |
+| `Mz` | 1 | Bending moment about local z |
+| `My` | 4 | Bending moment about local y |
+| `T` | 6 | Torsion |
+| `Vy` | 3 | Shear in local y |
+| `Vz` | 5 | Shear in local z |
+
+---
+
+## 6. Section response order matches `getType()` order, NOT any canonical layout
+
+A bare `FiberSection3d` has `getType() = [P, Mz, My, T]` (codes
+`(2, 1, 4, 6)`, that order). `SectionAggregator` appends in user-listed
+order: `section Aggregator 11 100 Vy 101 Vz -section 1` produces
+`[P, Mz, My, T, Vy, Vz]` (codes `(2, 1, 4, 6, 3, 5)`).
+
+User-defined aggregation orders are also valid — there's no enforced
+canonical layout. **Read the actual codes from META/COMPONENTS** rather
+than assuming one. The `n_components` count alone is insufficient: a
+4-comp section could be `(P, Mz, My, T)` OR `(P, Mz, Vy, T)` if someone
+aggregated weirdly.
+
+---
+
+## 7. `ops.eleResponse(eid, "integrationPoints")` returns physical `pts[i] * L`
+
+Per `ForceBeamColumn3d.cpp:3338–3346`, the live openseespy call returns
+positions along the beam in **physical length** (`[0, L]`), NOT natural
+parent coordinates. MPCO's `GP_X` attribute, in contrast, is in **natural
+ξ ∈ [-1, +1]**.
+
+To bridge:
+
+```python
+xi_natural = 2.0 * xi_phys / L - 1.0
+# where L = ||coords[node_j] - coords[node_i]|| from connectivity
+```
+
+Easy to miss because both APIs talk about "integration points" without
+flagging the unit difference. Burned 30 minutes in a debugging session
+before we caught it.
+
+---
+
+## 8. Disp-based beam-columns don't expose `integrationPoints` (live)
+
+`DispBeamColumn{2d,3d}` and family don't implement
+`getResponse("integrationPoints")` in OpenSees v3.7.x. MPCO writes their
+`GP_X` to disk anyway via internal Tier 2/3 probing in
+`MPCORecorder.cpp:4089–4265` (a `setResponse(["section", "dummy"], ...)`
+trick), so `.mpco` files contain the data. But any tool doing **live**
+openseespy introspection (e.g. an in-memory recorder) will silently miss
+disp-based beams.
+
+For STKO_to_python: not directly relevant if you only read `.mpco` files,
+but worth knowing if you ever extend to live capture.
+
+---
+
+## 9. `globalForce` / `localForce` use different component-name conventions
+
+For the same closed-form 3D beam:
+
+| Frame | Per-node names |
+|---|---|
+| `globalForce` | `Px, Py, Pz, Mx, My, Mz` (global axes) |
+| `localForce` | `N, Vy, Vz, T, My, Mz` (element-local axes) |
+
+Same physical DOFs, different naming. The `My` / `Mz` symbols **collide**
+between frames; only the keyword (`globalForce` vs `localForce`)
+disambiguates them. `N`, `Vy`, `Vz`, `T` are local-frame-only; `Px`, `Py`,
+`Pz`, `Mx` are global-frame-only.
+
+---
+
+## 10. Path ints in META/COMPONENTS are descriptor types, not array indices
+
+`<pathInts>` like `0.1.2.` is **NOT** `(elem_idx, gauss_idx, section_idx)`
+— it's `ElementOutputDescriptorType` codes:
+
+```
+0 = Element
+1 = Gauss
+2 = Section
+3 = Fiber
+4 = Material
+```
+
+So `0.1.2.` means "Element→Gauss→Section" hierarchy. The Gauss-point
+INDEX is encoded by the **segment's position** in the `;`-separated list,
+NOT by anything in `pathInts`. Don't read `0.1.2.` as "element 0, gauss 1,
+section 2".
+
+For deeper levels like fiber probing, expect paths like `0.1.2.3.` (adds
+Fiber) or `0.1.2.4.` (adds Material).
+
+---
+
+## 11. `NUM_COLUMNS` should equal the META block sum
+
+Invariant: `sum(MULTIPLICITY[i] * NUM_COMPONENTS[i]) == NUM_COLUMNS`.
+For closed-form (single block): `1 * NUM_COMPONENTS[0] == NUM_COLUMNS`.
+For gauss-level: e.g. `5 * 6 == 30` for 5-IP × 6-comp aggregated section.
+
+This invariant catches MPCO version drift early. If your reader sees a
+mismatch, the bucket layout assumption is wrong and you should stop
+rather than producing silently-misaligned data.
+
+---
+
+## 12. `MULTIPLICITY > 1` indicates compressed META
+
+Adjacent blocks with identical structure (e.g. all fibers of one section
+sharing the same component layout) get collapsed: a `MULTIPLICITY[i] = N`
+means N adjacent column-groups share `NUM_COMPONENTS[i]` and the same
+component names (the COMPONENTS string repeats once for each, but
+sometimes MPCO compresses the shared structure). Worth checking when
+parsing fiber buckets in Phase 11c-equivalent work.
+
+---
+
+## 13. Catalog architecture: split "fixed by class" vs "varies per instance"
+
+When wiring beam-columns we found a clean separation:
+
+- **`ResponseLayout`** (fixed by class): `(class, rule, token) → (n_GP,
+  natural_coords, component_layout)`. Works for continuum solids, shells,
+  trusses — anything with class-determined response shape.
+- **`CustomRuleLayout`** (per-instance): just `(class_tag, coord_system)`.
+  The actual `(n_IP, GP_X, component_layout)` is resolved at read time
+  from `(GP_X attribute, META/COMPONENTS section codes)`.
+
+Two parallel catalogs, non-overlapping membership. Keeps the
+"declarative" catalog small and pushes the variable shape into a
+narrow runtime resolver. This pattern likely scales to fibers and
+layered shells — anywhere the response shape depends on per-element
+metadata (assigned section, layered material, etc.).
+
+---
+
+## 14. Topology-aware routing avoids canonical-name collisions
+
+Same canonical user-facing name routes to different on-disk groups by
+*topology context*:
+
+| Canonical | Topology | MPCO keyword |
+|---|---|---|
+| `axial_force` | gauss-points | `axialForce` (Truss scalar) |
+| `axial_force` | line-stations | `section.force` (beam vector, first comp) |
+| `bending_moment_y` | shells (gauss) | `stresses` (resultant) |
+| `bending_moment_y` | line-stations | `section.force` (Mz column) |
+
+Lets the user keep ONE canonical vocabulary even when the same name maps
+to different on-disk groups depending on which element type carries it.
+The reader takes a `topology=` hint; the lookup table is per-topology.
+
+For STKO_to_python, this is relevant if you expose user-friendly names
+across multiple element families that might otherwise collide.
+
+---
+
+## 15. META is the source of truth; the catalog is a hint
+
+Always validate `NUM_COLUMNS` against your assumed layout and fail loudly
+if they disagree. Don't trust the catalog blindly — MPCO files can come
+from section configurations the catalog wasn't designed for, and silently
+mis-naming columns is worse than raising.
+
+We added a per-bucket `validate_*_meta(bucket_grp, layout, ...)` helper
+for each topology that cross-checks NUM_COLUMNS, MULTIPLICITY shape, and
+GAUSS_IDS sequence/sentinel against the resolved layout before any data
+is read.
+
+---
+
+## 16. Three-way agreement testing catches convention bugs
+
+For each topology we built three independent paths to the same data:
+
+1. **Read from `.mpco`** (file format)
+2. **Capture live via openseespy** (in-process)
+3. **Transcode from `.out` text recorder** (file format, different
+   conventions than MPCO)
+
+Then ran an identical OpenSees model and asserted the three paths
+produce the **same numbers**. Most bugs we caught were path-disagreements
+on column order or component naming — not numeric errors. The three-way
+test is the strongest signal for "convention bugs are absent."
+
+For STKO_to_python: even a two-way version (MPCO vs `.out`-via-Tcl-script)
+would catch most format-side bugs.
+
+---
+
+## 17. Inspect a real fixture before writing reader code
+
+The apeGmsh Phase 11b plan called the META/COMPONENTS format "pseudo"
+because nobody had inspected an actual file. We saved real time by:
+
+1. Writing a tiny Tcl script (`recorder mpco run.mpco -E section.force ...`)
+2. Running it through OpenSees once
+3. Dumping the HDF5 tree with `h5py` directly (skipping the
+   `inspect_mpco.py` script which had a bug on this file)
+
+Turned three guesses about the format into one verified ground truth.
+Cost ~5 minutes; saved at least an hour of "why doesn't my parser work."
+
+---
+
+## Quick-reference summary
+
+| Topology | MPCO group | GP_X location | META segments | Sentinel |
+|---|---|---|---|---|
+| Continuum gauss | `stresses` / `strains` | (catalog lookup; not per-bucket) | per-GP, sequential | `GAUSS_IDS=[0..n-1]` |
+| Line-stations (beam-columns) | `section.force` | `MODEL/ELEMENTS/<bracket-2-field>/@GP_X` | per-IP `0.1.2.<comps>` | `GAUSS_IDS=[0..n_IP-1]` |
+| Nodal forces (closed-form beams) | `globalForce` / `localForce` | n/a (no IPs) | single block `0.<node-suffixed names>` | `GAUSS_IDS=[[-1]]` |
+| Fibers | `section.fiber.stress` | per-section | per-fiber within per-IP segments | (Phase 11c — not yet codified) |
+| Layers (layered shells) | `material.fiber.stress` (with shell keyword swap) | per-surface-IP | per-layer × per-sub-IP | (Phase 11c — not yet codified) |

--- a/examples/usage_tour.py
+++ b/examples/usage_tour.py
@@ -174,14 +174,14 @@ def section_7_fetch_element(ds: MPCODataSet) -> ElementResults:
 def section_8_element_broker(er: ElementResults) -> None:
     section("8. ElementResults broker API")
 
-    sub = er.fetch(component="val_3", element_ids=[1, 2])
-    print(f"fetch('val_3', [1,2]) -> Series length {len(sub)}")
+    sub = er.fetch(component="Pz_1", element_ids=[1, 2])
+    print(f"fetch('Pz_1', [1,2]) -> Series length {len(sub)}")
 
-    view = er.val_3[[1, 2]]
-    print(f"er.val_3[[1,2]]        -> type {type(view).__name__}")
+    view = er.Pz_1[[1, 2]]
+    print(f"er.Pz_1[[1,2]]        -> type {type(view).__name__}")
 
-    env = er.envelope(component="val_3")
-    print(f"envelope('val_3'):     {list(env.columns)}")
+    env = er.envelope(component="Pz_1")
+    print(f"envelope('Pz_1'):     {list(env.columns)}")
     print(env)
 
     snap_step = er.at_step(5)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Architecture: architecture.md
+  - MPCO format conventions: mpco_format_conventions.md
   - Design spec (historical): architecture-refactor-proposal.md
   - API reference:
       - Overview: api/index.md

--- a/src/STKO_to_python/elements/canonical.py
+++ b/src/STKO_to_python/elements/canonical.py
@@ -1,0 +1,212 @@
+"""Canonical (engineering-friendly) names for MPCO result components.
+
+Users pulling element results today must know each result-bucket's
+on-disk shortnames: ``P_ip0`` for axial force at the first IP of a
+line-station beam, ``N_1`` for axial force at node 1 of a closed-form
+``localForce`` bucket, ``Fxx_ip0`` for shell membrane Fxx, and so on.
+Every element family carries the same engineering quantity under a
+different MPCO shortname, by historical convention rather than design.
+
+This module provides a tiny canonical → shortname map plus helpers
+that filter the columns of an :class:`ElementResults` by canonical
+name. With it a user can write::
+
+    axial = er.canonical("axial_force")  # P_* or N_* depending on bucket
+    moments = er.canonical("bending_moment_z")  # Mz_*
+
+regardless of element family or whether the bucket is closed-form,
+line-station, or compressed-fiber.
+
+The mapping is intentionally **non-exhaustive**: only the engineering
+quantities that have a stable, unambiguous meaning across element
+classes are exposed. Disambiguating identifiers like the My/Mz
+collision between ``globalForce`` (global axes) and ``localForce``
+(element-local axes) is left to the user — they pick the bucket via
+the existing ``get_element_results(results_name, ...)`` call. See
+docs/mpco_format_conventions.md §9.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Tuple
+
+
+__all__ = [
+    "CANONICAL_TO_MPCO",
+    "available_canonicals",
+    "match_canonical_columns",
+    "list_canonical_for_columns",
+    "shortname_of",
+]
+
+
+# ---------------------------------------------------------------------- #
+# Canonical map                                                           #
+# ---------------------------------------------------------------------- #
+#
+# Each canonical name maps to a tuple of MPCO shortnames that may
+# appear in the column-name prefix once IP/node/fiber suffixes are
+# stripped. Multiple shortnames per canonical are expected: e.g.
+# ``axial_force`` is ``P`` in line-station ``section.force`` buckets
+# but ``N`` in element-local ``localForce`` buckets.
+
+CANONICAL_TO_MPCO: dict[str, Tuple[str, ...]] = {
+    # ---- Beam element actions ------------------------------------------
+    "axial_force":          ("P", "N"),
+    "bending_moment_z":     ("Mz",),
+    "bending_moment_y":     ("My",),
+    "torsion":              ("T",),
+    "shear_y":              ("Vy",),
+    "shear_z":              ("Vz",),
+
+    # ---- Beam section deformations -------------------------------------
+    "axial_strain":         ("eps",),
+    "curvature_z":          ("kappaZ",),
+    "curvature_y":          ("kappaY",),
+    "twist":                ("theta",),
+
+    # ---- Shell section forces (resultants) -----------------------------
+    "membrane_xx":          ("Fxx",),
+    "membrane_yy":          ("Fyy",),
+    "membrane_xy":          ("Fxy",),
+    "bending_moment_xx":    ("Mxx",),
+    "bending_moment_yy":    ("Myy",),
+    "bending_moment_xy":    ("Mxy",),
+    "transverse_shear_xz":  ("Vxz",),
+    "transverse_shear_yz":  ("Vyz",),
+
+    # ---- Shell section deformations ------------------------------------
+    "membrane_strain_xx":   ("epsXX",),
+    "membrane_strain_yy":   ("epsYY",),
+    "membrane_strain_xy":   ("epsXY",),
+    "curvature_xx":         ("kappaXX",),
+    "curvature_yy":         ("kappaYY",),
+    "curvature_xy":         ("kappaXY",),
+    "transverse_shear_strain_xz": ("gammaXZ",),
+    "transverse_shear_strain_yz": ("gammaYZ",),
+
+    # ---- Continuum stresses --------------------------------------------
+    "stress_11":            ("sigma11",),
+    "stress_22":            ("sigma22",),
+    "stress_33":            ("sigma33",),
+    "stress_12":            ("sigma12",),
+    "stress_23":            ("sigma23",),
+    "stress_13":            ("sigma13",),
+
+    # ---- Continuum strains ---------------------------------------------
+    "strain_11":            ("eps11",),
+    "strain_22":            ("eps22",),
+    "strain_33":            ("eps33",),
+    "strain_12":            ("eps12",),
+    "strain_23":            ("eps23",),
+    "strain_13":            ("eps13",),
+
+    # ---- Damage / plasticity (continuum) -------------------------------
+    "damage_pos":           ("d+",),
+    "damage_neg":           ("d-",),
+    "plastic_strain_pos":   ("PLE+",),
+    "plastic_strain_neg":   ("PLE-",),
+    "crack_width":          ("cw",),
+
+    # ---- Closed-form global axes (per-node DOFs) -----------------------
+    "force_x_global":       ("Px",),
+    "force_y_global":       ("Py",),
+    "force_z_global":       ("Pz",),
+    "moment_x_global":      ("Mx",),
+    # Note: moment_y_global / moment_z_global would collide with the
+    # local-axis "bending_moment_y" / "bending_moment_z". Users wanting
+    # global-axis moments should fetch the column directly by its
+    # shortname (My_1, Mz_2, ...).
+}
+
+
+# ---------------------------------------------------------------------- #
+# Suffix stripper                                                         #
+# ---------------------------------------------------------------------- #
+#
+# Column names produced by io/meta_parser.py end in one of:
+#   * ``_<int>``        — closed-form node-suffixed (Px_1, N_2, P3_8)
+#   * ``_ip<int>``      — line-stations / gauss-level (P_ip0, sigma11_ip7)
+#   * ``_f<int>_ip<int>`` — compressed fiber (sigma11_f0_ip0)
+# Stripping the suffix yields the MPCO shortname.
+
+_SUFFIX_RE = re.compile(r"_(?:f\d+_ip\d+|ip\d+|\d+)$")
+
+
+def shortname_of(column: str) -> str:
+    """Return the MPCO shortname carried by a flat column name.
+
+    Strips the ``_<int>`` / ``_ip<int>`` / ``_f<int>_ip<int>`` suffix
+    introduced by :func:`STKO_to_python.io.meta_parser.parse_bucket_meta`.
+
+    Examples
+    --------
+    >>> shortname_of("Px_1")
+    'Px'
+    >>> shortname_of("P_ip3")
+    'P'
+    >>> shortname_of("sigma11_f5_ip0")
+    'sigma11'
+    >>> shortname_of("Fxx_ip0")
+    'Fxx'
+    >>> shortname_of("d+")            # already a shortname
+    'd+'
+    """
+    return _SUFFIX_RE.sub("", str(column))
+
+
+# ---------------------------------------------------------------------- #
+# Public helpers                                                          #
+# ---------------------------------------------------------------------- #
+
+
+def available_canonicals() -> Tuple[str, ...]:
+    """Tuple of all known canonical names, sorted."""
+    return tuple(sorted(CANONICAL_TO_MPCO))
+
+
+def match_canonical_columns(
+    canonical: str, columns: Iterable[str]
+) -> list[str]:
+    """Return the subset of ``columns`` whose MPCO shortname matches
+    the canonical name's mapped shortnames.
+
+    Parameters
+    ----------
+    canonical : str
+        A name from :data:`CANONICAL_TO_MPCO`.
+    columns : iterable of str
+        Flat column names from an :class:`ElementResults.df`.
+
+    Returns
+    -------
+    list of str
+        Original column names (preserving order) that match.
+
+    Raises
+    ------
+    ValueError
+        If ``canonical`` is unknown.
+    """
+    if canonical not in CANONICAL_TO_MPCO:
+        raise ValueError(
+            f"Unknown canonical name {canonical!r}. "
+            f"Available: {available_canonicals()}"
+        )
+    targets = set(CANONICAL_TO_MPCO[canonical])
+    return [c for c in columns if shortname_of(c) in targets]
+
+
+def list_canonical_for_columns(columns: Iterable[str]) -> Tuple[str, ...]:
+    """Return canonical names whose shortnames are present in the
+    given columns. Useful for ``ElementResults.list_canonicals()``.
+    """
+    cols = list(columns)
+    if not cols:
+        return ()
+    present_shortnames = {shortname_of(c) for c in cols}
+    hits = []
+    for canon, shortnames in CANONICAL_TO_MPCO.items():
+        if any(s in present_shortnames for s in shortnames):
+            hits.append(canon)
+    return tuple(sorted(hits))

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -200,6 +200,64 @@ class ElementResults:
         """Number of integration points (0 for closed-form buckets)."""
         return 0 if self.gp_xi is None else int(self.gp_xi.size)
 
+    # ------------------------------------------------------------------ #
+    # Canonical-name access                                              #
+    # ------------------------------------------------------------------ #
+
+    def list_canonicals(self) -> Tuple[str, ...]:
+        """Canonical-name vocabulary present in this result's columns.
+
+        Returns the engineering-friendly names (e.g. ``"axial_force"``,
+        ``"bending_moment_z"``) for which at least one matching column
+        exists. See :mod:`STKO_to_python.elements.canonical` for the
+        full mapping.
+        """
+        from .canonical import list_canonical_for_columns
+
+        return list_canonical_for_columns(self.df.columns)
+
+    def canonical_columns(self, name: str) -> Tuple[str, ...]:
+        """List the column names that match a canonical engineering name.
+
+        Parameters
+        ----------
+        name : str
+            E.g. ``"axial_force"``, ``"bending_moment_z"``,
+            ``"stress_11"``. See ``list_canonicals()`` for what's
+            available in this result, or ``available_canonicals()`` in
+            :mod:`STKO_to_python.elements.canonical` for the full map.
+
+        Returns
+        -------
+        tuple of str
+            Column names in their on-disk order. Empty tuple if no
+            columns match (e.g. asking for ``"axial_force"`` on a
+            shell ``section.force`` result).
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not a known canonical name.
+        """
+        from .canonical import match_canonical_columns
+
+        return tuple(match_canonical_columns(name, self.df.columns))
+
+    def canonical(self, name: str) -> pd.DataFrame:
+        """Return the DataFrame subset for a canonical engineering name.
+
+        Convenience wrapper around :meth:`canonical_columns`. Raises if
+        no columns match (catches typos and shells-asking-for-axial-
+        force-style misuse loudly).
+        """
+        cols = self.canonical_columns(name)
+        if not cols:
+            raise ValueError(
+                f"No columns matching canonical name {name!r} in this "
+                f"result. Present canonicals: {self.list_canonicals()}"
+            )
+        return self.df[list(cols)]
+
     def physical_x(self, length: float) -> np.ndarray:
         """Convert ``self.gp_xi`` (natural ξ ∈ [-1, +1]) to physical
         positions along an element of the given ``length``.

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -26,9 +26,15 @@ class _ElementResultView:
     """
     Lightweight proxy for a single value column in element results.
 
+    Column names are derived from the bucket's META/COMPONENTS — see
+    ``docs/mpco_format_conventions.md`` and ``io/meta_parser.py``.
+    Examples: ``Px_1`` for closed-form globalForce, ``N_2`` for
+    localForce, ``Mz_ip3`` for line-station section.force,
+    ``sigma11_f0_ip0`` for compressed fibers.
+
     Allows:
-        results.val_1                   -> all elements, all steps
-        results.val_1[element_ids]      -> filtered by element
+        results.<name>                  -> all elements, all steps
+        results.<name>[element_ids]     -> filtered by element
     """
 
     def __init__(self, parent: "ElementResults", col_name: str) -> None:
@@ -76,7 +82,12 @@ class ElementResults:
 
     Expected df shape:
       - index: (element_id, step)
-      - columns: val_1, val_2, ..., val_N  (component values)
+      - columns: real component names parsed from META/COMPONENTS
+        (e.g. ``Px_1, Py_1, ..., Mz_2`` for closed-form globalForce;
+        ``P_ip0, Mz_ip0, ..., T_ip4`` for line-station section.force;
+        ``sigma11_f0_ip0, ...`` for compressed fiber buckets).
+        Falls back to ``val_1, val_2, ..., val_N`` only when META is
+        absent.
 
     Attributes
     ----------
@@ -106,6 +117,7 @@ class ElementResults:
         element_type: Optional[str] = None,
         results_name: Optional[str] = None,
         model_stage: Optional[str] = None,
+        gp_xi: Optional[np.ndarray] = None,
     ) -> None:
         self.df = df
         self.time = time
@@ -114,6 +126,14 @@ class ElementResults:
         self.element_type = element_type or ""
         self.results_name = results_name or ""
         self.model_stage = model_stage or ""
+        # Natural-coordinate integration-point positions (ξ ∈ [-1, +1]).
+        # Length equals the number of integration points; ``None`` for
+        # closed-form buckets (no IPs) and for buckets whose connectivity
+        # dataset lacks a ``GP_X`` attribute.
+        # See docs/mpco_format_conventions.md §1, §7.
+        self.gp_xi: Optional[np.ndarray] = (
+            np.asarray(gp_xi, dtype=np.float64) if gp_xi is not None else None
+        )
 
         self._views: Dict[str, _ElementResultView] = {}
         self._build_views()
@@ -133,7 +153,7 @@ class ElementResults:
             self._views[col_str] = _ElementResultView(self, col_str)
 
     def __getattr__(self, name: str) -> Any:
-        """Allow attribute-style access to result columns (e.g., results.val_1)."""
+        """Allow attribute-style access to result columns (e.g., results.Mz_ip2)."""
         if name.startswith("_"):
             raise AttributeError(name)
         views = self.__dict__.get("_views", {})
@@ -175,6 +195,90 @@ class ElementResults:
     def empty(self) -> bool:
         return self.df.empty
 
+    @property
+    def n_ip(self) -> int:
+        """Number of integration points (0 for closed-form buckets)."""
+        return 0 if self.gp_xi is None else int(self.gp_xi.size)
+
+    def physical_x(self, length: float) -> np.ndarray:
+        """Convert ``self.gp_xi`` (natural ξ ∈ [-1, +1]) to physical
+        positions along an element of the given ``length``.
+
+        Useful for plotting moment diagrams along beams in physical
+        coordinates. See ``utilities/coords.py``.
+
+        Parameters
+        ----------
+        length : float
+            Element length L (positive). Per docs §1, all elements that
+            share a connectivity bracket also share the same beam-
+            integration rule, but their physical lengths can differ —
+            so this method takes ``length`` per call.
+
+        Returns
+        -------
+        np.ndarray
+            Physical positions, length ``n_ip``.
+
+        Raises
+        ------
+        ValueError
+            If the bucket is closed-form (no IPs) or ``length`` is
+            non-positive.
+        """
+        if self.gp_xi is None:
+            raise ValueError(
+                "physical_x() is only valid for line-station / "
+                "gauss-level buckets. This result is closed-form "
+                "(no integration points)."
+            )
+        from ..utilities.coords import xi_natural_to_physical
+
+        return xi_natural_to_physical(self.gp_xi, length)
+
+    def at_ip(self, ip_idx: int) -> pd.DataFrame:
+        """Return the columns belonging to a single integration point.
+
+        Column names use the ``..._ip<gauss_id>`` suffix introduced by
+        the META parser; this method filters by that suffix.
+
+        Parameters
+        ----------
+        ip_idx : int
+            Sequential integration-point index, ``0..n_ip-1``.
+
+        Returns
+        -------
+        pd.DataFrame
+            Subset of ``self.df`` whose column names end with
+            ``_ip<ip_idx>``. Index is preserved (``element_id, step``).
+
+        Raises
+        ------
+        ValueError
+            If the bucket is closed-form (no IPs), if ``ip_idx`` is out
+            of range, or if no columns match the suffix.
+        """
+        if self.gp_xi is None:
+            raise ValueError(
+                "at_ip() is only valid for line-station / gauss-level "
+                "buckets. This result is closed-form (no integration "
+                "points)."
+            )
+        n = int(self.gp_xi.size)
+        if not (0 <= ip_idx < n):
+            raise ValueError(
+                f"ip_idx={ip_idx} out of range [0, {n})."
+            )
+        suffix = f"_ip{int(ip_idx)}"
+        cols = [c for c in self.df.columns if str(c).endswith(suffix)]
+        if not cols:
+            raise ValueError(
+                f"No columns matching '*{suffix}' in this result. "
+                f"Available columns: {list(self.df.columns)}"
+            )
+        return self.df[cols]
+
     # ------------------------------------------------------------------ #
     # Data access
     # ------------------------------------------------------------------ #
@@ -191,7 +295,8 @@ class ElementResults:
         Parameters
         ----------
         component : str or None
-            Column name (e.g. 'val_1'). If None, returns all columns.
+            Column name (e.g. ``'Mz_ip2'``, ``'Px_1'``). If None, returns
+            all columns.
         element_ids : int, list[int], or None
             Filter to specific elements. If None, returns all.
 
@@ -359,13 +464,15 @@ class ElementResults:
     # ------------------------------------------------------------------ #
 
     def __repr__(self) -> str:
+        ip_part = f", n_ip={self.n_ip}" if self.n_ip else ""
         return (
             f"ElementResults("
             f"results_name={self.results_name!r}, "
             f"element_type={self.element_type!r}, "
             f"n_elements={self.n_elements}, "
             f"n_steps={self.n_steps}, "
-            f"n_components={self.n_components})"
+            f"n_components={self.n_components}"
+            f"{ip_part})"
         )
 
     def __str__(self) -> str:

--- a/src/STKO_to_python/elements/elements.py
+++ b/src/STKO_to_python/elements/elements.py
@@ -45,6 +45,12 @@ class ElementManager:
         ("element_idx", "i8"),
         ("file_id", "i8"),
         ("element_type", object),
+        # ``decorated_type`` is the 2-field connectivity bracket
+        # (e.g. "64-DispBeamColumn3d[1000:1]"). Required to disambiguate
+        # results buckets when a model contains multiple integration
+        # rules per element class — see docs/mpco_format_conventions.md
+        # §1, §4.
+        ("decorated_type", object),
         ("node_list", object),
         ("num_nodes", "i8"),
         ("centroid_x", "f8"),
@@ -167,6 +173,7 @@ class ElementManager:
                                 "element_idx": np.arange(n_elems, dtype=np.int64),
                                 "file_id": int(file_id),
                                 "element_type": etype,
+                                "decorated_type": dset_name,
                                 "node_list": node_lists,
                                 "num_nodes": n_nodes_per,
                                 "centroid_x": cx,
@@ -194,6 +201,7 @@ class ElementManager:
             arr["element_idx"] = df["element_idx"].to_numpy()
             arr["file_id"] = df["file_id"].to_numpy()
             arr["element_type"] = df["element_type"].to_numpy()
+            arr["decorated_type"] = df["decorated_type"].to_numpy()
             arr["node_list"] = df["node_list"].to_numpy()
             arr["num_nodes"] = df["num_nodes"].to_numpy()
             arr["centroid_x"] = df["centroid_x"].to_numpy()
@@ -207,6 +215,7 @@ class ElementManager:
                     "element_idx",
                     "file_id",
                     "element_type",
+                    "decorated_type",
                     "node_list",
                     "num_nodes",
                     "centroid_x",
@@ -547,6 +556,72 @@ class ElementManager:
     # ------------------------------------------------------------------ #
 
     @staticmethod
+    def _validate_homogeneous_layouts(
+        collected,
+        *,
+        results_name: str,
+        element_type: str,
+    ) -> None:
+        """Refuse silently mis-aligning the result frame when matched
+        buckets disagree on column layout.
+
+        ``collected`` is the list of accumulated chunks from the
+        per-partition / per-decorated-bracket read loop. Each entry's
+        second slot is the ``col_names`` list. Concatenating chunks
+        with different ``col_names`` would silently produce NaN-padded
+        rows under ``pd.concat``, so we refuse loudly and ask the
+        caller to query each decorated bracket separately. See
+        docs/mpco_format_conventions §4 (the ``customRuleIdx`` axis:
+        heterogeneous beam-integration rules in the same model spawn
+        multiple results buckets per element class).
+        """
+        unique_layouts = {tuple(entry[1]) for entry in collected}
+        if len(unique_layouts) <= 1:
+            return
+        from ..io.meta_parser import MpcoFormatError
+
+        sample = {entry[0]: list(entry[1]) for entry in collected}
+        raise MpcoFormatError(
+            f"Heterogeneous bucket layouts for "
+            f"results_name={results_name!r}, "
+            f"element_type={element_type!r}: "
+            f"{len(unique_layouts)} distinct column layouts across "
+            f"{len(collected)} buckets. "
+            f"This usually means the model has multiple integration "
+            f"rules per element class. Query each decorated bucket "
+            f"separately. Layouts encountered: {sample}"
+        )
+
+    @staticmethod
+    def _resolve_bucket_layout(
+        bucket_grp,
+        bucket_path: str,
+        *,
+        verbose: bool = False,
+    ):
+        """Parse META for a results bucket; return ``None`` if META is
+        absent or unreadable so the caller can fall back to the legacy
+        ``val_*`` placeholders.
+
+        Hard format violations (NUM_COLUMNS mismatch, GAUSS_IDS shape
+        wrong) raise ``MpcoFormatError`` per the fail-loud contract —
+        only "META not present" is silently downgraded to a fallback.
+        """
+        from ..io.meta_parser import MpcoFormatError, parse_bucket_meta
+
+        if "META" not in bucket_grp:
+            if verbose:
+                print(
+                    f"[Elements] No META at {bucket_path}; "
+                    f"falling back to val_* column names."
+                )
+            return None
+        try:
+            return parse_bucket_meta(bucket_grp, bucket_path=bucket_path)
+        except MpcoFormatError:
+            raise
+
+    @staticmethod
     def _sort_step_keys(keys: Sequence[str]) -> list[str]:
         """Sort HDF5 step keys numerically."""
         try:
@@ -658,21 +733,18 @@ class ElementManager:
                 f"[Elements] {len(df_info)} matching elements for '{element_type}'"
             )
 
-        collected: list[pd.DataFrame] = []
+        # Each entry: (results_bucket_path, col_names, gp_xi_or_None, df_chunk).
+        # Collected across partitions and connectivity brackets, then
+        # concatenated with a column-layout consistency check. ``gp_xi``
+        # is the natural-coordinate integration-point array read from
+        # the connectivity dataset's ``@GP_X`` attribute (only present
+        # for custom-rule beam-columns); ``None`` otherwise.
+        collected: list[
+            tuple[str, list[str], Optional[np.ndarray], pd.DataFrame]
+        ] = []
 
         # Group by partition for efficient HDF5 access
         for file_id, df_group in df_info.groupby("file_id"):
-            idx_arr = df_group["element_idx"].to_numpy(dtype=np.int64)
-            id_arr = df_group["element_id"].to_numpy(dtype=np.int64)
-
-            # Sort indices for efficient HDF5 fancy indexing
-            sort_order = np.argsort(idx_arr, kind="mergesort")
-            idx_sorted = idx_arr[sort_order]
-            id_sorted = id_arr[sort_order]
-            # Inverse to restore original order
-            inv = np.empty_like(sort_order)
-            inv[sort_order] = np.arange(sort_order.size)
-
             with self.dataset._pool.with_partition(int(file_id)) as f:
                 base_path = f"{model_stage}/RESULTS/ON_ELEMENTS/{results_name}"
                 if base_path not in f:
@@ -683,42 +755,148 @@ class ElementManager:
                     continue
 
                 candidates = list(f[base_path].keys())
-                matching = [n for n in candidates if n.startswith(base)]
 
-                if not matching:
-                    if verbose:
-                        print(
-                            f"[WARN] No match for '{base}' under '{base_path}'"
-                        )
-                    continue
+                # Group by *connectivity* decorated bracket (2-field —
+                # the element_idx values are positions within that
+                # specific MODEL/ELEMENTS/<bracket> dataset and only
+                # apply to results buckets sharing the same rule:cust
+                # prefix).
+                if "decorated_type" not in df_group.columns:
+                    raise RuntimeError(
+                        "element index missing 'decorated_type' column; "
+                        "rebuild the dataset to populate it."
+                    )
 
-                for decorated_type in matching:
-                    h5_data_path = f"{base_path}/{decorated_type}/DATA"
-                    if h5_data_path not in f:
+                for conn_decorated, sub_group in df_group.groupby(
+                    "decorated_type"
+                ):
+                    if not conn_decorated.endswith("]"):
+                        # Defensive: connectivity brackets always end in ']'.
                         if verbose:
-                            print(f"[WARN] Path not found: {h5_data_path}")
+                            print(
+                                f"[WARN] Unexpected decorated_type "
+                                f"{conn_decorated!r}; skipping."
+                            )
                         continue
 
-                    data_group = f[h5_data_path]
-                    step_names = self._sort_step_keys(data_group.keys())
-                    n_steps = len(step_names)
-                    n_elems = len(idx_sorted)
+                    # 3-field results bucket = 2-field connectivity
+                    # bracket with ']' replaced by ':' followed by the
+                    # response stream index, then ']'.
+                    bracket_prefix = conn_decorated[:-1] + ":"
+                    matching_results = [
+                        n
+                        for n in candidates
+                        if n.startswith(bracket_prefix) and n.endswith("]")
+                    ]
 
-                    # Read one step to determine shape
-                    sample = data_group[step_names[0]][idx_sorted[:1]]
-                    n_comp = sample.shape[1]
+                    if not matching_results:
+                        if verbose:
+                            print(
+                                f"[WARN] No results bucket for connectivity "
+                                f"bracket {conn_decorated!r} under "
+                                f"{base_path}"
+                            )
+                        continue
 
-                    # Pre-allocate and read all steps
-                    out = np.empty((n_steps * n_elems, n_comp), dtype=np.float64)
-                    for s, sname in enumerate(step_names):
-                        raw = data_group[sname][idx_sorted]
-                        out[s * n_elems : (s + 1) * n_elems, :] = raw[inv]
+                    # Read GP_X from the connectivity dataset (only
+                    # present on custom-rule beam-columns; None for
+                    # closed-form connectivities and continuum classes).
+                    # See docs/mpco_format_conventions §1.
+                    conn_path = (
+                        f"{model_stage}/MODEL/ELEMENTS/{conn_decorated}"
+                    )
+                    conn_grp = f.get(conn_path)
+                    gp_xi: Optional[np.ndarray] = None
+                    if conn_grp is not None and "GP_X" in conn_grp.attrs:
+                        gp_xi = (
+                            np.asarray(conn_grp.attrs["GP_X"])
+                            .flatten()
+                            .astype(np.float64)
+                        )
 
-                    col_names = [f"val_{i + 1}" for i in range(n_comp)]
-                    df_chunk = pd.DataFrame(out, columns=col_names)
-                    df_chunk["element_id"] = np.tile(id_arr, n_steps)
-                    df_chunk["step"] = np.repeat(np.arange(n_steps), n_elems)
-                    collected.append(df_chunk)
+                    # Pre-compute fancy-indexing arrays for this group
+                    # (element_idx is local to this connectivity bucket).
+                    idx_arr = sub_group["element_idx"].to_numpy(dtype=np.int64)
+                    id_arr = sub_group["element_id"].to_numpy(dtype=np.int64)
+                    sort_order = np.argsort(idx_arr, kind="mergesort")
+                    idx_sorted = idx_arr[sort_order]
+                    inv = np.empty_like(sort_order)
+                    inv[sort_order] = np.arange(sort_order.size)
+
+                    # If there are multiple response streams under the
+                    # same connectivity bracket (rare; ":1", ":2", ...),
+                    # take the first stream and warn — concatenating
+                    # them would silently duplicate (element_id, step)
+                    # rows. Users wanting other streams should query
+                    # the decorated_type explicitly.
+                    if len(matching_results) > 1:
+                        matching_results = sorted(matching_results)
+                        if verbose:
+                            print(
+                                f"[WARN] Multiple response streams under "
+                                f"{conn_decorated!r}: {matching_results}; "
+                                f"using {matching_results[0]!r}."
+                            )
+                        matching_results = matching_results[:1]
+
+                    for results_decorated in matching_results:
+                        bucket_path = f"{base_path}/{results_decorated}"
+                        h5_data_path = f"{bucket_path}/DATA"
+                        if h5_data_path not in f:
+                            if verbose:
+                                print(f"[WARN] Path not found: {h5_data_path}")
+                            continue
+
+                        bucket_grp = f[bucket_path]
+                        layout = self._resolve_bucket_layout(
+                            bucket_grp, bucket_path, verbose=verbose
+                        )
+
+                        data_group = f[h5_data_path]
+                        step_names = self._sort_step_keys(data_group.keys())
+                        n_steps = len(step_names)
+                        n_elems = len(idx_sorted)
+
+                        if layout is not None:
+                            n_comp = layout.num_columns
+                            col_names = list(layout.flat_columns)
+                        else:
+                            sample = data_group[step_names[0]][idx_sorted[:1]]
+                            n_comp = sample.shape[1]
+                            col_names = [f"val_{i + 1}" for i in range(n_comp)]
+
+                        out = np.empty(
+                            (n_steps * n_elems, n_comp), dtype=np.float64
+                        )
+                        for s, sname in enumerate(step_names):
+                            raw = data_group[sname][idx_sorted]
+                            if raw.shape[1] != n_comp:
+                                from ..io.meta_parser import MpcoFormatError
+
+                                raise MpcoFormatError(
+                                    f"{bucket_path}/DATA/{sname}: width "
+                                    f"{raw.shape[1]} disagrees with expected "
+                                    f"{n_comp} "
+                                    f"(from {'META' if layout else 'first step'})"
+                                )
+                            out[s * n_elems : (s + 1) * n_elems, :] = raw[inv]
+
+                        df_chunk = pd.DataFrame(out, columns=col_names)
+                        df_chunk["element_id"] = np.tile(id_arr, n_steps)
+                        df_chunk["step"] = np.repeat(
+                            np.arange(n_steps), n_elems
+                        )
+                        # GP_X is only meaningful for non-closed-form
+                        # buckets. For closed-form, drop it even if the
+                        # connectivity dataset happened to carry one.
+                        chunk_gp_xi = (
+                            gp_xi
+                            if (layout is not None and not layout.closed_form)
+                            else None
+                        )
+                        collected.append(
+                            (bucket_path, col_names, chunk_gp_xi, df_chunk)
+                        )
 
         if not collected:
             if verbose:
@@ -736,7 +914,41 @@ class ElementManager:
                 model_stage=model_stage,
             )
 
-        result_df = pd.concat(collected, ignore_index=True)
+        # Cross-bucket layout consistency check (refuses heterogeneous
+        # integration rules — see docs/mpco_format_conventions §4).
+        self._validate_homogeneous_layouts(
+            collected,
+            results_name=results_name,
+            element_type=element_type,
+        )
+
+        # Reconcile GP_X across chunks. All non-None gp_xi values must
+        # agree (same beam-integration rule → same natural coords);
+        # otherwise that's another flavor of heterogeneous integration
+        # and we already raised above. Pick the first non-None.
+        merged_gp_xi: Optional[np.ndarray] = None
+        for _, _, chunk_gp_xi, _ in collected:
+            if chunk_gp_xi is None:
+                continue
+            if merged_gp_xi is None:
+                merged_gp_xi = chunk_gp_xi
+            elif not np.allclose(
+                merged_gp_xi, chunk_gp_xi, rtol=0.0, atol=1e-12
+            ):
+                from ..io.meta_parser import MpcoFormatError
+
+                raise MpcoFormatError(
+                    f"GP_X disagrees across buckets for "
+                    f"results_name={results_name!r}, "
+                    f"element_type={element_type!r}: "
+                    f"{merged_gp_xi.tolist()} vs {chunk_gp_xi.tolist()}. "
+                    f"This means heterogeneous beam-integration rules; "
+                    f"query each decorated bucket separately."
+                )
+
+        result_df = pd.concat(
+            [df for _, _, _, df in collected], ignore_index=True
+        )
         result_df = result_df.set_index(["element_id", "step"]).sort_index()
 
         # Extract time array for the model stage
@@ -755,6 +967,7 @@ class ElementManager:
             element_type=element_type,
             results_name=results_name,
             model_stage=model_stage,
+            gp_xi=merged_gp_xi,
         )
 
     def get_element_results_by_selection_and_z(

--- a/src/STKO_to_python/io/meta_parser.py
+++ b/src/STKO_to_python/io/meta_parser.py
@@ -1,0 +1,313 @@
+"""MPCO bucket META parser.
+
+A *bucket* is the HDF5 group at
+``MODEL_STAGE[<n>]/RESULTS/ON_ELEMENTS/<result_name>/<class[<bracket>]>``.
+Each bucket carries a ``META`` subgroup describing the on-disk column
+layout and a ``DATA`` subgroup with one dataset per step. The library
+historically ignored META and assigned generic ``val_1, val_2, ...``
+column names. This module reads META and produces real component names
+(``P``, ``Mz``, ``Px_1``, ...) plus a structured layout for downstream
+consumers.
+
+Format reference: ``docs/mpco_format_conventions.md`` §1–§3, §11–§12.
+
+Two bucket shapes are supported:
+
+* **Closed-form** (e.g. ``ElasticBeam3d`` ``force``/``localForce``):
+  ``GAUSS_IDS == [[-1]]`` sentinel, single COMPONENTS segment with
+  node-suffixed names (``Px_1, Py_1, ..., Mz_2``). No integration points.
+
+* **Line-stations** (e.g. force-/disp-based beam ``section.force``):
+  ``GAUSS_IDS == [[0], [1], ..., [n_IP-1]]``, one COMPONENTS segment per
+  integration point separated by ``;``, each with section response codes
+  (``P, Mz, My, T, Vy, Vz``).
+
+The parser also validates the invariant
+``NUM_COLUMNS == sum(MULTIPLICITY * NUM_COMPONENTS)`` and raises
+``MpcoFormatError`` on any mismatch — fail-loud per convention §15.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Sequence
+
+import numpy as np
+
+
+__all__ = [
+    "MpcoFormatError",
+    "BucketLayout",
+    "parse_bucket_meta",
+]
+
+
+class MpcoFormatError(ValueError):
+    """Raised when an MPCO bucket's META violates an expected invariant.
+
+    Always carries the bucket path (when available) plus expected vs.
+    actual values to make the failure self-explaining.
+    """
+
+
+# --------------------------------------------------------------------- #
+# BucketLayout                                                          #
+# --------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class BucketLayout:
+    """Resolved per-bucket column layout.
+
+    Attributes
+    ----------
+    closed_form : bool
+        True for closed-form (no integration point) buckets, identified
+        by the ``GAUSS_IDS == [[-1]]`` sentinel.
+    n_ip : int
+        Number of integration points. ``0`` for closed-form, otherwise
+        ``len(gauss_ids)``.
+    gauss_ids : tuple[int, ...]
+        Flattened ``GAUSS_IDS``. For closed-form, ``(-1,)``.
+    ip_components : tuple[tuple[str, ...], ...]
+        Component names per IP segment. For closed-form, length 1 with
+        node-suffixed names. For line-stations, one tuple per IP.
+    flat_columns : tuple[str, ...]
+        Flat column names aligned to the on-disk DATA slab. For
+        line-stations, names are suffixed ``_ip<gauss_id>`` to keep the
+        flat vector unambiguous (``P_ip0, Mz_ip0, ..., P_ip4, ...``).
+        Length equals ``num_columns``.
+    num_columns : int
+        Width of the DATA slab (``NUM_COLUMNS`` attribute).
+    """
+
+    closed_form: bool
+    n_ip: int
+    gauss_ids: tuple
+    ip_components: tuple
+    flat_columns: tuple
+    num_columns: int
+
+
+# --------------------------------------------------------------------- #
+# Helpers                                                               #
+# --------------------------------------------------------------------- #
+
+
+def _decode_components_blob(raw) -> str:
+    """Decode the COMPONENTS dataset (shape (1,) bytes string) to str."""
+    arr = np.asarray(raw)
+    if arr.shape == ():
+        val = arr.item()
+    elif arr.size >= 1:
+        val = arr.reshape(-1)[0]
+    else:
+        raise MpcoFormatError("META/COMPONENTS is empty")
+    if isinstance(val, bytes):
+        return val.decode("utf-8")
+    return str(val)
+
+
+def _extract_segment_components(segment: str) -> List[str]:
+    """Take the substring after the LAST '.' and split on ','.
+
+    Handles paths of arbitrary depth (``0.``, ``0.1.2.``, ``0.1.2.3.``)
+    per format docs §10.
+    """
+    body = segment.rsplit(".", 1)[-1]
+    return [tok.strip() for tok in body.split(",") if tok.strip()]
+
+
+# --------------------------------------------------------------------- #
+# Public API                                                            #
+# --------------------------------------------------------------------- #
+
+
+def parse_bucket_meta(bucket_grp, *, bucket_path: str | None = None) -> BucketLayout:
+    """Read META from an MPCO results bucket and resolve its column layout.
+
+    Parameters
+    ----------
+    bucket_grp : h5py.Group
+        The bucket group (e.g. ``f[".../section.force/64-DispBeamColumn3d[1000:1:0]"]``).
+    bucket_path : str, optional
+        Used only in error messages. If omitted, the parser falls back
+        to ``getattr(bucket_grp, "name", "<unknown>")``.
+
+    Returns
+    -------
+    BucketLayout
+
+    Raises
+    ------
+    MpcoFormatError
+        If META is missing, ``NUM_COLUMNS`` is missing, the invariant
+        ``NUM_COLUMNS == sum(MULTIPLICITY * NUM_COMPONENTS)`` fails, or
+        the resolved flat-column count disagrees with ``NUM_COLUMNS``.
+    """
+    path = bucket_path or getattr(bucket_grp, "name", "<unknown>")
+
+    if "META" not in bucket_grp:
+        raise MpcoFormatError(f"{path}: missing META subgroup")
+    meta = bucket_grp["META"]
+
+    for k in ("MULTIPLICITY", "GAUSS_IDS", "NUM_COMPONENTS", "COMPONENTS"):
+        if k not in meta:
+            raise MpcoFormatError(f"{path}: META/{k} not found")
+
+    multiplicity = np.asarray(meta["MULTIPLICITY"][()]).flatten().astype(np.int64)
+    gauss_ids = np.asarray(meta["GAUSS_IDS"][()]).flatten().astype(np.int64)
+    num_components = np.asarray(meta["NUM_COMPONENTS"][()]).flatten().astype(np.int64)
+    components_str = _decode_components_blob(meta["COMPONENTS"][()])
+
+    num_columns_attr = bucket_grp.attrs.get("NUM_COLUMNS")
+    if num_columns_attr is None:
+        raise MpcoFormatError(f"{path}: NUM_COLUMNS attribute missing on bucket")
+    num_columns = int(np.asarray(num_columns_attr).flatten()[0])
+
+    # Closed-form sentinel (§3).
+    closed_form = gauss_ids.size == 1 and int(gauss_ids[0]) == -1
+
+    # Parse semicolon-separated COMPONENTS segments (§2).
+    raw_segments = [s for s in components_str.split(";") if s.strip()]
+    if not raw_segments:
+        raise MpcoFormatError(f"{path}: META/COMPONENTS parsed to zero segments")
+
+    ip_components = tuple(
+        tuple(_extract_segment_components(s)) for s in raw_segments
+    )
+
+    # NUM_COLUMNS invariant (§11).
+    expected_total = int((multiplicity * num_components).sum())
+    if expected_total != num_columns:
+        raise MpcoFormatError(
+            f"{path}: NUM_COLUMNS invariant violated. "
+            f"NUM_COLUMNS={num_columns} but "
+            f"sum(MULTIPLICITY * NUM_COMPONENTS) = {expected_total} "
+            f"(MULTIPLICITY={multiplicity.tolist()}, "
+            f"NUM_COMPONENTS={num_components.tolist()})"
+        )
+
+    # All known bucket shapes have one COMPONENTS segment per block
+    # (i.e. per row of MULTIPLICITY/NUM_COMPONENTS/GAUSS_IDS). When
+    # ``MULT[i] > 1`` (compressed META, §12 — fibers per IP), the
+    # segment describes a *single* column-group's component names that
+    # repeats ``MULT[i]`` times in the slab.
+    n_blocks = multiplicity.size
+    if len(ip_components) != n_blocks:
+        raise MpcoFormatError(
+            f"{path}: META segment count ({len(ip_components)}) "
+            f"!= number of blocks ({n_blocks}) "
+            f"[MULTIPLICITY shape={multiplicity.tolist()}]"
+        )
+
+    # Per-block sanity: each segment must declare exactly NUM_COMPONENTS[i] names.
+    for i, (comps, expected_n) in enumerate(zip(ip_components, num_components)):
+        if len(comps) != int(expected_n):
+            raise MpcoFormatError(
+                f"{path}: block {i} META segment has {len(comps)} names "
+                f"but NUM_COMPONENTS[{i}]={int(expected_n)} "
+                f"(segment={comps})"
+            )
+
+    # Closed-form: a single block with MULT=[1], the segment is already
+    # the flat column list (Px_1, ..., Mz_2) — names not suffixed.
+    if closed_form:
+        if n_blocks != 1 or int(multiplicity[0]) != 1:
+            raise MpcoFormatError(
+                f"{path}: closed-form bucket (GAUSS_IDS=[[-1]]) expected "
+                f"a single block with MULTIPLICITY=[[1]], got "
+                f"MULTIPLICITY={multiplicity.tolist()}"
+            )
+        flat_columns = tuple(ip_components[0])
+        if len(flat_columns) != num_columns:
+            raise MpcoFormatError(
+                f"{path}: closed-form flat columns ({len(flat_columns)}) "
+                f"!= NUM_COLUMNS ({num_columns}). Names: {flat_columns}"
+            )
+        return BucketLayout(
+            closed_form=True,
+            n_ip=0,
+            gauss_ids=tuple(int(g) for g in gauss_ids),
+            ip_components=ip_components,
+            flat_columns=flat_columns,
+            num_columns=num_columns,
+        )
+
+    # Non-closed-form: one block per IP. GAUSS_IDS must be sequential
+    # 0..n-1 (the shape we've seen in practice; deviations would
+    # indicate format drift, raise loud).
+    expected_gids = np.arange(gauss_ids.size, dtype=np.int64)
+    if not np.array_equal(gauss_ids, expected_gids):
+        raise MpcoFormatError(
+            f"{path}: GAUSS_IDS must be sequential 0..n-1 for "
+            f"non-closed-form buckets, got {gauss_ids.tolist()}"
+        )
+
+    # Build the flat column vector. For MULT[i]==1 we only need the IP
+    # suffix (P_ip0, Mz_ip0, ...). For MULT[i]>1 (compressed fibers per
+    # IP) we add a fiber-index suffix so each column is unambiguous:
+    # sigma11_f0_ip0, sigma11_f1_ip0, ..., sigma11_f5_ip1.
+    flat_list: List[str] = []
+    for gid, mult_i, comps in zip(gauss_ids.tolist(), multiplicity.tolist(), ip_components):
+        mult_i = int(mult_i)
+        if mult_i == 1:
+            for c in comps:
+                flat_list.append(f"{c}_ip{int(gid)}")
+        else:
+            for fiber_j in range(mult_i):
+                for c in comps:
+                    flat_list.append(f"{c}_f{fiber_j}_ip{int(gid)}")
+
+    if len(flat_list) != num_columns:
+        raise MpcoFormatError(
+            f"{path}: line-station flat columns ({len(flat_list)}) "
+            f"!= NUM_COLUMNS ({num_columns}). "
+            f"ip_components={ip_components}"
+        )
+
+    return BucketLayout(
+        closed_form=False,
+        n_ip=int(gauss_ids.size),
+        gauss_ids=tuple(int(g) for g in gauss_ids),
+        ip_components=ip_components,
+        flat_columns=tuple(flat_list),
+        num_columns=num_columns,
+    )
+
+
+def validate_data_shape(
+    layout: BucketLayout,
+    data_shape: Sequence[int],
+    *,
+    bucket_path: str | None = None,
+) -> None:
+    """Cross-check a DATA dataset's column count against the layout.
+
+    Called once per bucket from the read path, before any data is
+    consumed, to refuse silently mis-sized slabs.
+
+    Parameters
+    ----------
+    layout : BucketLayout
+        Result of :func:`parse_bucket_meta`.
+    data_shape : sequence of int
+        Shape of one step's DATA dataset (typically ``(n_elems, n_cols)``).
+    bucket_path : str, optional
+        Used in error messages.
+
+    Raises
+    ------
+    MpcoFormatError
+        If ``data_shape[1] != layout.num_columns``.
+    """
+    if len(data_shape) < 2:
+        raise MpcoFormatError(
+            f"{bucket_path or '<unknown>'}: DATA shape {tuple(data_shape)} "
+            f"is not 2-D"
+        )
+    n_cols = int(data_shape[1])
+    if n_cols != layout.num_columns:
+        raise MpcoFormatError(
+            f"{bucket_path or '<unknown>'}: DATA n_cols={n_cols} "
+            f"disagrees with META NUM_COLUMNS={layout.num_columns}"
+        )

--- a/src/STKO_to_python/utilities/coords.py
+++ b/src/STKO_to_python/utilities/coords.py
@@ -1,0 +1,87 @@
+"""Coordinate conversions for integration-point positions.
+
+OpenSees and MPCO use **two different conventions** for integration-
+point coordinates along a beam:
+
+* MPCO writes ``GP_X`` to disk in **natural** ξ ∈ [-1, +1]. (The
+  parent-element parametric coordinate.)
+* ``ops.eleResponse(eid, "integrationPoints")`` returns positions in
+  **physical** length ``[0, L]`` (per ``ForceBeamColumn3d.cpp:3338``).
+
+When integrating these two surfaces (e.g. cross-checking MPCO output
+against a live openseespy model), one of the two has to be converted.
+This module is the canonical place for those conversions.
+
+See ``docs/mpco_format_conventions.md`` §7.
+"""
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+
+
+__all__ = [
+    "xi_natural_to_physical",
+    "x_physical_to_natural",
+]
+
+
+ArrayLike = Union[float, np.ndarray]
+
+
+def xi_natural_to_physical(xi: ArrayLike, length: float) -> np.ndarray:
+    """Convert natural ξ ∈ [-1, +1] to physical x ∈ [0, L].
+
+    Formula: ``x = (xi + 1) * L / 2``.
+
+    Parameters
+    ----------
+    xi : float or array_like
+        Natural-coordinate position(s).
+    length : float
+        Element length ``L`` (positive).
+
+    Returns
+    -------
+    np.ndarray
+        Physical position(s) along the element. ``xi=-1`` maps to
+        ``0``, ``xi=+1`` maps to ``L``, ``xi=0`` to ``L/2``.
+
+    Raises
+    ------
+    ValueError
+        If ``length`` is non-positive.
+    """
+    if length <= 0:
+        raise ValueError(f"length must be positive, got {length!r}")
+    return (np.asarray(xi, dtype=np.float64) + 1.0) * (length / 2.0)
+
+
+def x_physical_to_natural(x: ArrayLike, length: float) -> np.ndarray:
+    """Convert physical x ∈ [0, L] to natural ξ ∈ [-1, +1].
+
+    Formula: ``xi = 2 * x / L - 1``. This is the conversion required
+    when comparing MPCO ``GP_X`` (natural) against openseespy's
+    ``eleResponse("integrationPoints")`` (physical).
+
+    Parameters
+    ----------
+    x : float or array_like
+        Physical position(s) along the element.
+    length : float
+        Element length ``L`` (positive).
+
+    Returns
+    -------
+    np.ndarray
+        Natural-coordinate position(s).
+
+    Raises
+    ------
+    ValueError
+        If ``length`` is non-positive.
+    """
+    if length <= 0:
+        raise ValueError(f"length must be positive, got {length!r}")
+    return 2.0 * np.asarray(x, dtype=np.float64) / length - 1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES_DIR = REPO_ROOT / "stko_results_examples"
 ELASTIC_FRAME_DIR = EXAMPLES_DIR / "elasticFrame" / "results"
 QUAD_FRAME_DIR = EXAMPLES_DIR / "elasticFrame" / "QuadFrame_results"
+SOLID_PARTITION_DIR = EXAMPLES_DIR / "solid_partition_example"
 
 
 @pytest.fixture(scope="session")
@@ -62,3 +63,21 @@ def quad_frame_dir() -> Path:
     if not (QUAD_FRAME_DIR / "results.part-0.mpco").exists():
         pytest.skip(f"QuadFrame MP example not available at {QUAD_FRAME_DIR}")
     return QUAD_FRAME_DIR
+
+
+@pytest.fixture(scope="session")
+def solid_partition_dir() -> Path:
+    """Two-partition fixture combining a Brick continuum and a
+    DispBeamColumn3d (with ``section.fiber.stress`` compressed META).
+
+    Exercises every META shape codified in
+    ``docs/mpco_format_conventions.md`` — closed-form (beam + brick),
+    line-stations (section.force/section.deformation), Gauss-level
+    continuum (material.stress/material.strain), and MULTIPLICITY > 1
+    fiber compression. Skips the test if the fixture is absent.
+    """
+    if not (SOLID_PARTITION_DIR / "Recorder.part-0.mpco").exists():
+        pytest.skip(
+            f"solid_partition_example not available at {SOLID_PARTITION_DIR}"
+        )
+    return SOLID_PARTITION_DIR

--- a/tests/integration/test_fixture_snapshots.py
+++ b/tests/integration/test_fixture_snapshots.py
@@ -1,0 +1,310 @@
+"""Snapshot tests against checked-in real fixtures.
+
+Per docs/mpco_format_conventions.md §16, the strongest signal that
+"convention bugs are absent" is identical numeric output across
+independent paths to the same data. We don't run a live OpenSees model
+in CI, so this file is the lightweight version: pin the expected
+``(n_cols, n_ip, gp_xi, first_3_cols, last_3_cols)`` tuple for each
+result bucket the library is known to handle. If MPCO format drifts,
+or if the META parser regresses on naming/IP-coord conventions, these
+tests fail loudly.
+
+Numeric sanity (no NaN in fetched data, time array lengths align with
+step count) is also asserted on a representative subset.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# Snapshot table                                                          #
+# ---------------------------------------------------------------------- #
+#
+# Each row pins what the library should currently produce for the
+# corresponding (fixture, recorder, results_name, element_type) tuple.
+# Update ONLY when a deliberate format/library change occurs.
+#
+# ``element_id_picker`` chooses a single element_id from the cached
+# index so each parametrized case loads the smallest meaningful slab.
+# ``gp_xi_expected`` is None for closed-form / continuum-without-GP_X
+# buckets.
+
+SNAPSHOTS = [
+    # ---- elasticFrame (single partition, ElasticBeam3d only) -----------
+    {
+        "id": "elasticFrame::force/5-ElasticBeam3d",
+        "fixture_attr": "elastic_frame_dir",
+        "recorder": "results",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "force",
+        "element_type": "5-ElasticBeam3d",
+        "n_cols": 12,
+        "n_ip": 0,
+        "gp_xi": None,
+        "first3": ("Px_1", "Py_1", "Pz_1"),
+        "last3": ("Mx_2", "My_2", "Mz_2"),
+    },
+    {
+        "id": "elasticFrame::localForce/5-ElasticBeam3d",
+        "fixture_attr": "elastic_frame_dir",
+        "recorder": "results",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "localForce",
+        "element_type": "5-ElasticBeam3d",
+        "n_cols": 12,
+        "n_ip": 0,
+        "gp_xi": None,
+        "first3": ("N_1", "Vy_1", "Vz_1"),
+        "last3": ("T_2", "My_2", "Mz_2"),
+    },
+    # ---- QuadFrame (multi-partition: ElasticBeam3d + ASDShellQ4) -------
+    {
+        "id": "QuadFrame::force/203-ASDShellQ4",
+        "fixture_attr": "quad_frame_dir",
+        "recorder": "results",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "force",
+        "element_type": "203-ASDShellQ4",
+        "n_cols": 24,
+        "n_ip": 0,
+        "gp_xi": None,
+        "first3": ("P1", "P2", "P3"),
+        "last3": ("P22", "P23", "P24"),
+    },
+    {
+        "id": "QuadFrame::section.force/203-ASDShellQ4",
+        "fixture_attr": "quad_frame_dir",
+        "recorder": "results",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "section.force",
+        "element_type": "203-ASDShellQ4",
+        "n_cols": 32,
+        "n_ip": 0,  # shell connectivity carries no GP_X attribute
+        "gp_xi": None,
+        "first3": ("Fxx_ip0", "Fyy_ip0", "Fxy_ip0"),
+        "last3": ("Mxy_ip3", "Vxz_ip3", "Vyz_ip3"),
+    },
+    {
+        "id": "QuadFrame::section.deformation/203-ASDShellQ4",
+        "fixture_attr": "quad_frame_dir",
+        "recorder": "results",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "section.deformation",
+        "element_type": "203-ASDShellQ4",
+        "n_cols": 32,
+        "n_ip": 0,
+        "gp_xi": None,
+        "first3": ("epsXX_ip0", "epsYY_ip0", "epsXY_ip0"),
+        "last3": ("kappaXY_ip3", "gammaXZ_ip3", "gammaYZ_ip3"),
+    },
+    # ---- solid_partition (DispBeamColumn3d + Brick, multi-partition) ---
+    {
+        "id": "solid::force/56-Brick",
+        "fixture_attr": "solid_partition_dir",
+        "recorder": "Recorder",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "force",
+        "element_type": "56-Brick",
+        "n_cols": 24,
+        "n_ip": 0,
+        "gp_xi": None,
+        "first3": ("P1_1", "P2_1", "P3_1"),
+        "last3": ("P1_8", "P2_8", "P3_8"),
+    },
+    {
+        "id": "solid::section.force/64-DispBeamColumn3d",
+        "fixture_attr": "solid_partition_dir",
+        "recorder": "Recorder",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "section.force",
+        "element_type": "64-DispBeamColumn3d",
+        "n_cols": 8,
+        "n_ip": 2,
+        "gp_xi": (-1.0, 1.0),
+        "first3": ("P_ip0", "Mz_ip0", "My_ip0"),
+        "last3": ("Mz_ip1", "My_ip1", "T_ip1"),
+    },
+    {
+        "id": "solid::material.stress/56-Brick",
+        "fixture_attr": "solid_partition_dir",
+        "recorder": "Recorder",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "material.stress",
+        "element_type": "56-Brick",
+        "n_cols": 48,
+        "n_ip": 0,  # no GP_X on Brick connectivity
+        "gp_xi": None,
+        "first3": ("sigma11_ip0", "sigma22_ip0", "sigma33_ip0"),
+        "last3": ("sigma12_ip7", "sigma23_ip7", "sigma13_ip7"),
+    },
+    {
+        "id": "solid::section.fiber.stress/64-DispBeamColumn3d",
+        "fixture_attr": "solid_partition_dir",
+        "recorder": "Recorder",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "section.fiber.stress",
+        "element_type": "64-DispBeamColumn3d",
+        "n_cols": 12,
+        "n_ip": 2,
+        "gp_xi": (-1.0, 1.0),
+        "first3": ("sigma11_f0_ip0", "sigma11_f1_ip0", "sigma11_f2_ip0"),
+        "last3": ("sigma11_f3_ip1", "sigma11_f4_ip1", "sigma11_f5_ip1"),
+    },
+    # ---- 5-IP Lobatto: separate disp-based fixture ---------------------
+    {
+        "id": "dispBased5IP::section.force/64-DispBeamColumn3d",
+        "fixture_attr": "_disp_based_dir",
+        "recorder": "results",
+        "stage": "MODEL_STAGE[1]",
+        "results_name": "section.force",
+        "element_type": "64-DispBeamColumn3d",
+        "n_cols": 20,
+        "n_ip": 5,
+        "gp_xi": (-1.0, -0.65465367, 0.0, 0.65465367, 1.0),
+        "first3": ("P_ip0", "Mz_ip0", "My_ip0"),
+        "last3": ("Mz_ip4", "My_ip4", "T_ip4"),
+    },
+]
+
+
+# ---------------------------------------------------------------------- #
+# Helper to find the disp-based 5-IP fixture (not in conftest)            #
+# ---------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def _disp_based_dir() -> Path:
+    p = (
+        Path(__file__).resolve().parents[2]
+        / "stko_results_examples"
+        / "elasticFrame"
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    if not (p / "results.mpco").exists():
+        pytest.skip(f"disp-based fixture missing at {p}")
+    return p
+
+
+# ---------------------------------------------------------------------- #
+# Parametrized snapshot test                                              #
+# ---------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def _ds_cache():
+    """Cache MPCODataSet per (fixture_path, recorder) so we don't
+    re-open large multi-partition fixtures for every snapshot row."""
+    return {}
+
+
+@pytest.mark.parametrize("snap", SNAPSHOTS, ids=[s["id"] for s in SNAPSHOTS])
+def test_bucket_snapshot(snap, request, _ds_cache):
+    fixture_dir: Path = request.getfixturevalue(snap["fixture_attr"])
+
+    cache_key = (str(fixture_dir), snap["recorder"])
+    if cache_key in _ds_cache:
+        ds = _ds_cache[cache_key]
+    else:
+        ds = MPCODataSet(str(fixture_dir), snap["recorder"], verbose=False)
+        _ds_cache[cache_key] = ds
+
+    # Pick the first element of the requested type from the index.
+    df_idx = ds.elements_info["dataframe"]
+    matched = df_idx[df_idx["element_type"].str.startswith(snap["element_type"])]
+    assert not matched.empty, (
+        f"no elements of type {snap['element_type']!r} in fixture"
+    )
+    eid = int(matched["element_id"].iloc[0])
+
+    er = ds.elements.get_element_results(
+        results_name=snap["results_name"],
+        element_type=snap["element_type"],
+        model_stage=snap["stage"],
+        element_ids=[eid],
+    )
+
+    cols = list(er.df.columns)
+    assert er.df.shape[1] == snap["n_cols"], (
+        f"{snap['id']}: n_cols got {er.df.shape[1]}, expected {snap['n_cols']}"
+    )
+    assert tuple(cols[:3]) == snap["first3"], (
+        f"{snap['id']}: first3 got {tuple(cols[:3])}, expected {snap['first3']}"
+    )
+    assert tuple(cols[-3:]) == snap["last3"], (
+        f"{snap['id']}: last3 got {tuple(cols[-3:])}, expected {snap['last3']}"
+    )
+    assert er.n_ip == snap["n_ip"], (
+        f"{snap['id']}: n_ip got {er.n_ip}, expected {snap['n_ip']}"
+    )
+
+    if snap["gp_xi"] is None:
+        assert er.gp_xi is None, (
+            f"{snap['id']}: expected gp_xi=None, got {er.gp_xi!r}"
+        )
+    else:
+        assert er.gp_xi is not None, (
+            f"{snap['id']}: expected gp_xi shape {len(snap['gp_xi'])}, got None"
+        )
+        np.testing.assert_allclose(
+            er.gp_xi,
+            np.asarray(snap["gp_xi"], dtype=np.float64),
+            rtol=1e-6,
+            atol=1e-7,
+            err_msg=f"{snap['id']}: gp_xi snapshot mismatch",
+        )
+
+
+# ---------------------------------------------------------------------- #
+# Numeric sanity                                                          #
+# ---------------------------------------------------------------------- #
+
+
+def test_no_nans_in_section_force(elastic_frame_dir: Path):
+    """Result data is finite — catches silently-misaligned fancy
+    indexing or empty-step bugs that would surface as NaN."""
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+    assert np.isfinite(er.df.to_numpy()).all()
+
+
+def test_time_array_length_matches_steps(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1],
+    )
+    assert er.time.size == er.n_steps
+
+
+def test_step_index_is_dense(quad_frame_dir: Path):
+    """The (element_id, step) MultiIndex covers every step from 0..n-1
+    for each element — no missing rows that would produce NaN under
+    common pandas operations."""
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    df_idx = ds.elements_info["dataframe"]
+    eid = int(
+        df_idx[df_idx["element_type"].str.startswith("5-ElasticBeam3d")]
+        ["element_id"].iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[eid],
+    )
+    steps = sorted(er.df.xs(eid, level="element_id").index.unique().tolist())
+    assert steps == list(range(len(steps)))

--- a/tests/integration/test_gp_xi_and_at_ip.py
+++ b/tests/integration/test_gp_xi_and_at_ip.py
@@ -1,0 +1,213 @@
+"""End-to-end tests for B2 — ``GP_X`` (integration-point coordinates)
+and the ``at_ip()`` per-IP slicer on :class:`ElementResults`.
+
+Per docs/mpco_format_conventions.md §1, custom-rule beam-columns write
+their integration-point coordinates as a ``GP_X`` attribute on the
+connectivity dataset (in natural ξ ∈ [-1, +1]). The library now reads
+that attribute and exposes it as ``ElementResults.gp_xi`` for line-
+station / gauss-level buckets. Closed-form buckets and continuum
+classes (which lack ``GP_X`` on connectivity) get ``gp_xi=None``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ----- helpers ------------------------------------------------------------ #
+
+
+def _disp_based_dir() -> Path | None:
+    """Directory of the displacement-based 5-IP fixture (5 Lobatto IPs)."""
+    p = (
+        Path(__file__).resolve().parents[2]
+        / "stko_results_examples"
+        / "elasticFrame"
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    return p if (p / "results.mpco").exists() else None
+
+
+@pytest.fixture(scope="module")
+def disp_based_ds():
+    p = _disp_based_dir()
+    if p is None:
+        pytest.skip("displacement-based fixture not available")
+    return MPCODataSet(str(p), "results", verbose=False)
+
+
+@pytest.fixture(scope="module")
+def disp_based_beam_ids(disp_based_ds):
+    return disp_based_ds.elements_info["dataframe"]["element_id"].tolist()[:3]
+
+
+# ----- closed-form: gp_xi is None ---------------------------------------- #
+
+
+def test_closed_form_has_no_gp_xi(disp_based_ds, disp_based_beam_ids):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    assert er.gp_xi is None
+    assert er.n_ip == 0
+
+
+def test_closed_form_at_ip_raises(disp_based_ds, disp_based_beam_ids):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    with pytest.raises(ValueError, match="closed-form"):
+        er.at_ip(0)
+
+
+# ----- 5-IP line-stations ------------------------------------------------ #
+
+
+def test_line_station_gp_xi_is_5_lobatto_points(disp_based_ds, disp_based_beam_ids):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    assert er.n_ip == 5
+    assert er.gp_xi is not None
+    assert er.gp_xi.shape == (5,)
+    # Endpoints are exactly ±1 (Lobatto includes endpoints)
+    assert er.gp_xi[0] == pytest.approx(-1.0)
+    assert er.gp_xi[-1] == pytest.approx(1.0)
+    # Mid-station is at the geometric center
+    assert er.gp_xi[2] == pytest.approx(0.0)
+    # Strictly increasing
+    assert np.all(np.diff(er.gp_xi) > 0)
+
+
+def test_at_ip_returns_only_that_ip_columns(disp_based_ds, disp_based_beam_ids):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    sub = er.at_ip(0)
+    assert list(sub.columns) == ["P_ip0", "Mz_ip0", "My_ip0", "T_ip0"]
+    sub4 = er.at_ip(4)
+    assert list(sub4.columns) == ["P_ip4", "Mz_ip4", "My_ip4", "T_ip4"]
+    # Same MultiIndex preserved
+    assert list(sub.index.names) == ["element_id", "step"]
+
+
+def test_at_ip_out_of_range_raises(disp_based_ds, disp_based_beam_ids):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    with pytest.raises(ValueError, match=r"out of range"):
+        er.at_ip(10)
+    with pytest.raises(ValueError, match=r"out of range"):
+        er.at_ip(-1)
+
+
+def test_repr_includes_n_ip_when_present(disp_based_ds, disp_based_beam_ids):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    assert "n_ip=5" in repr(er)
+
+    er_cf = disp_based_ds.elements.get_element_results(
+        results_name="force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    # Closed-form: n_ip section omitted from repr
+    assert "n_ip" not in repr(er_cf)
+
+
+# ----- compressed fibers + continuum gauss --------------------------------- #
+
+
+def test_compressed_fiber_at_ip_returns_all_fibers_for_ip(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    beam_ids = ds.elements_info["dataframe"].query(
+        "element_type == '64-DispBeamColumn3d'"
+    )["element_id"].head(3).tolist()
+
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=beam_ids,
+    )
+    assert er.n_ip == 2
+    assert er.gp_xi is not None
+    assert er.gp_xi.tolist() == [-1.0, 1.0]
+
+    # at_ip(0) returns the 6 fibers at IP 0
+    sub = er.at_ip(0)
+    assert sub.shape[1] == 6
+    assert all(c.endswith("_ip0") for c in sub.columns)
+    assert all(c.startswith("sigma11_f") for c in sub.columns)
+
+
+def test_continuum_class_has_no_gp_xi_even_with_ips(solid_partition_dir: Path):
+    """Brick continuum has 8 Gauss IPs but no ``GP_X`` on its
+    connectivity (custom-rule attribute is force/disp-beam-only). The
+    bucket parses fine and shows named columns; ``gp_xi`` is ``None``
+    because we don't synthesize coordinates from a class-level catalog
+    yet (that's the B7 ResponseLayout work).
+    """
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_ids = ds.elements_info["dataframe"].query(
+        "element_type == '56-Brick'"
+    )["element_id"].head(2).tolist()
+
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=brick_ids,
+    )
+    assert er.gp_xi is None
+    assert er.n_ip == 0
+    # at_ip is gated on gp_xi presence — even though columns have _ip suffixes
+    with pytest.raises(ValueError, match="closed-form"):
+        er.at_ip(0)
+
+
+# ----- pickle round-trip preserves gp_xi --------------------------------- #
+
+
+def test_gp_xi_survives_pickle(disp_based_ds, disp_based_beam_ids, tmp_path: Path):
+    er = disp_based_ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=disp_based_beam_ids,
+    )
+    p = tmp_path / "er.pkl"
+    er.save_pickle(p)
+
+    from STKO_to_python.elements.element_results import ElementResults
+
+    er2 = ElementResults.load_pickle(p)
+    assert er2.n_ip == 5
+    assert er2.gp_xi is not None
+    np.testing.assert_array_equal(er2.gp_xi, er.gp_xi)
+    # at_ip still works after reload
+    assert list(er2.at_ip(2).columns) == ["P_ip2", "Mz_ip2", "My_ip2", "T_ip2"]

--- a/tests/integration/test_meta_naming_end_to_end.py
+++ b/tests/integration/test_meta_naming_end_to_end.py
@@ -1,0 +1,155 @@
+"""End-to-end tests that the META parser produces real component names
+through the public API.
+
+These tests exercise every bucket shape codified in
+``docs/mpco_format_conventions.md`` against real fixtures:
+
+* Closed-form beams (``GAUSS_IDS=[[-1]]``) — globalForce, localForce
+* Closed-form continuum (8-node brick) — globalForce
+* Line-stations (sequential GAUSS_IDS) — section.force, section.deformation
+* Gauss-level continuum — material.stress, material.strain
+* Compressed META (``MULTIPLICITY > 1``) — section.fiber.stress
+
+The previous behaviour (``val_1, val_2, ...``) is explicitly negated so
+any regression in the meta-parser would cause these to fail loudly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# Closed-form: elasticFrame / 5-ElasticBeam3d
+# ---------------------------------------------------------------------- #
+
+def test_global_force_columns_are_named_per_node(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="force",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+    assert list(er.df.columns) == [
+        "Px_1", "Py_1", "Pz_1", "Mx_1", "My_1", "Mz_1",
+        "Px_2", "Py_2", "Pz_2", "Mx_2", "My_2", "Mz_2",
+    ]
+    # Real names, not val_*
+    assert "val_1" not in er.df.columns
+
+
+def test_local_force_columns_use_local_axis_names(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+    # localForce uses N/Vy/Vz/T/My/Mz — disambiguated from globalForce
+    assert er.df.columns[0] == "N_1"
+    assert er.df.columns[3] == "T_1"
+    assert er.df.columns[6] == "N_2"
+
+
+def test_attribute_style_access_uses_real_names(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+    # User can now reach into result by physical name, not val_3
+    series = er.N_1[1]
+    assert len(series) == er.n_steps
+    assert er.fetch(component="Mz_2", element_ids=[1]) is not None
+
+
+# ---------------------------------------------------------------------- #
+# Line-stations + compressed fibers + gauss continuum: solid_partition_example
+# ---------------------------------------------------------------------- #
+
+def test_line_station_section_force_has_ip_suffix(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    beams = ds.elements_info["dataframe"]
+    beam_ids = beams[
+        beams["element_type"].str.startswith("64-DispBeamColumn3d")
+    ]["element_id"].head(3).tolist()
+
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=beam_ids,
+    )
+    assert list(er.df.columns) == [
+        "P_ip0", "Mz_ip0", "My_ip0", "T_ip0",
+        "P_ip1", "Mz_ip1", "My_ip1", "T_ip1",
+    ]
+
+
+def test_compressed_fiber_columns_expand(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    beams = ds.elements_info["dataframe"]
+    beam_ids = beams[
+        beams["element_type"].str.startswith("64-DispBeamColumn3d")
+    ]["element_id"].head(3).tolist()
+
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=beam_ids,
+    )
+    # MULTIPLICITY=[6,6] with 1 component each → 12 named fiber columns
+    assert er.df.shape[1] == 12
+    assert er.df.columns[0] == "sigma11_f0_ip0"
+    assert er.df.columns[5] == "sigma11_f5_ip0"
+    assert er.df.columns[6] == "sigma11_f0_ip1"
+    assert er.df.columns[-1] == "sigma11_f5_ip1"
+
+
+def test_gauss_continuum_brick_stress(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    bricks = ds.elements_info["dataframe"]
+    brick_ids = bricks[
+        bricks["element_type"].str.startswith("56-Brick")
+    ]["element_id"].head(2).tolist()
+
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=brick_ids,
+    )
+    # 8 Gauss × 6 stress components
+    assert er.df.shape[1] == 48
+    assert er.df.columns.tolist()[:6] == [
+        "sigma11_ip0", "sigma22_ip0", "sigma33_ip0",
+        "sigma12_ip0", "sigma23_ip0", "sigma13_ip0",
+    ]
+    assert er.df.columns.tolist()[-1] == "sigma13_ip7"
+
+
+def test_brick_global_force_uses_per_node_dof_names(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    bricks = ds.elements_info["dataframe"]
+    brick_ids = bricks[
+        bricks["element_type"].str.startswith("56-Brick")
+    ]["element_id"].head(2).tolist()
+
+    er = ds.elements.get_element_results(
+        results_name="force",
+        element_type="56-Brick",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=brick_ids,
+    )
+    # 8-node brick × 3 force DOFs = 24 closed-form columns
+    assert er.df.shape[1] == 24
+    assert er.df.columns[0] == "P1_1"
+    assert er.df.columns[-1] == "P3_8"

--- a/tests/unit/io/test_meta_parser.py
+++ b/tests/unit/io/test_meta_parser.py
@@ -1,0 +1,294 @@
+"""Unit tests for the MPCO META parser.
+
+Mix of in-memory mock buckets (for invariant + error coverage) and
+real-fixture exercises (for end-to-end shape coverage across every
+bucket-type the example folder covers).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pytest
+
+from STKO_to_python.io.meta_parser import (
+    BucketLayout,
+    MpcoFormatError,
+    parse_bucket_meta,
+    validate_data_shape,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLES = REPO_ROOT / "stko_results_examples"
+
+
+# ----- helpers ------------------------------------------------------------ #
+
+
+class _FakeMeta(dict):
+    """Map-like META that returns numpy arrays via ``[k][()]`` semantics."""
+
+    class _Holder:
+        def __init__(self, value):
+            self._value = value
+
+        def __getitem__(self, idx):
+            assert idx == ()
+            return self._value
+
+    def __getitem__(self, k):
+        return self._Holder(super().__getitem__(k))
+
+
+class _FakeBucket:
+    """Minimal h5py-Group lookalike for parser tests."""
+
+    def __init__(self, *, components, multiplicity, gauss_ids,
+                 num_components, num_columns, name="<fake>"):
+        self._meta = _FakeMeta(
+            COMPONENTS=np.array([components.encode("utf-8")]),
+            MULTIPLICITY=np.asarray(multiplicity, dtype=np.int32),
+            GAUSS_IDS=np.asarray(gauss_ids, dtype=np.int32),
+            NUM_COMPONENTS=np.asarray(num_components, dtype=np.int32),
+        )
+        self.attrs = {"NUM_COLUMNS": np.asarray([num_columns], dtype=np.int32)}
+        self.name = name
+
+    def __contains__(self, key):
+        return key == "META"
+
+    def __getitem__(self, key):
+        if key == "META":
+            return self._meta
+        raise KeyError(key)
+
+
+# ----- closed-form (GAUSS_IDS=[[-1]]) ------------------------------------- #
+
+
+def test_closed_form_global_force_3d():
+    bucket = _FakeBucket(
+        components="0.Px_1,Py_1,Pz_1,Mx_1,My_1,Mz_1,Px_2,Py_2,Pz_2,Mx_2,My_2,Mz_2",
+        multiplicity=[[1]],
+        gauss_ids=[[-1]],
+        num_components=[[12]],
+        num_columns=12,
+    )
+    layout = parse_bucket_meta(bucket)
+
+    assert layout.closed_form is True
+    assert layout.n_ip == 0
+    assert layout.gauss_ids == (-1,)
+    assert layout.num_columns == 12
+    assert layout.flat_columns[0] == "Px_1"
+    assert layout.flat_columns[-1] == "Mz_2"
+    assert len(layout.flat_columns) == 12
+
+
+def test_closed_form_local_force_3d():
+    bucket = _FakeBucket(
+        components="0.N_1,Vy_1,Vz_1,T_1,My_1,Mz_1,N_2,Vy_2,Vz_2,T_2,My_2,Mz_2",
+        multiplicity=[[1]],
+        gauss_ids=[[-1]],
+        num_components=[[12]],
+        num_columns=12,
+    )
+    layout = parse_bucket_meta(bucket)
+
+    assert layout.closed_form is True
+    # N/Vy/Vz/T/My/Mz pattern — disambiguates from globalForce's Px/Py/Pz/Mx/My/Mz
+    assert layout.flat_columns[0] == "N_1"
+    assert layout.flat_columns[3] == "T_1"
+
+
+# ----- line-stations (sequential GAUSS_IDS) ------------------------------- #
+
+
+def test_line_station_5_ip_section_force():
+    seg = "0.1.2.P,Mz,My,T"
+    bucket = _FakeBucket(
+        components=";".join([seg] * 5),
+        multiplicity=[[1], [1], [1], [1], [1]],
+        gauss_ids=[[0], [1], [2], [3], [4]],
+        num_components=[[4], [4], [4], [4], [4]],
+        num_columns=20,
+    )
+    layout = parse_bucket_meta(bucket)
+
+    assert layout.closed_form is False
+    assert layout.n_ip == 5
+    assert layout.gauss_ids == (0, 1, 2, 3, 4)
+    assert layout.num_columns == 20
+    # IP suffix included
+    assert layout.flat_columns[0] == "P_ip0"
+    assert layout.flat_columns[3] == "T_ip0"
+    assert layout.flat_columns[4] == "P_ip1"
+    assert layout.flat_columns[-1] == "T_ip4"
+
+
+# ----- compressed META (MULTIPLICITY > 1, fibers) ------------------------- #
+
+
+def test_compressed_fiber_bucket_expands_with_fiber_suffix():
+    bucket = _FakeBucket(
+        components="0.1.2.3.4.sigma11;0.1.2.3.4.sigma11",
+        multiplicity=[[6], [6]],
+        gauss_ids=[[0], [1]],
+        num_components=[[1], [1]],
+        num_columns=12,
+    )
+    layout = parse_bucket_meta(bucket)
+
+    assert layout.closed_form is False
+    assert layout.num_columns == 12
+    assert len(layout.flat_columns) == 12
+    assert layout.flat_columns[0] == "sigma11_f0_ip0"
+    assert layout.flat_columns[5] == "sigma11_f5_ip0"
+    assert layout.flat_columns[6] == "sigma11_f0_ip1"
+    assert layout.flat_columns[-1] == "sigma11_f5_ip1"
+
+
+# ----- invariant violations (fail loud) ----------------------------------- #
+
+
+def test_num_columns_invariant_violation_raises():
+    bucket = _FakeBucket(
+        components="0.Px_1,Py_1",
+        multiplicity=[[1]],
+        gauss_ids=[[-1]],
+        num_components=[[2]],
+        num_columns=99,  # disagrees with sum(MULT * NUM_COMP) = 2
+    )
+    with pytest.raises(MpcoFormatError, match="NUM_COLUMNS invariant violated"):
+        parse_bucket_meta(bucket)
+
+
+def test_segment_count_mismatch_raises():
+    bucket = _FakeBucket(
+        components="0.1.2.P,Mz,My,T",  # 1 segment
+        multiplicity=[[1], [1], [1]],   # 3 blocks
+        gauss_ids=[[0], [1], [2]],
+        num_components=[[4], [4], [4]],
+        num_columns=12,
+    )
+    with pytest.raises(MpcoFormatError, match="META segment count"):
+        parse_bucket_meta(bucket)
+
+
+def test_per_block_component_count_mismatch_raises():
+    bucket = _FakeBucket(
+        components="0.1.2.P,Mz,My",  # 3 names...
+        multiplicity=[[1]],
+        gauss_ids=[[0]],
+        num_components=[[4]],         # ...but block expects 4
+        num_columns=4,
+    )
+    with pytest.raises(MpcoFormatError, match="block 0 META segment has 3 names"):
+        parse_bucket_meta(bucket)
+
+
+def test_non_sequential_gauss_ids_raises():
+    bucket = _FakeBucket(
+        components="0.1.2.P;0.1.2.P",
+        multiplicity=[[1], [1]],
+        gauss_ids=[[0], [3]],         # not sequential
+        num_components=[[1], [1]],
+        num_columns=2,
+    )
+    with pytest.raises(MpcoFormatError, match="sequential 0..n-1"):
+        parse_bucket_meta(bucket)
+
+
+def test_closed_form_with_multiblock_raises():
+    # Closed-form sentinel but >1 block → format violation.
+    bucket = _FakeBucket(
+        components="0.A;0.B",
+        multiplicity=[[1], [1]],
+        gauss_ids=[[-1]],             # sentinel for closed-form
+        num_components=[[1], [1]],
+        num_columns=2,
+    )
+    # Sentinel detected on flat gauss_ids; segment_count(2) != n_blocks(2) ok,
+    # but n_blocks(2) != 1 for closed-form → raises.
+    with pytest.raises(MpcoFormatError, match="closed-form bucket"):
+        parse_bucket_meta(bucket)
+
+
+# ----- validate_data_shape -------------------------------------------------- #
+
+
+def test_validate_data_shape_passes_on_match():
+    layout = BucketLayout(
+        closed_form=True, n_ip=0, gauss_ids=(-1,),
+        ip_components=(("a", "b", "c"),),
+        flat_columns=("a", "b", "c"), num_columns=3,
+    )
+    # Should not raise.
+    validate_data_shape(layout, (10, 3))
+
+
+def test_validate_data_shape_raises_on_mismatch():
+    layout = BucketLayout(
+        closed_form=True, n_ip=0, gauss_ids=(-1,),
+        ip_components=(("a", "b"),),
+        flat_columns=("a", "b"), num_columns=2,
+    )
+    with pytest.raises(MpcoFormatError, match="disagrees with META"):
+        validate_data_shape(layout, (10, 5))
+
+
+# ----- real-fixture coverage ---------------------------------------------- #
+
+
+def _real_buckets():
+    """Iterate over (path, fixture_label, bucket_path, bucket_grp) for every
+    bucket with a META under stko_results_examples/."""
+    if not EXAMPLES.exists():
+        return
+    for mpco in sorted(EXAMPLES.rglob("*.mpco")):
+        try:
+            f = h5py.File(mpco, "r")
+        except OSError:
+            continue
+        try:
+            for stage in (k for k in f.keys() if k.startswith("MODEL_STAGE")):
+                base = f"{stage}/RESULTS/ON_ELEMENTS"
+                if base not in f:
+                    continue
+                for rname in f[base].keys():
+                    rgrp = f[base][rname]
+                    for ekey in rgrp.keys():
+                        eg = rgrp[ekey]
+                        if "META" in eg:
+                            yield mpco, f"{base}/{rname}/{ekey}", eg
+        finally:
+            # Don't close — h5py.File needs to outlive the layout.flat_columns
+            # snapshot (parameterize closes it). We close eagerly.
+            pass
+        f.close()
+
+
+@pytest.mark.parametrize(
+    "mpco_path,bucket_path",
+    [
+        pytest.param(p, b, id=f"{p.parent.name}::{b.split('/RESULTS/')[1]}")
+        for p, b, _ in _real_buckets()
+    ],
+)
+def test_parse_real_fixture_bucket(mpco_path: Path, bucket_path: str) -> None:
+    """Every checked-in fixture bucket parses cleanly and passes the
+    NUM_COLUMNS invariant. Catches format drift in real-world files."""
+    with h5py.File(mpco_path, "r") as f:
+        layout = parse_bucket_meta(f[bucket_path], bucket_path=bucket_path)
+
+    assert isinstance(layout, BucketLayout)
+    assert layout.num_columns > 0
+    assert len(layout.flat_columns) == layout.num_columns
+    # Names are non-empty and unique
+    assert all(isinstance(c, str) and c for c in layout.flat_columns)
+    assert len(set(layout.flat_columns)) == len(layout.flat_columns), (
+        f"duplicate flat column names in {bucket_path}: {layout.flat_columns}"
+    )

--- a/tests/unit/test_canonical_names.py
+++ b/tests/unit/test_canonical_names.py
@@ -1,0 +1,196 @@
+"""Unit tests for :mod:`STKO_to_python.elements.canonical`."""
+from __future__ import annotations
+
+import pytest
+
+from STKO_to_python.elements.canonical import (
+    CANONICAL_TO_MPCO,
+    available_canonicals,
+    list_canonical_for_columns,
+    match_canonical_columns,
+    shortname_of,
+)
+
+
+# ---------------------------------------------------------------------- #
+# shortname_of                                                            #
+# ---------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "column,expected",
+    [
+        # Closed-form node-suffixed
+        ("Px_1", "Px"),
+        ("Mz_2", "Mz"),
+        ("N_1", "N"),
+        ("T_2", "T"),
+        ("Vy_1", "Vy"),
+        # Brick closed-form (Pi_j naming)
+        ("P1_1", "P1"),
+        ("P3_8", "P3"),
+        # Line-stations / gauss-level
+        ("P_ip0", "P"),
+        ("Mz_ip4", "Mz"),
+        ("sigma11_ip7", "sigma11"),
+        ("Fxx_ip3", "Fxx"),
+        ("kappaXY_ip0", "kappaXY"),
+        # Compressed fibers
+        ("sigma11_f0_ip0", "sigma11"),
+        ("sigma11_f5_ip1", "sigma11"),
+        ("eps11_f3_ip0", "eps11"),
+        # Special characters preserved
+        ("d+_ip0", "d+"),
+        ("d-_ip3", "d-"),
+        ("PLE+_ip2", "PLE+"),
+        # Fallback: nothing to strip
+        ("cw", "cw"),
+    ],
+)
+def test_shortname_of(column, expected):
+    assert shortname_of(column) == expected
+
+
+# ---------------------------------------------------------------------- #
+# match_canonical_columns                                                 #
+# ---------------------------------------------------------------------- #
+
+
+def test_axial_force_matches_P_in_line_stations():
+    cols = ("P_ip0", "Mz_ip0", "My_ip0", "T_ip0", "P_ip1", "Mz_ip1", "My_ip1", "T_ip1")
+    assert match_canonical_columns("axial_force", cols) == ["P_ip0", "P_ip1"]
+
+
+def test_axial_force_matches_N_in_local_force():
+    cols = ("N_1", "Vy_1", "Vz_1", "T_1", "My_1", "Mz_1",
+            "N_2", "Vy_2", "Vz_2", "T_2", "My_2", "Mz_2")
+    assert match_canonical_columns("axial_force", cols) == ["N_1", "N_2"]
+
+
+def test_bending_moment_matches_compressed_fiber_layout():
+    """For section.fiber.* the shortnames are sigma11/eps11 not Mz —
+    bending_moment_z should return [] there, not raise."""
+    cols = ("sigma11_f0_ip0", "sigma11_f1_ip0", "sigma11_f0_ip1", "sigma11_f1_ip1")
+    assert match_canonical_columns("bending_moment_z", cols) == []
+
+
+def test_membrane_xx_only_matches_shell_columns():
+    cols = ("Fxx_ip0", "Fyy_ip0", "Fxy_ip0", "Mxx_ip0", "Myy_ip0", "Mxy_ip0",
+            "Fxx_ip1", "Fyy_ip1")
+    assert match_canonical_columns("membrane_xx", cols) == ["Fxx_ip0", "Fxx_ip1"]
+
+
+def test_stress_11_matches_continuum_gauss():
+    cols = tuple(f"{c}_ip{i}" for i in range(3) for c in ("sigma11", "sigma22", "sigma33"))
+    got = match_canonical_columns("stress_11", cols)
+    assert got == ["sigma11_ip0", "sigma11_ip1", "sigma11_ip2"]
+
+
+def test_damage_with_plus_minus_in_shortname():
+    cols = ("d+_ip0", "d-_ip0", "d+_ip1", "d-_ip1")
+    assert match_canonical_columns("damage_pos", cols) == ["d+_ip0", "d+_ip1"]
+    assert match_canonical_columns("damage_neg", cols) == ["d-_ip0", "d-_ip1"]
+
+
+def test_unknown_canonical_raises():
+    with pytest.raises(ValueError, match="Unknown canonical name"):
+        match_canonical_columns("made_up_thing", ["P_ip0"])
+
+
+def test_no_match_returns_empty_list():
+    """Asking for shell membrane_xx on a beam returns [] (silent miss
+    — the higher-level ``ElementResults.canonical()`` is the layer
+    that raises on no-match)."""
+    cols = ("Px_1", "Py_1", "Pz_1")
+    assert match_canonical_columns("membrane_xx", cols) == []
+
+
+# ---------------------------------------------------------------------- #
+# list_canonical_for_columns                                              #
+# ---------------------------------------------------------------------- #
+
+
+def test_list_canonicals_for_local_force_beam():
+    cols = ("N_1", "Vy_1", "Vz_1", "T_1", "My_1", "Mz_1",
+            "N_2", "Vy_2", "Vz_2", "T_2", "My_2", "Mz_2")
+    got = set(list_canonical_for_columns(cols))
+    assert got == {
+        "axial_force", "shear_y", "shear_z", "torsion",
+        "bending_moment_y", "bending_moment_z",
+    }
+
+
+def test_list_canonicals_for_shell_section_force():
+    cols = tuple(
+        f"{c}_ip{i}"
+        for i in range(4)
+        for c in ("Fxx", "Fyy", "Fxy", "Mxx", "Myy", "Mxy", "Vxz", "Vyz")
+    )
+    got = set(list_canonical_for_columns(cols))
+    assert "membrane_xx" in got
+    assert "bending_moment_xx" in got
+    assert "transverse_shear_xz" in got
+    # Beam canonicals not present
+    assert "axial_force" not in got
+    assert "torsion" not in got
+
+
+def test_list_canonicals_for_empty_columns():
+    assert list_canonical_for_columns(()) == ()
+
+
+# ---------------------------------------------------------------------- #
+# Map sanity                                                              #
+# ---------------------------------------------------------------------- #
+
+
+def test_canonical_names_lowercase_underscore():
+    """Naming convention — every canonical key is snake_case."""
+    for name in CANONICAL_TO_MPCO:
+        assert name == name.lower(), name
+        assert " " not in name, name
+
+
+def test_available_canonicals_sorted():
+    avail = available_canonicals()
+    assert list(avail) == sorted(avail)
+
+
+def test_no_duplicate_shortname_targets_per_canonical():
+    for name, targets in CANONICAL_TO_MPCO.items():
+        assert len(targets) == len(set(targets)), name
+
+
+# ---------------------------------------------------------------------- #
+# ElementResults integration (uses real fixture)                           #
+# ---------------------------------------------------------------------- #
+
+
+def test_element_results_canonical_methods(elastic_frame_dir):
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+    assert "axial_force" in er.list_canonicals()
+    assert er.canonical_columns("axial_force") == ("N_1", "N_2")
+    assert list(er.canonical("bending_moment_z").columns) == ["Mz_1", "Mz_2"]
+
+
+def test_element_results_canonical_raises_on_no_match(elastic_frame_dir):
+    """The DataFrame-returning ``canonical()`` raises if no columns
+    match (vs ``canonical_columns()`` which returns the empty tuple)."""
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1],
+    )
+    with pytest.raises(ValueError, match="No columns matching"):
+        er.canonical("membrane_xx")  # shell quantity asked of a beam

--- a/tests/unit/test_coords.py
+++ b/tests/unit/test_coords.py
@@ -1,0 +1,110 @@
+"""Unit tests for :mod:`STKO_to_python.utilities.coords`."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.utilities.coords import (
+    x_physical_to_natural,
+    xi_natural_to_physical,
+)
+
+
+# ----- xi_natural_to_physical --------------------------------------------- #
+
+
+def test_xi_natural_to_physical_endpoints():
+    """ξ=-1 → 0, ξ=+1 → L."""
+    assert xi_natural_to_physical(-1.0, 10.0) == pytest.approx(0.0)
+    assert xi_natural_to_physical(1.0, 10.0) == pytest.approx(10.0)
+
+
+def test_xi_natural_to_physical_midpoint():
+    """ξ=0 → L/2."""
+    assert xi_natural_to_physical(0.0, 8.0) == pytest.approx(4.0)
+
+
+def test_xi_natural_to_physical_array():
+    """Array of 5 Lobatto points → physical positions on a 4 m beam."""
+    xi = np.array([-1.0, -0.65465367, 0.0, 0.65465367, 1.0])
+    x = xi_natural_to_physical(xi, 4.0)
+    assert x.shape == (5,)
+    assert x[0] == pytest.approx(0.0)
+    assert x[-1] == pytest.approx(4.0)
+    assert x[2] == pytest.approx(2.0)
+
+
+def test_xi_natural_to_physical_zero_length_raises():
+    with pytest.raises(ValueError, match="positive"):
+        xi_natural_to_physical(0.0, 0.0)
+
+
+def test_xi_natural_to_physical_negative_length_raises():
+    with pytest.raises(ValueError, match="positive"):
+        xi_natural_to_physical(0.0, -2.0)
+
+
+# ----- x_physical_to_natural ---------------------------------------------- #
+
+
+def test_x_physical_to_natural_endpoints():
+    """0 → -1, L → +1."""
+    assert x_physical_to_natural(0.0, 10.0) == pytest.approx(-1.0)
+    assert x_physical_to_natural(10.0, 10.0) == pytest.approx(1.0)
+
+
+def test_x_physical_to_natural_midpoint():
+    """L/2 → 0."""
+    assert x_physical_to_natural(5.0, 10.0) == pytest.approx(0.0)
+
+
+def test_round_trip_through_both_directions():
+    """xi → x → xi recovers the input."""
+    L = 7.5
+    xi = np.array([-0.9, -0.3, 0.0, 0.4, 0.95])
+    x = xi_natural_to_physical(xi, L)
+    xi2 = x_physical_to_natural(x, L)
+    np.testing.assert_array_almost_equal(xi2, xi)
+
+
+# ----- ElementResults.physical_x integration ------------------------------ #
+
+
+def test_element_results_physical_x_integration(elastic_frame_dir):
+    """End-to-end: a 5-IP Lobatto beam's gp_xi → physical."""
+    from STKO_to_python import MPCODataSet
+
+    p = (
+        elastic_frame_dir.parent
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    if not (p / "results.mpco").exists():
+        pytest.skip("displacement-based fixture not available")
+
+    ds = MPCODataSet(str(p), "results", verbose=False)
+    beam_ids = ds.elements_info["dataframe"]["element_id"].tolist()[:1]
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=beam_ids,
+    )
+    x = er.physical_x(2.0)  # 2 m beam
+    assert x.shape == (5,)
+    assert x[0] == pytest.approx(0.0)
+    assert x[-1] == pytest.approx(2.0)
+    assert x[2] == pytest.approx(1.0)
+
+
+def test_element_results_physical_x_closed_form_raises(elastic_frame_dir):
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="force",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1],
+    )
+    with pytest.raises(ValueError, match="closed-form"):
+        er.physical_x(1.0)

--- a/tests/unit/test_element_bucket_grouping.py
+++ b/tests/unit/test_element_bucket_grouping.py
@@ -1,0 +1,137 @@
+"""Unit tests for B5 — customRuleIdx-aware bucket grouping.
+
+Two surfaces:
+
+* :meth:`ElementManager._validate_homogeneous_layouts` — pure-function
+  cross-bucket layout consistency check. Tested with synthesized
+  ``collected`` lists, no HDF5 needed.
+* The new ``decorated_type`` column on the cached element index — that
+  the column exists, is populated with the 2-field connectivity
+  bracket, and survives partition deduplication.
+
+Heterogeneous-bracket end-to-end coverage (a real .mpco file with
+multiple integration rules under the same element class) is left for a
+future fixture; the validation helper test below exercises the same
+code path that the read loop calls.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from STKO_to_python.elements.elements import ElementManager
+from STKO_to_python.io.meta_parser import MpcoFormatError
+
+
+# ---------------------------------------------------------------------- #
+# Validation helper                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def _chunk(cols):
+    """Build a (bucket_path, col_names, gp_xi, df) tuple matching the
+    shape used in :meth:`ElementManager._fetch_element_results_uncached`.
+    """
+    return (
+        "bucket/" + "_".join(cols[:1]),
+        list(cols),
+        None,
+        pd.DataFrame(),
+    )
+
+
+def test_validate_homogeneous_passes_on_single_layout():
+    cols = ["P_ip0", "Mz_ip0", "P_ip1", "Mz_ip1"]
+    # Single bucket — trivially homogeneous.
+    ElementManager._validate_homogeneous_layouts(
+        [_chunk(cols)],
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+    )
+
+
+def test_validate_homogeneous_passes_on_repeated_layout():
+    # Two buckets, same column layout (e.g. same beam-integration rule
+    # split across partitions) — must not raise.
+    cols = ["Px_1", "Py_1", "Pz_1", "Mx_1", "My_1", "Mz_1",
+            "Px_2", "Py_2", "Pz_2", "Mx_2", "My_2", "Mz_2"]
+    ElementManager._validate_homogeneous_layouts(
+        [_chunk(cols), _chunk(cols)],
+        results_name="force",
+        element_type="5-ElasticBeam3d",
+    )
+
+
+def test_validate_homogeneous_raises_on_layout_mismatch():
+    # Heterogeneous: 5-IP bucket (20 cols) and 3-IP bucket (12 cols).
+    cols_5ip = [f"{c}_ip{i}" for i in range(5) for c in ("P", "Mz", "My", "T")]
+    cols_3ip = [f"{c}_ip{i}" for i in range(3) for c in ("P", "Mz", "My", "T")]
+    with pytest.raises(MpcoFormatError, match="Heterogeneous bucket layouts"):
+        ElementManager._validate_homogeneous_layouts(
+            [_chunk(cols_5ip), _chunk(cols_3ip)],
+            results_name="section.force",
+            element_type="64-DispBeamColumn3d",
+        )
+
+
+def test_validate_error_message_lists_offending_buckets():
+    cols_a = ["A_ip0", "B_ip0"]
+    cols_b = ["X_ip0", "Y_ip0", "Z_ip0"]
+    with pytest.raises(MpcoFormatError) as exc:
+        ElementManager._validate_homogeneous_layouts(
+            [_chunk(cols_a), _chunk(cols_b)],
+            results_name="material.stress",
+            element_type="56-Brick",
+        )
+    msg = str(exc.value)
+    # Both bucket paths and at least one column from each layout appear.
+    assert "section.force" not in msg  # no leakage from other tests
+    assert "Brick" in msg
+    assert "A_ip0" in msg or "B_ip0" in msg
+    assert "X_ip0" in msg or "Y_ip0" in msg or "Z_ip0" in msg
+
+
+# ---------------------------------------------------------------------- #
+# decorated_type column on the cached element index                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_index_has_decorated_type_column(elastic_frame_dir: Path):
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    df = ds.elements_info["dataframe"]
+    assert "decorated_type" in df.columns
+    # The 2-field bracket carries a single ':' between rule and cust.
+    types = df["decorated_type"].unique().tolist()
+    assert all(t.endswith("]") for t in types)
+    assert all(t.count(":") == 1 for t in types), types
+
+
+def test_index_decorated_type_distinguishes_classes(quad_frame_dir: Path):
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    df = ds.elements_info["dataframe"]
+    decs = set(df["decorated_type"].unique())
+    # Both 5-ElasticBeam3d and 203-ASDShellQ4 are present in this fixture
+    assert any(d.startswith("5-ElasticBeam3d[") for d in decs)
+    assert any(d.startswith("203-ASDShellQ4[") for d in decs)
+
+
+def test_index_decorated_type_shared_across_partitions(solid_partition_dir: Path):
+    """Multi-partition fixture: every element row carries a non-null
+    decorated_type and the same decorated bracket appears in both
+    partitions for shared classes."""
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    df = ds.elements_info["dataframe"]
+    # No null decorated_type
+    assert df["decorated_type"].notna().all()
+    # Brick + DispBeam decorated brackets both appear
+    decs = set(df["decorated_type"].unique())
+    assert any("56-Brick[" in d for d in decs)
+    assert any("64-DispBeamColumn3d[" in d for d in decs)


### PR DESCRIPTION
## Summary

Replaces the placeholder ``val_1, val_2, ...`` column names on ``ElementResults`` with names parsed from each bucket's ``META/COMPONENTS``, exposes integration-point coordinates, and adds engineering-friendly canonical names. Heterogeneous integration rules under one base class now raise loudly instead of silently mis-aligning data — that was the highest-risk pre-existing read-path bug.

Three commits, each independently reviewable:

- **`b7ac4b4` Parse MPCO META so element results carry real component names** — the foundation slice (B1 + B3 + B4 + B5 + B2 + B9 from the audit plan).
- **`af212f4` Add bucket-shape snapshot tests for the META parser** — pins ``(n_cols, n_ip, gp_xi, first3, last3)`` per bucket type across the four checked-in fixtures so future format drift breaks loudly (B8).
- **`f75be70` Add canonical engineering names for ElementResults columns** — ``axial_force``, ``bending_moment_z``, ``stress_11``, ``membrane_xx``, etc. resolve to the right shortname regardless of element family (B6).

### What you can now do

```python
er = ds.elements.get_element_results(""section.force"", ""64-DispBeamColumn3d"", element_ids=[1])
er.df.columns                       # ('P_ip0', 'Mz_ip0', ..., 'T_ip4')  — real names, not val_*
er.gp_xi                            # array([-1., -0.65, 0., 0.65, 1.])  — Lobatto 5-pt natural ξ
er.physical_x(beam_length=2.0)      # array([0., 0.345, 1., 1.655, 2.])
er.at_ip(2)                         # only midspan columns
er.canonical(""bending_moment_z"")    # Mz_ip0..Mz_ip4 across element families
```

### Plan items still open

- B7 (``ResponseLayout`` / ``CustomRuleLayout`` catalog) — deferred. Most relevant once the user model has a continuum class with rich per-bucket metadata that the META parser alone can't recover (e.g. canonical IP coordinates for Brick that aren't written to ``GP_X``).

## Test plan

- [x] All existing tests pass (351 → **503 passing**, 0 regressions).
- [x] Parametrized real-fixture parser tests cover every bucket shape across 7 ``.mpco`` files (closed-form beams, line-stations, shells, brick continuum, compressed fibers, MP partitions).
- [x] Snapshot tests pin ``(n_cols, n_ip, gp_xi, first3, last3)`` per bucket type — any future format drift breaks the test loudly.
- [x] Heterogeneous-integration validation raises ``MpcoFormatError`` with the offending column layouts (unit-tested via the extracted helper; no real heterogeneous fixture available yet).
- [x] Pickle round-trip verified for ``gp_xi``.
- [x] Docs updated: ``docs/ElementResults.md`` rewritten around real names + canonical names; ``docs/mpco_format_conventions.md`` added to the MkDocs nav; ``examples/usage_tour.py`` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)