### PR TITLE
Bring Gauss-point catalog into main (was merged into stacking base)

### DIFF
--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -229,9 +229,56 @@ moments_at_midspan = sub["Mz_ip2"]
 
 Closed-form buckets (no integration points) have `er.gp_xi is None`,
 `er.n_ip == 0`, and calling `er.at_ip(...)` or `er.physical_x(...)`
-raises `ValueError`. Continuum classes like 8-IP brick `material.stress`
-also expose `n_ip == 0` for now (no `GP_X` on their connectivity);
-class-level catalog support is planned future work.
+raises `ValueError`.
+
+### Multi-dimensional integration points (shells & solids)
+
+For shells, plane elements, and 3-D solids the integration-point
+positions are *fixed by the element class* and not written to disk.
+The library carries a static catalog at
+[`utilities/gauss_points.py`](api/index.md) and exposes the resolved
+layout as a multi-dimensional array on `ElementResults`:
+
+```python
+# Brick continuum, 8 Gauss points
+er = ds.elements.get_element_results("material.stress", "56-Brick", element_ids=[100])
+er.n_ip            # 8
+er.gp_dim          # 3
+er.gp_natural      # shape (8, 3) — (ξ, η, ζ) at ±1/√3 per axis
+er.gp_weights      # shape (8,)   — all 1.0 for 2×2×2 Gauss-Legendre
+
+# Shell, 4 Gauss points
+er_shell = ds.elements.get_element_results("section.force", "203-ASDShellQ4", element_ids=[7])
+er_shell.gp_natural    # shape (4, 2)
+er_shell.gp_weights    # shape (4,)
+```
+
+`gp_xi` stays line-element-only — it's the 1-D ξ from connectivity
+``GP_X`` for force/disp-based beams. `gp_natural` is the multi-D
+generalization, also populated for line elements as a shape `(n_ip, 1)`
+view of `gp_xi`. `gp_weights` is catalog-driven only (line-element
+Lobatto / Legendre weights aren't written to MPCO, so it's `None`
+there).
+
+`at_ip(idx)` works on any bucket with integration points — line,
+plane, or solid. For numerical integration:
+
+```python
+# Volume integral of stress_11 over the parent cube (per element):
+# ∫ sigma11 dV ≈ Σ sigma11_ip * weight_ip * |J|
+# (|J| from element geometry — supplied by the user.)
+sigma_at_ips = er.canonical("stress_11").to_numpy()   # (n_steps*n_elem, 8)
+weighted = sigma_at_ips * er.gp_weights[None, :]
+```
+
+**Ordering convention.** Tensor-product schemes enumerate IPs with **ξ
+varying fastest, then η, then ζ**. If your model uses a non-default
+integration scheme or the OpenSees ordering happens to differ, override
+the catalog entry in `utilities/gauss_points.py`.
+
+**Unknown classes.** Element classes not in the catalog yield
+`gp_natural=None`. Adding an entry is a one-line change — see the
+catalog docstring for the convention.
 
 For the underlying convention details, see
 [mpco_format_conventions.md §1, §7](mpco_format_conventions.md). The

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -118,6 +118,8 @@ class ElementResults:
         results_name: Optional[str] = None,
         model_stage: Optional[str] = None,
         gp_xi: Optional[np.ndarray] = None,
+        gp_natural: Optional[np.ndarray] = None,
+        gp_weights: Optional[np.ndarray] = None,
     ) -> None:
         self.df = df
         self.time = time
@@ -126,6 +128,31 @@ class ElementResults:
         self.element_type = element_type or ""
         self.results_name = results_name or ""
         self.model_stage = model_stage or ""
+
+        # Multi-dimensional natural-coord IP positions, shape
+        # ``(n_ip, dim)``: dim=1 for lines, 2 for shells / plane
+        # elements, 3 for solids. Populated from connectivity ``GP_X``
+        # (line elements) or from the static catalog at
+        # :mod:`STKO_to_python.utilities.gauss_points` (shells / solids).
+        # Always in natural / parent-element coordinates ∈ [-1, +1]^dim.
+        # ``None`` when no source is available.
+        self.gp_natural: Optional[np.ndarray] = (
+            np.asarray(gp_natural, dtype=np.float64)
+            if gp_natural is not None
+            else None
+        )
+
+        # Quadrature weights aligned to ``gp_natural`` (same first
+        # axis). Catalog-driven only — line-element custom rules don't
+        # write weights to the file. Use for numerical integration
+        # over the parent domain (``sum(value * weight * |J|)``) once a
+        # Jacobian is supplied for the physical element.
+        self.gp_weights: Optional[np.ndarray] = (
+            np.asarray(gp_weights, dtype=np.float64)
+            if gp_weights is not None
+            else None
+        )
+
         # Natural-coordinate integration-point positions (ξ ∈ [-1, +1]).
         # Length equals the number of integration points; ``None`` for
         # closed-form buckets (no IPs) and for buckets whose connectivity
@@ -197,8 +224,31 @@ class ElementResults:
 
     @property
     def n_ip(self) -> int:
-        """Number of integration points (0 for closed-form buckets)."""
-        return 0 if self.gp_xi is None else int(self.gp_xi.size)
+        """Number of integration points (0 for closed-form buckets).
+
+        Considers both the line-element ``gp_xi`` and the multi-D
+        ``gp_natural`` so the count is consistent for shells / solids
+        as well as beams.
+        """
+        if self.gp_natural is not None:
+            return int(self.gp_natural.shape[0])
+        if self.gp_xi is not None:
+            return int(self.gp_xi.size)
+        return 0
+
+    @property
+    def gp_dim(self) -> int:
+        """Parametric dimensionality of the integration scheme.
+
+        ``1`` for line elements, ``2`` for shells / plane elements,
+        ``3`` for solids. ``0`` for closed-form buckets and unknown
+        element classes.
+        """
+        if self.gp_natural is not None:
+            return int(self.gp_natural.shape[1])
+        if self.gp_xi is not None:
+            return 1
+        return 0
 
     # ------------------------------------------------------------------ #
     # Canonical-name access                                              #
@@ -317,13 +367,12 @@ class ElementResults:
             If the bucket is closed-form (no IPs), if ``ip_idx`` is out
             of range, or if no columns match the suffix.
         """
-        if self.gp_xi is None:
+        n = self.n_ip
+        if n == 0:
             raise ValueError(
-                "at_ip() is only valid for line-station / gauss-level "
-                "buckets. This result is closed-form (no integration "
-                "points)."
+                "at_ip() is only valid for buckets with integration "
+                "points. This result is closed-form (no IPs)."
             )
-        n = int(self.gp_xi.size)
         if not (0 <= ip_idx < n):
             raise ValueError(
                 f"ip_idx={ip_idx} out of range [0, {n})."

--- a/src/STKO_to_python/elements/elements.py
+++ b/src/STKO_to_python/elements/elements.py
@@ -733,14 +733,26 @@ class ElementManager:
                 f"[Elements] {len(df_info)} matching elements for '{element_type}'"
             )
 
-        # Each entry: (results_bucket_path, col_names, gp_xi_or_None, df_chunk).
-        # Collected across partitions and connectivity brackets, then
-        # concatenated with a column-layout consistency check. ``gp_xi``
-        # is the natural-coordinate integration-point array read from
-        # the connectivity dataset's ``@GP_X`` attribute (only present
-        # for custom-rule beam-columns); ``None`` otherwise.
+        # Each entry:
+        #   (results_bucket_path, col_names, gp_xi, gp_natural,
+        #    gp_weights, df_chunk).
+        #
+        # ``gp_xi`` is the natural ξ from the connectivity ``@GP_X``
+        # attribute (1-D, custom-rule beams only). ``gp_natural`` is
+        # the multi-D natural-coord array (n_ip, dim) — for line
+        # elements this is ``gp_xi.reshape(-1, 1)``; for shells/solids
+        # it comes from the static catalog at
+        # ``utilities/gauss_points.py``. ``gp_weights`` is catalog-
+        # provided integration weights (None for line elements).
         collected: list[
-            tuple[str, list[str], Optional[np.ndarray], pd.DataFrame]
+            tuple[
+                str,
+                list[str],
+                Optional[np.ndarray],
+                Optional[np.ndarray],
+                Optional[np.ndarray],
+                pd.DataFrame,
+            ]
         ] = []
 
         # Group by partition for efficient HDF5 access
@@ -886,16 +898,55 @@ class ElementManager:
                         df_chunk["step"] = np.repeat(
                             np.arange(n_steps), n_elems
                         )
-                        # GP_X is only meaningful for non-closed-form
-                        # buckets. For closed-form, drop it even if the
-                        # connectivity dataset happened to carry one.
+                        # GP_X (1-D ξ) is only meaningful for non-closed-
+                        # form line buckets. For closed-form, drop it
+                        # even if the connectivity dataset happened to
+                        # carry one.
                         chunk_gp_xi = (
                             gp_xi
                             if (layout is not None and not layout.closed_form)
                             else None
                         )
+
+                        # Resolve the multi-D natural-coord layout. For
+                        # line elements with GP_X we get a 1×n_ip vector
+                        # which we promote to (n_ip, 1). For shells /
+                        # solids we consult the catalog by base class +
+                        # IP count. Closed-form buckets stay None.
+                        chunk_gp_natural: Optional[np.ndarray] = None
+                        chunk_gp_weights: Optional[np.ndarray] = None
+                        if layout is not None and not layout.closed_form:
+                            if chunk_gp_xi is not None:
+                                chunk_gp_natural = chunk_gp_xi.reshape(-1, 1)
+                                # Line-element custom rules: weights
+                                # are not in the file. Leave as None.
+                            else:
+                                # Look up catalog by the connectivity
+                                # bracket's base class (strip the
+                                # ``[rule:cust]`` suffix).
+                                from ..utilities.gauss_points import (
+                                    get_ip_layout,
+                                )
+
+                                conn_base = conn_decorated.split("[", 1)[0]
+                                cat = get_ip_layout(conn_base, layout.n_ip)
+                                if cat is not None:
+                                    chunk_gp_natural = np.asarray(
+                                        cat[0], dtype=np.float64
+                                    )
+                                    chunk_gp_weights = np.asarray(
+                                        cat[1], dtype=np.float64
+                                    )
+
                         collected.append(
-                            (bucket_path, col_names, chunk_gp_xi, df_chunk)
+                            (
+                                bucket_path,
+                                col_names,
+                                chunk_gp_xi,
+                                chunk_gp_natural,
+                                chunk_gp_weights,
+                                df_chunk,
+                            )
                         )
 
         if not collected:
@@ -922,32 +973,38 @@ class ElementManager:
             element_type=element_type,
         )
 
-        # Reconcile GP_X across chunks. All non-None gp_xi values must
-        # agree (same beam-integration rule → same natural coords);
-        # otherwise that's another flavor of heterogeneous integration
-        # and we already raised above. Pick the first non-None.
+        # Reconcile gp_xi / gp_natural / gp_weights across chunks.
+        # All non-None values for a given attribute must agree; if not,
+        # that's another flavor of heterogeneous integration (already
+        # caught by the layout check above unless someone changes the
+        # catalog out from under us). Pick the first non-None.
         merged_gp_xi: Optional[np.ndarray] = None
-        for _, _, chunk_gp_xi, _ in collected:
-            if chunk_gp_xi is None:
-                continue
-            if merged_gp_xi is None:
-                merged_gp_xi = chunk_gp_xi
-            elif not np.allclose(
-                merged_gp_xi, chunk_gp_xi, rtol=0.0, atol=1e-12
-            ):
-                from ..io.meta_parser import MpcoFormatError
+        merged_gp_natural: Optional[np.ndarray] = None
+        merged_gp_weights: Optional[np.ndarray] = None
+        for _, _, c_xi, c_nat, c_w, _ in collected:
+            if c_xi is not None:
+                if merged_gp_xi is None:
+                    merged_gp_xi = c_xi
+                elif not np.allclose(
+                    merged_gp_xi, c_xi, rtol=0.0, atol=1e-12
+                ):
+                    from ..io.meta_parser import MpcoFormatError
 
-                raise MpcoFormatError(
-                    f"GP_X disagrees across buckets for "
-                    f"results_name={results_name!r}, "
-                    f"element_type={element_type!r}: "
-                    f"{merged_gp_xi.tolist()} vs {chunk_gp_xi.tolist()}. "
-                    f"This means heterogeneous beam-integration rules; "
-                    f"query each decorated bucket separately."
-                )
+                    raise MpcoFormatError(
+                        f"GP_X disagrees across buckets for "
+                        f"results_name={results_name!r}, "
+                        f"element_type={element_type!r}: "
+                        f"{merged_gp_xi.tolist()} vs {c_xi.tolist()}. "
+                        f"This means heterogeneous beam-integration "
+                        f"rules; query each decorated bucket separately."
+                    )
+            if c_nat is not None and merged_gp_natural is None:
+                merged_gp_natural = c_nat
+            if c_w is not None and merged_gp_weights is None:
+                merged_gp_weights = c_w
 
         result_df = pd.concat(
-            [df for _, _, _, df in collected], ignore_index=True
+            [entry[5] for entry in collected], ignore_index=True
         )
         result_df = result_df.set_index(["element_id", "step"]).sort_index()
 
@@ -968,6 +1025,8 @@ class ElementManager:
             results_name=results_name,
             model_stage=model_stage,
             gp_xi=merged_gp_xi,
+            gp_natural=merged_gp_natural,
+            gp_weights=merged_gp_weights,
         )
 
     def get_element_results_by_selection_and_z(

--- a/src/STKO_to_python/utilities/gauss_points.py
+++ b/src/STKO_to_python/utilities/gauss_points.py
@@ -1,0 +1,192 @@
+"""Standard Gauss-point coordinates for fixed-class elements.
+
+For force/disp-based beam-columns the integration-point coordinates
+live on the connectivity dataset's ``@GP_X`` attribute (custom rule —
+see docs/mpco_format_conventions.md §1, §4). For continuum solids,
+shells, and plane elements, the coordinates are *fixed by the
+element class and integration-point count* and are **not** written to
+disk. This module is the catalog the read path consults to fill in
+``ElementResults.gp_natural`` for those classes.
+
+Values are in **natural coordinates** (parent-element parametric
+space): ξ ∈ [-1, +1] for line elements, (ξ, η) ∈ [-1, +1]² for 2-D
+shells / plane elements, (ξ, η, ζ) ∈ [-1, +1]³ for 3-D solids.
+
+Ordering convention
+-------------------
+Tensor-product integration schemes enumerate points with **ξ varying
+fastest, then η, then ζ** — a left-to-right, bottom-to-top, front-to-
+back walk. This is the standard convention used by most FEM textbooks
+and by OpenSees's natural-coordinate quadrature loops. If a particular
+element class turns out to enumerate differently, override its catalog
+entry rather than changing the global helpers.
+
+The catalog is intentionally small in v1 — entries are added per
+element class as fixtures or user reports appear. Lookup falls back
+to ``None`` for unknown (class, n_ip) pairs; the read path then leaves
+``gp_natural`` unset rather than guessing.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+__all__ = [
+    "gauss_legendre_1d",
+    "tensor_product_2d",
+    "tensor_product_3d",
+    "ELEMENT_IP_CATALOG",
+    "get_ip_layout",
+]
+
+
+# --------------------------------------------------------------------- #
+# Gauss-Legendre primitives                                             #
+# --------------------------------------------------------------------- #
+
+
+@lru_cache(maxsize=16)
+def gauss_legendre_1d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Return the 1-D Gauss-Legendre points and weights for ``n``-point
+    quadrature.
+
+    Backed by :func:`numpy.polynomial.legendre.leggauss`. Cached so a
+    repeat lookup is free.
+
+    Returns
+    -------
+    points, weights : np.ndarray of shape (n,)
+        Sorted ascending in ξ ∈ (-1, +1).
+    """
+    if n < 1:
+        raise ValueError(f"n must be ≥ 1, got {n!r}")
+    pts, wts = np.polynomial.legendre.leggauss(int(n))
+    return pts.astype(np.float64), wts.astype(np.float64)
+
+
+def tensor_product_2d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the 2-D tensor-product Gauss-Legendre rule with ``n`` points
+    per direction.
+
+    Ordering: ξ varies fastest, then η.
+
+    Returns
+    -------
+    coords : np.ndarray of shape (n*n, 2)
+        Each row is (ξ_i, η_i).
+    weights : np.ndarray of shape (n*n,)
+        Product weights.
+    """
+    pts, wts = gauss_legendre_1d(n)
+    # ξ-fastest: outer loop over η.
+    xi_grid, eta_grid = np.meshgrid(pts, pts, indexing="xy")
+    wxi, weta = np.meshgrid(wts, wts, indexing="xy")
+    coords = np.stack([xi_grid.ravel(), eta_grid.ravel()], axis=1)
+    weights = (wxi * weta).ravel()
+    return coords.astype(np.float64), weights.astype(np.float64)
+
+
+def tensor_product_3d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the 3-D tensor-product Gauss-Legendre rule with ``n`` points
+    per direction.
+
+    Ordering: ξ varies fastest, then η, then ζ.
+
+    Returns
+    -------
+    coords : np.ndarray of shape (n^3, 3)
+        Each row is (ξ_i, η_i, ζ_i).
+    weights : np.ndarray of shape (n^3,)
+        Product weights.
+    """
+    pts, wts = gauss_legendre_1d(n)
+    # ξ-fastest, then η, then ζ.
+    xi_grid, eta_grid, zeta_grid = np.meshgrid(pts, pts, pts, indexing="ij")
+    # 'ij' indexing makes the FIRST axis vary slowest. We want xi-fastest
+    # which means xi should be the LAST varying axis when raveled. Re-
+    # arrange axes accordingly.
+    coords = np.stack(
+        [
+            xi_grid.transpose(2, 1, 0).ravel(),
+            eta_grid.transpose(2, 1, 0).ravel(),
+            zeta_grid.transpose(2, 1, 0).ravel(),
+        ],
+        axis=1,
+    )
+    wxi, weta, wzeta = np.meshgrid(wts, wts, wts, indexing="ij")
+    weights = (wxi * weta * wzeta).transpose(2, 1, 0).ravel()
+    return coords.astype(np.float64), weights.astype(np.float64)
+
+
+# --------------------------------------------------------------------- #
+# Element catalog                                                       #
+# --------------------------------------------------------------------- #
+#
+# Keys are the *base* element name carried in MPCO connectivity datasets
+# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
+# Inner keys are the integration-point count expected for the bucket.
+# Values are ``(coords, weights)`` tuples.
+#
+# Add new entries as fixtures or user models surface them. Unknown
+# (class, n_ip) pairs return ``None`` from :func:`get_ip_layout` and
+# the read path leaves ``gp_natural`` empty.
+
+ELEMENT_IP_CATALOG: Dict[str, Dict[int, Tuple[np.ndarray, np.ndarray]]] = {
+    # --- Shells (in-plane 2-D Gauss-Legendre) ---
+    "203-ASDShellQ4": {
+        4: tensor_product_2d(2),  # standard 2×2 quadrature
+    },
+    # --- 3-D continuum solids ---
+    "56-Brick": {
+        8: tensor_product_3d(2),   # standard 2×2×2
+        27: tensor_product_3d(3),  # full 3×3×3
+    },
+    # --- Plane elements (2-D quads) ---
+    # Common 4-node quad classes — names need verification against
+    # actual fixtures before relying on these in production.
+    "FourNodeQuad": {
+        4: tensor_product_2d(2),
+        9: tensor_product_2d(3),
+    },
+}
+
+
+def get_ip_layout(
+    element_class_base: str, n_ip: int
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Look up natural coords + weights for a ``(class, n_ip)`` pair.
+
+    Parameters
+    ----------
+    element_class_base : str
+        Base class name as it appears in the MPCO connectivity bracket
+        — e.g. ``"56-Brick"`` (not ``"56-Brick[401:0]"``).
+    n_ip : int
+        Number of integration points actually present in the bucket
+        (from META/GAUSS_IDS).
+
+    Returns
+    -------
+    (coords, weights) or None
+        ``coords`` shape ``(n_ip, dim)``; ``weights`` shape ``(n_ip,)``.
+        ``None`` if the class or the requested IP count is not in the
+        catalog — the read path then leaves ``gp_natural`` unset and
+        the user keeps named columns but no spatial coordinates.
+    """
+    entry = ELEMENT_IP_CATALOG.get(element_class_base)
+    if entry is None:
+        return None
+    layout = entry.get(int(n_ip))
+    if layout is None:
+        return None
+    coords, weights = layout
+    if coords.shape[0] != int(n_ip):
+        # Defensive: catch a miscataloged entry early.
+        raise RuntimeError(
+            f"Catalog inconsistency for {element_class_base!r} n_ip={n_ip}: "
+            f"got {coords.shape[0]} coords."
+        )
+    return coords, weights

--- a/tests/integration/test_fixture_snapshots.py
+++ b/tests/integration/test_fixture_snapshots.py
@@ -86,8 +86,9 @@ SNAPSHOTS = [
         "results_name": "section.force",
         "element_type": "203-ASDShellQ4",
         "n_cols": 32,
-        "n_ip": 0,  # shell connectivity carries no GP_X attribute
-        "gp_xi": None,
+        "n_ip": 4,                     # 2x2 Gauss-Legendre, from catalog
+        "gp_xi": None,                 # multi-D — gp_xi is line-element only
+        "gp_natural_shape": (4, 2),    # in-plane (ξ, η)
         "first3": ("Fxx_ip0", "Fyy_ip0", "Fxy_ip0"),
         "last3": ("Mxy_ip3", "Vxz_ip3", "Vyz_ip3"),
     },
@@ -99,8 +100,9 @@ SNAPSHOTS = [
         "results_name": "section.deformation",
         "element_type": "203-ASDShellQ4",
         "n_cols": 32,
-        "n_ip": 0,
+        "n_ip": 4,
         "gp_xi": None,
+        "gp_natural_shape": (4, 2),
         "first3": ("epsXX_ip0", "epsYY_ip0", "epsXY_ip0"),
         "last3": ("kappaXY_ip3", "gammaXZ_ip3", "gammaYZ_ip3"),
     },
@@ -139,8 +141,9 @@ SNAPSHOTS = [
         "results_name": "material.stress",
         "element_type": "56-Brick",
         "n_cols": 48,
-        "n_ip": 0,  # no GP_X on Brick connectivity
-        "gp_xi": None,
+        "n_ip": 8,                     # 2x2x2 Gauss-Legendre, from catalog
+        "gp_xi": None,                 # multi-D — gp_xi is line-element only
+        "gp_natural_shape": (8, 3),    # 3-D (ξ, η, ζ)
         "first3": ("sigma11_ip0", "sigma22_ip0", "sigma33_ip0"),
         "last3": ("sigma12_ip7", "sigma23_ip7", "sigma13_ip7"),
     },
@@ -258,6 +261,17 @@ def test_bucket_snapshot(snap, request, _ds_cache):
             rtol=1e-6,
             atol=1e-7,
             err_msg=f"{snap['id']}: gp_xi snapshot mismatch",
+        )
+
+    expected_nat_shape = snap.get("gp_natural_shape")
+    if expected_nat_shape is not None:
+        assert er.gp_natural is not None, (
+            f"{snap['id']}: expected gp_natural shape {expected_nat_shape}, "
+            f"got None"
+        )
+        assert er.gp_natural.shape == expected_nat_shape, (
+            f"{snap['id']}: gp_natural shape "
+            f"{er.gp_natural.shape} != {expected_nat_shape}"
         )
 
 

--- a/tests/integration/test_gp_xi_and_at_ip.py
+++ b/tests/integration/test_gp_xi_and_at_ip.py
@@ -165,12 +165,13 @@ def test_compressed_fiber_at_ip_returns_all_fibers_for_ip(solid_partition_dir: P
     assert all(c.startswith("sigma11_f") for c in sub.columns)
 
 
-def test_continuum_class_has_no_gp_xi_even_with_ips(solid_partition_dir: Path):
-    """Brick continuum has 8 Gauss IPs but no ``GP_X`` on its
-    connectivity (custom-rule attribute is force/disp-beam-only). The
-    bucket parses fine and shows named columns; ``gp_xi`` is ``None``
-    because we don't synthesize coordinates from a class-level catalog
-    yet (that's the B7 ResponseLayout work).
+def test_continuum_class_uses_catalog_gauss_points(solid_partition_dir: Path):
+    """Brick continuum has 8 Gauss IPs and no ``GP_X`` attribute on its
+    connectivity. The natural coordinates of those IPs are *fixed by
+    the element class* and come from the static catalog at
+    :mod:`STKO_to_python.utilities.gauss_points` (B7a). The 1-D ``gp_xi``
+    stays ``None`` (it's line-element-only); the multi-D ``gp_natural``
+    carries the (8, 3) array of (ξ, η, ζ) Gauss-Legendre points.
     """
     ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
     brick_ids = ds.elements_info["dataframe"].query(
@@ -183,11 +184,23 @@ def test_continuum_class_has_no_gp_xi_even_with_ips(solid_partition_dir: Path):
         model_stage="MODEL_STAGE[1]",
         element_ids=brick_ids,
     )
+    # 1-D ξ stays None (multi-D bucket).
     assert er.gp_xi is None
-    assert er.n_ip == 0
-    # at_ip is gated on gp_xi presence — even though columns have _ip suffixes
-    with pytest.raises(ValueError, match="closed-form"):
-        er.at_ip(0)
+    # 3-D natural coords from catalog.
+    assert er.n_ip == 8
+    assert er.gp_dim == 3
+    assert er.gp_natural is not None
+    assert er.gp_natural.shape == (8, 3)
+    # Standard 2x2x2 Gauss-Legendre points are at ±1/sqrt(3) per axis.
+    assert np.allclose(np.abs(er.gp_natural), 1.0 / np.sqrt(3.0))
+    # Weights are uniform 1.0 on a [-1,1]^3 cube → sum = 8.
+    assert er.gp_weights is not None
+    assert er.gp_weights.shape == (8,)
+    assert er.gp_weights.sum() == pytest.approx(8.0)
+    # at_ip now works for continuum gauss-level buckets too.
+    sub = er.at_ip(0)
+    assert sub.shape[1] == 6  # 6 stress components per Gauss point
+    assert all(c.endswith("_ip0") for c in sub.columns)
 
 
 # ----- pickle round-trip preserves gp_xi --------------------------------- #

--- a/tests/unit/test_element_bucket_grouping.py
+++ b/tests/unit/test_element_bucket_grouping.py
@@ -37,7 +37,9 @@ def _chunk(cols):
     return (
         "bucket/" + "_".join(cols[:1]),
         list(cols),
-        None,
+        None,  # gp_xi
+        None,  # gp_natural
+        None,  # gp_weights
         pd.DataFrame(),
     )
 

--- a/tests/unit/test_gauss_points.py
+++ b/tests/unit/test_gauss_points.py
@@ -1,0 +1,193 @@
+"""Unit tests for :mod:`STKO_to_python.utilities.gauss_points`.
+
+Validates the 1-D / 2-D / 3-D Gauss-Legendre primitives and the
+catalog lookups used to fill in ``ElementResults.gp_natural`` for
+fixed-class elements (shells, plane elements, solids).
+
+Ordering convention (per the module docstring): ξ varies fastest, then
+η, then ζ. Tests pin this so a future refactor that flips the
+iteration order breaks loudly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.utilities.gauss_points import (
+    ELEMENT_IP_CATALOG,
+    gauss_legendre_1d,
+    get_ip_layout,
+    tensor_product_2d,
+    tensor_product_3d,
+)
+
+
+# ---------------------------------------------------------------------- #
+# 1-D Gauss-Legendre primitives                                           #
+# ---------------------------------------------------------------------- #
+
+
+def test_gl1d_n2_points_and_weights():
+    pts, wts = gauss_legendre_1d(2)
+    assert np.allclose(pts, [-1.0 / np.sqrt(3.0), 1.0 / np.sqrt(3.0)])
+    assert np.allclose(wts, [1.0, 1.0])
+
+
+def test_gl1d_n3_points_and_weights():
+    pts, wts = gauss_legendre_1d(3)
+    assert np.allclose(pts, [-np.sqrt(3 / 5), 0.0, np.sqrt(3 / 5)])
+    assert np.allclose(wts, [5 / 9, 8 / 9, 5 / 9])
+
+
+def test_gl1d_weights_sum_to_2():
+    """Sum of weights on the parent interval [-1, +1] is 2."""
+    for n in range(1, 6):
+        _, wts = gauss_legendre_1d(n)
+        assert wts.sum() == pytest.approx(2.0), n
+
+
+def test_gl1d_invalid_n_raises():
+    with pytest.raises(ValueError, match="≥ 1"):
+        gauss_legendre_1d(0)
+
+
+def test_gl1d_is_cached():
+    """lru_cache on the public function — same array object returned."""
+    a, _ = gauss_legendre_1d(2)
+    b, _ = gauss_legendre_1d(2)
+    assert a is b
+
+
+# ---------------------------------------------------------------------- #
+# 2-D tensor product                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_tensor_product_2d_n2_shape_and_ordering():
+    coords, weights = tensor_product_2d(2)
+    a = 1.0 / np.sqrt(3.0)
+    expected = np.array(
+        [
+            [-a, -a],
+            [+a, -a],
+            [-a, +a],
+            [+a, +a],
+        ]
+    )
+    assert coords.shape == (4, 2)
+    assert weights.shape == (4,)
+    np.testing.assert_allclose(coords, expected, rtol=1e-12)
+    assert weights.sum() == pytest.approx(4.0)  # area of [-1,1]^2
+
+
+def test_tensor_product_2d_n3_count_and_weights_sum():
+    coords, weights = tensor_product_2d(3)
+    assert coords.shape == (9, 2)
+    assert weights.sum() == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------- #
+# 3-D tensor product                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_tensor_product_3d_n2_shape_and_ordering():
+    coords, weights = tensor_product_3d(2)
+    a = 1.0 / np.sqrt(3.0)
+    expected = np.array(
+        [
+            [-a, -a, -a],
+            [+a, -a, -a],
+            [-a, +a, -a],
+            [+a, +a, -a],
+            [-a, -a, +a],
+            [+a, -a, +a],
+            [-a, +a, +a],
+            [+a, +a, +a],
+        ]
+    )
+    assert coords.shape == (8, 3)
+    assert weights.shape == (8,)
+    np.testing.assert_allclose(coords, expected, rtol=1e-12)
+    assert weights.sum() == pytest.approx(8.0)  # volume of [-1,1]^3
+
+
+def test_tensor_product_3d_n3_count():
+    coords, weights = tensor_product_3d(3)
+    assert coords.shape == (27, 3)
+    assert weights.sum() == pytest.approx(8.0)
+
+
+# ---------------------------------------------------------------------- #
+# Numerical-integration sanity                                             #
+# ---------------------------------------------------------------------- #
+
+
+def test_2d_gauss_legendre_integrates_polynomials_exactly():
+    """Gauss-Legendre n=2 integrates polynomials of degree ≤ 3 exactly."""
+    coords, weights = tensor_product_2d(2)
+    # ∫∫ (xi^2 + eta^2) dxi deta over [-1,1]^2
+    #   = ∫(2 xi^2) dxi + ∫(2 eta^2) deta
+    #   = 2*(2/3) + 2*(2/3) = 8/3
+    f = coords[:, 0] ** 2 + coords[:, 1] ** 2
+    integral = (f * weights).sum()
+    assert integral == pytest.approx(8 / 3)
+
+
+def test_3d_gauss_legendre_integrates_polynomials_exactly():
+    coords, weights = tensor_product_3d(2)
+    # ∫∫∫ (xi*eta*zeta + 1) over [-1,1]^3 = 0 + 8 = 8
+    f = coords[:, 0] * coords[:, 1] * coords[:, 2] + 1.0
+    integral = (f * weights).sum()
+    assert integral == pytest.approx(8.0)
+
+
+# ---------------------------------------------------------------------- #
+# Catalog lookups                                                          #
+# ---------------------------------------------------------------------- #
+
+
+def test_catalog_lookup_asd_shell_q4():
+    layout = get_ip_layout("203-ASDShellQ4", 4)
+    assert layout is not None
+    coords, weights = layout
+    assert coords.shape == (4, 2)
+    assert weights.shape == (4,)
+    assert weights.sum() == pytest.approx(4.0)
+
+
+def test_catalog_lookup_brick_8ip():
+    coords, weights = get_ip_layout("56-Brick", 8)
+    assert coords.shape == (8, 3)
+    assert weights.sum() == pytest.approx(8.0)
+
+
+def test_catalog_lookup_brick_27ip():
+    coords, weights = get_ip_layout("56-Brick", 27)
+    assert coords.shape == (27, 3)
+    assert weights.sum() == pytest.approx(8.0)
+
+
+def test_catalog_unknown_class_returns_none():
+    assert get_ip_layout("99-MysteryElement", 4) is None
+
+
+def test_catalog_unknown_n_ip_returns_none():
+    """Class is in the catalog but the requested IP count isn't."""
+    assert get_ip_layout("56-Brick", 12) is None
+
+
+def test_catalog_consistency_n_ip_matches_coords_length():
+    """Every catalog entry advertises the right n_ip in its key."""
+    for class_name, schemes in ELEMENT_IP_CATALOG.items():
+        for n_ip, (coords, weights) in schemes.items():
+            assert coords.shape[0] == n_ip, (class_name, n_ip)
+            assert weights.shape[0] == n_ip, (class_name, n_ip)
+
+
+def test_catalog_dim_per_class():
+    """Spot-check that 2-D classes return 2-vectors and 3-D return 3-vectors."""
+    coords, _ = get_ip_layout("203-ASDShellQ4", 4)
+    assert coords.shape[1] == 2
+    coords, _ = get_ip_layout("56-Brick", 8)
+    assert coords.shape[1] == 3


### PR DESCRIPTION
## Why this PR exists

PR #23 (the Gauss-point catalog for shells/solids) targeted the stacking base ``feat/mpco-meta-parser`` rather than ``main``. When you merged it, the commit landed on that feature branch but never made it to ``main``. This PR re-targets the same change at ``main``.

## What's in it

Just the single commit ``0ed5041`` from PR #23 (plus its merge commit ``730cc14``), unchanged. See [#23](https://github.com/nmorabowen/STKO_to_python/pull/23) for the full description.

TL;DR: adds ``ElementResults.gp_natural`` (multi-D natural coordinates from a static catalog) and ``gp_weights`` (Gauss-Legendre weights) for shells, plane elements, and 3-D solids — bricks now report ``n_ip=8``, shells ``n_ip=4``, etc.

## Test plan

- [x] **521 passing** locally on this branch (vs **503** on current ``main``); 18 new tests cover the catalog primitives + integration on real fixtures.
- [x] Re-verified end-to-end on the QuadFrame shell fixture and the solid_partition Brick fixture.

## How this happened

When I opened PR #23 I set ``--base feat/mpco-meta-parser`` to stack it. After PR #22 merged into ``main``, GitHub did **not** auto-rebase #23 onto ``main`` — it waited for the stacking base to receive #23's merge. Standard GitHub stacked-PR gotcha. Won't happen again on this set; future stacks should re-target after the parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)