### PR TITLE
Physical coordinates + Jacobians for shells / solids / lines

### DIFF
--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -280,6 +280,50 @@ the catalog entry in `utilities/gauss_points.py`.
 `gp_natural=None`. Adding an entry is a one-line change — see the
 catalog docstring for the convention.
 
+### Physical coordinates and Jacobians
+
+For numerical integration over the *physical* element (volume / area /
+length, not just the parent domain) the library exposes shape-function-
+based mapping for each catalogued class. Two methods on
+`ElementResults`:
+
+```python
+phys = er.physical_coords()   # (n_elements, n_ip, 3) — physical (x, y, z) per IP
+dets = er.jacobian_dets()     # (n_elements, n_ip)    — |J| per IP
+```
+
+For solids the determinant is `|det(∂x/∂ξ)|` (volume measure); for
+shells it's `||∂x/∂ξ × ∂x/∂η||` (surface measure); for line elements
+it's `||∂x/∂ξ||` (line measure).
+
+**Numerical integration.** Multiply value × weight × `|J|` and sum
+over IPs to get a contribution to the integral over the physical
+element. For a brick `material.stress`:
+
+```python
+cols = er.canonical_columns("stress_11")
+sigma_step = er.df.xs(100, level="step")[list(cols)].to_numpy()  # (n_e, n_ip)
+volume_int_per_elem = (sigma_step * er.gp_weights[None, :] * dets).sum(axis=1)
+```
+
+For a shell `section.force`, the same pattern integrates a quantity
+over the physical surface. For a line element, over the physical
+length.
+
+**Inputs.** `physical_coords()` and `jacobian_dets()` rely on
+``element_node_coords`` (populated automatically from the dataset's
+node table at fetch time, aligned with `er.element_ids`). Both return
+``None`` when any of these is missing:
+
+- The bucket is closed-form (`gp_natural is None`), or
+- Node coordinates aren't available on the dataset, or
+- The element class isn't in the shape-function catalog
+  (``utilities/shape_functions.py``).
+
+The ``element_node_coords`` and ``element_node_ids`` arrays survive
+pickle round-trips, so a saved `ElementResults` carries everything
+needed to recompute physical coords without re-opening the MPCO file.
+
 For the underlying convention details, see
 [mpco_format_conventions.md §1, §7](mpco_format_conventions.md). The
 natural↔physical conversion utilities live at

--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -229,9 +229,56 @@ moments_at_midspan = sub["Mz_ip2"]
 
 Closed-form buckets (no integration points) have `er.gp_xi is None`,
 `er.n_ip == 0`, and calling `er.at_ip(...)` or `er.physical_x(...)`
-raises `ValueError`. Continuum classes like 8-IP brick `material.stress`
-also expose `n_ip == 0` for now (no `GP_X` on their connectivity);
-class-level catalog support is planned future work.
+raises `ValueError`.
+
+### Multi-dimensional integration points (shells & solids)
+
+For shells, plane elements, and 3-D solids the integration-point
+positions are *fixed by the element class* and not written to disk.
+The library carries a static catalog at
+[`utilities/gauss_points.py`](api/index.md) and exposes the resolved
+layout as a multi-dimensional array on `ElementResults`:
+
+```python
+# Brick continuum, 8 Gauss points
+er = ds.elements.get_element_results("material.stress", "56-Brick", element_ids=[100])
+er.n_ip            # 8
+er.gp_dim          # 3
+er.gp_natural      # shape (8, 3) — (ξ, η, ζ) at ±1/√3 per axis
+er.gp_weights      # shape (8,)   — all 1.0 for 2×2×2 Gauss-Legendre
+
+# Shell, 4 Gauss points
+er_shell = ds.elements.get_element_results("section.force", "203-ASDShellQ4", element_ids=[7])
+er_shell.gp_natural    # shape (4, 2)
+er_shell.gp_weights    # shape (4,)
+```
+
+`gp_xi` stays line-element-only — it's the 1-D ξ from connectivity
+``GP_X`` for force/disp-based beams. `gp_natural` is the multi-D
+generalization, also populated for line elements as a shape `(n_ip, 1)`
+view of `gp_xi`. `gp_weights` is catalog-driven only (line-element
+Lobatto / Legendre weights aren't written to MPCO, so it's `None`
+there).
+
+`at_ip(idx)` works on any bucket with integration points — line,
+plane, or solid. For numerical integration:
+
+```python
+# Volume integral of stress_11 over the parent cube (per element):
+# ∫ sigma11 dV ≈ Σ sigma11_ip * weight_ip * |J|
+# (|J| from element geometry — supplied by the user.)
+sigma_at_ips = er.canonical("stress_11").to_numpy()   # (n_steps*n_elem, 8)
+weighted = sigma_at_ips * er.gp_weights[None, :]
+```
+
+**Ordering convention.** Tensor-product schemes enumerate IPs with **ξ
+varying fastest, then η, then ζ**. If your model uses a non-default
+integration scheme or the OpenSees ordering happens to differ, override
+the catalog entry in `utilities/gauss_points.py`.
+
+**Unknown classes.** Element classes not in the catalog yield
+`gp_natural=None`. Adding an entry is a one-line change — see the
+catalog docstring for the convention.
 
 For the underlying convention details, see
 [mpco_format_conventions.md §1, §7](mpco_format_conventions.md). The

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -120,6 +120,8 @@ class ElementResults:
         gp_xi: Optional[np.ndarray] = None,
         gp_natural: Optional[np.ndarray] = None,
         gp_weights: Optional[np.ndarray] = None,
+        element_node_coords: Optional[np.ndarray] = None,
+        element_node_ids: Optional[np.ndarray] = None,
     ) -> None:
         self.df = df
         self.time = time
@@ -160,6 +162,23 @@ class ElementResults:
         # See docs/mpco_format_conventions.md §1, §7.
         self.gp_xi: Optional[np.ndarray] = (
             np.asarray(gp_xi, dtype=np.float64) if gp_xi is not None else None
+        )
+
+        # Per-element nodal coordinates and node IDs, ordered to match
+        # ``self.element_ids`` (sorted ascending). Shape
+        # ``(n_elements, n_nodes_per, 3)`` for coords; ``(n_elements,
+        # n_nodes_per)`` for IDs. Required by :meth:`physical_coords`
+        # and :meth:`jacobian_dets`. ``None`` for empty results or when
+        # the read path couldn't resolve node coordinates.
+        self.element_node_coords: Optional[np.ndarray] = (
+            np.asarray(element_node_coords, dtype=np.float64)
+            if element_node_coords is not None
+            else None
+        )
+        self.element_node_ids: Optional[np.ndarray] = (
+            np.asarray(element_node_ids, dtype=np.int64)
+            if element_node_ids is not None
+            else None
         )
 
         self._views: Dict[str, _ElementResultView] = {}
@@ -307,6 +326,90 @@ class ElementResults:
                 f"result. Present canonicals: {self.list_canonicals()}"
             )
         return self.df[list(cols)]
+
+    # ------------------------------------------------------------------ #
+    # Physical-coordinate mapping (B7b — shells / solids / lines)         #
+    # ------------------------------------------------------------------ #
+
+    def physical_coords(self) -> Optional[np.ndarray]:
+        """Physical (x, y, z) of each integration point in each element.
+
+        Maps ``gp_natural`` through the element-class shape function
+        catalog at :mod:`STKO_to_python.utilities.shape_functions`.
+
+        Returns
+        -------
+        np.ndarray, shape ``(n_elements, n_ip, 3)``, or ``None``
+            First axis aligned with ``self.element_ids``. ``None`` if
+            any of the following is missing: ``gp_natural``,
+            ``element_node_coords``, or a shape function for this
+            element class.
+
+        Examples
+        --------
+        Brick continuum, plot σ_11 contour at midspan ζ=0:
+
+        >>> phys = er.physical_coords()              # (n_e, 8, 3)
+        >>> sigma11 = er.canonical("stress_11").to_numpy()
+        >>> # ... pick a step, then scatter(phys[:, :, 0], phys[:, :, 1], c=sigma11)
+        """
+        if self.gp_natural is None or self.element_node_coords is None:
+            return None
+        from ..utilities.shape_functions import (
+            compute_physical_coords,
+            get_shape_functions,
+        )
+
+        base = self.element_type.split("[", 1)[0]
+        fns = get_shape_functions(base)
+        if fns is None:
+            return None
+        N_fn, _, _ = fns
+        return compute_physical_coords(
+            self.gp_natural, self.element_node_coords, N_fn
+        )
+
+    def jacobian_dets(self) -> Optional[np.ndarray]:
+        """Jacobian determinants at each IP for each element.
+
+        - Solids (3-D): ``|det(∂x/∂ξ)|`` — the volume measure.
+        - Shells (2-D in 3-D): ``||∂x/∂ξ × ∂x/∂η||`` — the surface
+          measure.
+        - Line elements: ``||∂x/∂ξ||`` — the line measure.
+
+        Multiplying ``value_at_ip * gp_weights * jacobian_dets`` gives a
+        contribution to the integral over the *physical* element.
+
+        Returns
+        -------
+        np.ndarray, shape ``(n_elements, n_ip)``, or ``None``
+            Same alignment + ``None`` conditions as
+            :meth:`physical_coords`.
+
+        Examples
+        --------
+        Volume-integrate σ_11 over each brick element at step 100:
+
+        >>> dets = er.jacobian_dets()                   # (n_e, n_ip)
+        >>> sigma11 = er.canonical("stress_11").xs(100, level="step").to_numpy()
+        >>> # sigma11 shape: (n_e, n_ip)
+        >>> per_elem = (sigma11 * er.gp_weights[None, :] * dets).sum(axis=1)
+        """
+        if self.gp_natural is None or self.element_node_coords is None:
+            return None
+        from ..utilities.shape_functions import (
+            compute_jacobian_dets,
+            get_shape_functions,
+        )
+
+        base = self.element_type.split("[", 1)[0]
+        fns = get_shape_functions(base)
+        if fns is None:
+            return None
+        _, dN_fn, geom_kind = fns
+        return compute_jacobian_dets(
+            self.gp_natural, self.element_node_coords, dN_fn, geom_kind
+        )
 
     def physical_x(self, length: float) -> np.ndarray:
         """Convert ``self.gp_xi`` (natural ξ ∈ [-1, +1]) to physical

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -118,6 +118,8 @@ class ElementResults:
         results_name: Optional[str] = None,
         model_stage: Optional[str] = None,
         gp_xi: Optional[np.ndarray] = None,
+        gp_natural: Optional[np.ndarray] = None,
+        gp_weights: Optional[np.ndarray] = None,
     ) -> None:
         self.df = df
         self.time = time
@@ -126,6 +128,31 @@ class ElementResults:
         self.element_type = element_type or ""
         self.results_name = results_name or ""
         self.model_stage = model_stage or ""
+
+        # Multi-dimensional natural-coord IP positions, shape
+        # ``(n_ip, dim)``: dim=1 for lines, 2 for shells / plane
+        # elements, 3 for solids. Populated from connectivity ``GP_X``
+        # (line elements) or from the static catalog at
+        # :mod:`STKO_to_python.utilities.gauss_points` (shells / solids).
+        # Always in natural / parent-element coordinates ∈ [-1, +1]^dim.
+        # ``None`` when no source is available.
+        self.gp_natural: Optional[np.ndarray] = (
+            np.asarray(gp_natural, dtype=np.float64)
+            if gp_natural is not None
+            else None
+        )
+
+        # Quadrature weights aligned to ``gp_natural`` (same first
+        # axis). Catalog-driven only — line-element custom rules don't
+        # write weights to the file. Use for numerical integration
+        # over the parent domain (``sum(value * weight * |J|)``) once a
+        # Jacobian is supplied for the physical element.
+        self.gp_weights: Optional[np.ndarray] = (
+            np.asarray(gp_weights, dtype=np.float64)
+            if gp_weights is not None
+            else None
+        )
+
         # Natural-coordinate integration-point positions (ξ ∈ [-1, +1]).
         # Length equals the number of integration points; ``None`` for
         # closed-form buckets (no IPs) and for buckets whose connectivity
@@ -197,8 +224,31 @@ class ElementResults:
 
     @property
     def n_ip(self) -> int:
-        """Number of integration points (0 for closed-form buckets)."""
-        return 0 if self.gp_xi is None else int(self.gp_xi.size)
+        """Number of integration points (0 for closed-form buckets).
+
+        Considers both the line-element ``gp_xi`` and the multi-D
+        ``gp_natural`` so the count is consistent for shells / solids
+        as well as beams.
+        """
+        if self.gp_natural is not None:
+            return int(self.gp_natural.shape[0])
+        if self.gp_xi is not None:
+            return int(self.gp_xi.size)
+        return 0
+
+    @property
+    def gp_dim(self) -> int:
+        """Parametric dimensionality of the integration scheme.
+
+        ``1`` for line elements, ``2`` for shells / plane elements,
+        ``3`` for solids. ``0`` for closed-form buckets and unknown
+        element classes.
+        """
+        if self.gp_natural is not None:
+            return int(self.gp_natural.shape[1])
+        if self.gp_xi is not None:
+            return 1
+        return 0
 
     # ------------------------------------------------------------------ #
     # Canonical-name access                                              #
@@ -317,13 +367,12 @@ class ElementResults:
             If the bucket is closed-form (no IPs), if ``ip_idx`` is out
             of range, or if no columns match the suffix.
         """
-        if self.gp_xi is None:
+        n = self.n_ip
+        if n == 0:
             raise ValueError(
-                "at_ip() is only valid for line-station / gauss-level "
-                "buckets. This result is closed-form (no integration "
-                "points)."
+                "at_ip() is only valid for buckets with integration "
+                "points. This result is closed-form (no IPs)."
             )
-        n = int(self.gp_xi.size)
         if not (0 <= ip_idx < n):
             raise ValueError(
                 f"ip_idx={ip_idx} out of range [0, {n})."

--- a/src/STKO_to_python/elements/elements.py
+++ b/src/STKO_to_python/elements/elements.py
@@ -555,6 +555,73 @@ class ElementManager:
     # Core results reader
     # ------------------------------------------------------------------ #
 
+    def _build_element_node_coords(
+        self,
+        sorted_ids: Tuple[int, ...],
+        df_info: pd.DataFrame,
+    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+        """Build (element_node_coords, element_node_ids) aligned to
+        ``sorted_ids`` (ascending element_id).
+
+        Returns ``(None, None)`` if the dataset has no node coordinate
+        table or the element index is missing — physical-coord
+        computations on the resulting :class:`ElementResults` will
+        return ``None``, but the named columns and IP layouts still
+        come through cleanly.
+
+        Shape:
+            element_node_coords : ``(n_elements, n_nodes_per, 3)``
+            element_node_ids    : ``(n_elements, n_nodes_per)``
+
+        Assumes ``num_nodes`` is uniform across the matched elements
+        (true within a single base class — different decorated brackets
+        of the same class still share node count).
+        """
+        if not sorted_ids:
+            return None, None
+        nodes_info = getattr(self.dataset, "nodes_info", None)
+        if not isinstance(nodes_info, dict):
+            return None, None
+        df_nodes = nodes_info.get("dataframe")
+        if df_nodes is None or df_nodes.empty:
+            return None, None
+
+        # Map node_id → row index in the coord array.
+        nids = df_nodes["node_id"].to_numpy(dtype=np.int64)
+        coords = df_nodes[["x", "y", "z"]].to_numpy(dtype=np.float64)
+        node_id_to_pos = {int(n): i for i, n in enumerate(nids)}
+
+        # Slice df_info to one row per element_id, in sorted order.
+        df_unique = df_info.drop_duplicates("element_id").set_index(
+            "element_id", drop=False
+        )
+        try:
+            df_sorted = df_unique.loc[list(sorted_ids)]
+        except KeyError:
+            return None, None
+
+        node_lists = df_sorted["node_list"].tolist()
+        if not node_lists:
+            return None, None
+        n_nodes_per = len(node_lists[0])
+        n_elems = len(node_lists)
+
+        out_ids = np.empty((n_elems, n_nodes_per), dtype=np.int64)
+        out_xyz = np.empty((n_elems, n_nodes_per, 3), dtype=np.float64)
+        for i, nl in enumerate(node_lists):
+            if len(nl) != n_nodes_per:
+                # Unexpected mixed node count — bail out rather than
+                # silently producing a ragged array.
+                return None, None
+            for j, nid in enumerate(nl):
+                out_ids[i, j] = int(nid)
+                pos = node_id_to_pos.get(int(nid))
+                if pos is None:
+                    out_xyz[i, j, :] = np.nan
+                else:
+                    out_xyz[i, j, :] = coords[pos]
+        return out_xyz, out_ids
+
     @staticmethod
     def _validate_homogeneous_layouts(
         collected,
@@ -1016,17 +1083,27 @@ class ElementManager:
 
         from .element_results import ElementResults
 
+        # Build per-element node-coordinate arrays for B7b physical-
+        # coordinate / Jacobian computations. Aligned with the sorted
+        # element_ids that the result df uses.
+        sorted_ids_tup = tuple(sorted(ids.tolist()))
+        elem_node_coords, elem_node_ids = self._build_element_node_coords(
+            sorted_ids_tup, df_info
+        )
+
         return ElementResults(
             df=result_df,
             time=time_arr,
             name=self.dataset.name,
-            element_ids=tuple(sorted(ids.tolist())),
+            element_ids=sorted_ids_tup,
             element_type=element_type,
             results_name=results_name,
             model_stage=model_stage,
             gp_xi=merged_gp_xi,
             gp_natural=merged_gp_natural,
             gp_weights=merged_gp_weights,
+            element_node_coords=elem_node_coords,
+            element_node_ids=elem_node_ids,
         )
 
     def get_element_results_by_selection_and_z(

--- a/src/STKO_to_python/elements/elements.py
+++ b/src/STKO_to_python/elements/elements.py
@@ -733,14 +733,26 @@ class ElementManager:
                 f"[Elements] {len(df_info)} matching elements for '{element_type}'"
             )
 
-        # Each entry: (results_bucket_path, col_names, gp_xi_or_None, df_chunk).
-        # Collected across partitions and connectivity brackets, then
-        # concatenated with a column-layout consistency check. ``gp_xi``
-        # is the natural-coordinate integration-point array read from
-        # the connectivity dataset's ``@GP_X`` attribute (only present
-        # for custom-rule beam-columns); ``None`` otherwise.
+        # Each entry:
+        #   (results_bucket_path, col_names, gp_xi, gp_natural,
+        #    gp_weights, df_chunk).
+        #
+        # ``gp_xi`` is the natural ξ from the connectivity ``@GP_X``
+        # attribute (1-D, custom-rule beams only). ``gp_natural`` is
+        # the multi-D natural-coord array (n_ip, dim) — for line
+        # elements this is ``gp_xi.reshape(-1, 1)``; for shells/solids
+        # it comes from the static catalog at
+        # ``utilities/gauss_points.py``. ``gp_weights`` is catalog-
+        # provided integration weights (None for line elements).
         collected: list[
-            tuple[str, list[str], Optional[np.ndarray], pd.DataFrame]
+            tuple[
+                str,
+                list[str],
+                Optional[np.ndarray],
+                Optional[np.ndarray],
+                Optional[np.ndarray],
+                pd.DataFrame,
+            ]
         ] = []
 
         # Group by partition for efficient HDF5 access
@@ -886,16 +898,55 @@ class ElementManager:
                         df_chunk["step"] = np.repeat(
                             np.arange(n_steps), n_elems
                         )
-                        # GP_X is only meaningful for non-closed-form
-                        # buckets. For closed-form, drop it even if the
-                        # connectivity dataset happened to carry one.
+                        # GP_X (1-D ξ) is only meaningful for non-closed-
+                        # form line buckets. For closed-form, drop it
+                        # even if the connectivity dataset happened to
+                        # carry one.
                         chunk_gp_xi = (
                             gp_xi
                             if (layout is not None and not layout.closed_form)
                             else None
                         )
+
+                        # Resolve the multi-D natural-coord layout. For
+                        # line elements with GP_X we get a 1×n_ip vector
+                        # which we promote to (n_ip, 1). For shells /
+                        # solids we consult the catalog by base class +
+                        # IP count. Closed-form buckets stay None.
+                        chunk_gp_natural: Optional[np.ndarray] = None
+                        chunk_gp_weights: Optional[np.ndarray] = None
+                        if layout is not None and not layout.closed_form:
+                            if chunk_gp_xi is not None:
+                                chunk_gp_natural = chunk_gp_xi.reshape(-1, 1)
+                                # Line-element custom rules: weights
+                                # are not in the file. Leave as None.
+                            else:
+                                # Look up catalog by the connectivity
+                                # bracket's base class (strip the
+                                # ``[rule:cust]`` suffix).
+                                from ..utilities.gauss_points import (
+                                    get_ip_layout,
+                                )
+
+                                conn_base = conn_decorated.split("[", 1)[0]
+                                cat = get_ip_layout(conn_base, layout.n_ip)
+                                if cat is not None:
+                                    chunk_gp_natural = np.asarray(
+                                        cat[0], dtype=np.float64
+                                    )
+                                    chunk_gp_weights = np.asarray(
+                                        cat[1], dtype=np.float64
+                                    )
+
                         collected.append(
-                            (bucket_path, col_names, chunk_gp_xi, df_chunk)
+                            (
+                                bucket_path,
+                                col_names,
+                                chunk_gp_xi,
+                                chunk_gp_natural,
+                                chunk_gp_weights,
+                                df_chunk,
+                            )
                         )
 
         if not collected:
@@ -922,32 +973,38 @@ class ElementManager:
             element_type=element_type,
         )
 
-        # Reconcile GP_X across chunks. All non-None gp_xi values must
-        # agree (same beam-integration rule → same natural coords);
-        # otherwise that's another flavor of heterogeneous integration
-        # and we already raised above. Pick the first non-None.
+        # Reconcile gp_xi / gp_natural / gp_weights across chunks.
+        # All non-None values for a given attribute must agree; if not,
+        # that's another flavor of heterogeneous integration (already
+        # caught by the layout check above unless someone changes the
+        # catalog out from under us). Pick the first non-None.
         merged_gp_xi: Optional[np.ndarray] = None
-        for _, _, chunk_gp_xi, _ in collected:
-            if chunk_gp_xi is None:
-                continue
-            if merged_gp_xi is None:
-                merged_gp_xi = chunk_gp_xi
-            elif not np.allclose(
-                merged_gp_xi, chunk_gp_xi, rtol=0.0, atol=1e-12
-            ):
-                from ..io.meta_parser import MpcoFormatError
+        merged_gp_natural: Optional[np.ndarray] = None
+        merged_gp_weights: Optional[np.ndarray] = None
+        for _, _, c_xi, c_nat, c_w, _ in collected:
+            if c_xi is not None:
+                if merged_gp_xi is None:
+                    merged_gp_xi = c_xi
+                elif not np.allclose(
+                    merged_gp_xi, c_xi, rtol=0.0, atol=1e-12
+                ):
+                    from ..io.meta_parser import MpcoFormatError
 
-                raise MpcoFormatError(
-                    f"GP_X disagrees across buckets for "
-                    f"results_name={results_name!r}, "
-                    f"element_type={element_type!r}: "
-                    f"{merged_gp_xi.tolist()} vs {chunk_gp_xi.tolist()}. "
-                    f"This means heterogeneous beam-integration rules; "
-                    f"query each decorated bucket separately."
-                )
+                    raise MpcoFormatError(
+                        f"GP_X disagrees across buckets for "
+                        f"results_name={results_name!r}, "
+                        f"element_type={element_type!r}: "
+                        f"{merged_gp_xi.tolist()} vs {c_xi.tolist()}. "
+                        f"This means heterogeneous beam-integration "
+                        f"rules; query each decorated bucket separately."
+                    )
+            if c_nat is not None and merged_gp_natural is None:
+                merged_gp_natural = c_nat
+            if c_w is not None and merged_gp_weights is None:
+                merged_gp_weights = c_w
 
         result_df = pd.concat(
-            [df for _, _, _, df in collected], ignore_index=True
+            [entry[5] for entry in collected], ignore_index=True
         )
         result_df = result_df.set_index(["element_id", "step"]).sort_index()
 
@@ -968,6 +1025,8 @@ class ElementManager:
             results_name=results_name,
             model_stage=model_stage,
             gp_xi=merged_gp_xi,
+            gp_natural=merged_gp_natural,
+            gp_weights=merged_gp_weights,
         )
 
     def get_element_results_by_selection_and_z(

--- a/src/STKO_to_python/utilities/gauss_points.py
+++ b/src/STKO_to_python/utilities/gauss_points.py
@@ -1,0 +1,192 @@
+"""Standard Gauss-point coordinates for fixed-class elements.
+
+For force/disp-based beam-columns the integration-point coordinates
+live on the connectivity dataset's ``@GP_X`` attribute (custom rule —
+see docs/mpco_format_conventions.md §1, §4). For continuum solids,
+shells, and plane elements, the coordinates are *fixed by the
+element class and integration-point count* and are **not** written to
+disk. This module is the catalog the read path consults to fill in
+``ElementResults.gp_natural`` for those classes.
+
+Values are in **natural coordinates** (parent-element parametric
+space): ξ ∈ [-1, +1] for line elements, (ξ, η) ∈ [-1, +1]² for 2-D
+shells / plane elements, (ξ, η, ζ) ∈ [-1, +1]³ for 3-D solids.
+
+Ordering convention
+-------------------
+Tensor-product integration schemes enumerate points with **ξ varying
+fastest, then η, then ζ** — a left-to-right, bottom-to-top, front-to-
+back walk. This is the standard convention used by most FEM textbooks
+and by OpenSees's natural-coordinate quadrature loops. If a particular
+element class turns out to enumerate differently, override its catalog
+entry rather than changing the global helpers.
+
+The catalog is intentionally small in v1 — entries are added per
+element class as fixtures or user reports appear. Lookup falls back
+to ``None`` for unknown (class, n_ip) pairs; the read path then leaves
+``gp_natural`` unset rather than guessing.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+__all__ = [
+    "gauss_legendre_1d",
+    "tensor_product_2d",
+    "tensor_product_3d",
+    "ELEMENT_IP_CATALOG",
+    "get_ip_layout",
+]
+
+
+# --------------------------------------------------------------------- #
+# Gauss-Legendre primitives                                             #
+# --------------------------------------------------------------------- #
+
+
+@lru_cache(maxsize=16)
+def gauss_legendre_1d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Return the 1-D Gauss-Legendre points and weights for ``n``-point
+    quadrature.
+
+    Backed by :func:`numpy.polynomial.legendre.leggauss`. Cached so a
+    repeat lookup is free.
+
+    Returns
+    -------
+    points, weights : np.ndarray of shape (n,)
+        Sorted ascending in ξ ∈ (-1, +1).
+    """
+    if n < 1:
+        raise ValueError(f"n must be ≥ 1, got {n!r}")
+    pts, wts = np.polynomial.legendre.leggauss(int(n))
+    return pts.astype(np.float64), wts.astype(np.float64)
+
+
+def tensor_product_2d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the 2-D tensor-product Gauss-Legendre rule with ``n`` points
+    per direction.
+
+    Ordering: ξ varies fastest, then η.
+
+    Returns
+    -------
+    coords : np.ndarray of shape (n*n, 2)
+        Each row is (ξ_i, η_i).
+    weights : np.ndarray of shape (n*n,)
+        Product weights.
+    """
+    pts, wts = gauss_legendre_1d(n)
+    # ξ-fastest: outer loop over η.
+    xi_grid, eta_grid = np.meshgrid(pts, pts, indexing="xy")
+    wxi, weta = np.meshgrid(wts, wts, indexing="xy")
+    coords = np.stack([xi_grid.ravel(), eta_grid.ravel()], axis=1)
+    weights = (wxi * weta).ravel()
+    return coords.astype(np.float64), weights.astype(np.float64)
+
+
+def tensor_product_3d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the 3-D tensor-product Gauss-Legendre rule with ``n`` points
+    per direction.
+
+    Ordering: ξ varies fastest, then η, then ζ.
+
+    Returns
+    -------
+    coords : np.ndarray of shape (n^3, 3)
+        Each row is (ξ_i, η_i, ζ_i).
+    weights : np.ndarray of shape (n^3,)
+        Product weights.
+    """
+    pts, wts = gauss_legendre_1d(n)
+    # ξ-fastest, then η, then ζ.
+    xi_grid, eta_grid, zeta_grid = np.meshgrid(pts, pts, pts, indexing="ij")
+    # 'ij' indexing makes the FIRST axis vary slowest. We want xi-fastest
+    # which means xi should be the LAST varying axis when raveled. Re-
+    # arrange axes accordingly.
+    coords = np.stack(
+        [
+            xi_grid.transpose(2, 1, 0).ravel(),
+            eta_grid.transpose(2, 1, 0).ravel(),
+            zeta_grid.transpose(2, 1, 0).ravel(),
+        ],
+        axis=1,
+    )
+    wxi, weta, wzeta = np.meshgrid(wts, wts, wts, indexing="ij")
+    weights = (wxi * weta * wzeta).transpose(2, 1, 0).ravel()
+    return coords.astype(np.float64), weights.astype(np.float64)
+
+
+# --------------------------------------------------------------------- #
+# Element catalog                                                       #
+# --------------------------------------------------------------------- #
+#
+# Keys are the *base* element name carried in MPCO connectivity datasets
+# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
+# Inner keys are the integration-point count expected for the bucket.
+# Values are ``(coords, weights)`` tuples.
+#
+# Add new entries as fixtures or user models surface them. Unknown
+# (class, n_ip) pairs return ``None`` from :func:`get_ip_layout` and
+# the read path leaves ``gp_natural`` empty.
+
+ELEMENT_IP_CATALOG: Dict[str, Dict[int, Tuple[np.ndarray, np.ndarray]]] = {
+    # --- Shells (in-plane 2-D Gauss-Legendre) ---
+    "203-ASDShellQ4": {
+        4: tensor_product_2d(2),  # standard 2×2 quadrature
+    },
+    # --- 3-D continuum solids ---
+    "56-Brick": {
+        8: tensor_product_3d(2),   # standard 2×2×2
+        27: tensor_product_3d(3),  # full 3×3×3
+    },
+    # --- Plane elements (2-D quads) ---
+    # Common 4-node quad classes — names need verification against
+    # actual fixtures before relying on these in production.
+    "FourNodeQuad": {
+        4: tensor_product_2d(2),
+        9: tensor_product_2d(3),
+    },
+}
+
+
+def get_ip_layout(
+    element_class_base: str, n_ip: int
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Look up natural coords + weights for a ``(class, n_ip)`` pair.
+
+    Parameters
+    ----------
+    element_class_base : str
+        Base class name as it appears in the MPCO connectivity bracket
+        — e.g. ``"56-Brick"`` (not ``"56-Brick[401:0]"``).
+    n_ip : int
+        Number of integration points actually present in the bucket
+        (from META/GAUSS_IDS).
+
+    Returns
+    -------
+    (coords, weights) or None
+        ``coords`` shape ``(n_ip, dim)``; ``weights`` shape ``(n_ip,)``.
+        ``None`` if the class or the requested IP count is not in the
+        catalog — the read path then leaves ``gp_natural`` unset and
+        the user keeps named columns but no spatial coordinates.
+    """
+    entry = ELEMENT_IP_CATALOG.get(element_class_base)
+    if entry is None:
+        return None
+    layout = entry.get(int(n_ip))
+    if layout is None:
+        return None
+    coords, weights = layout
+    if coords.shape[0] != int(n_ip):
+        # Defensive: catch a miscataloged entry early.
+        raise RuntimeError(
+            f"Catalog inconsistency for {element_class_base!r} n_ip={n_ip}: "
+            f"got {coords.shape[0]} coords."
+        )
+    return coords, weights

--- a/src/STKO_to_python/utilities/shape_functions.py
+++ b/src/STKO_to_python/utilities/shape_functions.py
@@ -1,0 +1,272 @@
+"""Shape functions and derivatives for fixed-class elements.
+
+Maps natural coordinates (ξ, η, ζ) from
+:mod:`STKO_to_python.utilities.gauss_points` to physical (x, y, z) on
+the actual element via standard FE shape functions, and provides the
+Jacobian determinants needed for physical-volume / physical-area
+integration.
+
+For each supported element class the catalog returns:
+
+* ``N(nat_coords)`` → ``(n_ip, n_nodes)`` shape-function values
+* ``dN_dnat(nat_coords)`` → ``(n_ip, n_nodes, parent_dim)`` derivatives
+  in the parametric directions
+* ``geom_kind`` ∈ ``{"line", "shell", "solid"}`` — determines how the
+  Jacobian determinant is computed:
+
+  - **solid** (parent_dim=3, physical_dim=3): square Jacobian, det.
+  - **shell** (parent_dim=2, physical_dim=3): rectangular Jacobian; the
+    surface measure is ``||∂x/∂ξ × ∂x/∂η||``.
+  - **line** (parent_dim=1, physical_dim=3): single-row Jacobian; the
+    line measure is the norm of ``∂x/∂ξ``.
+
+Node-ordering convention follows OpenSees's standard for each class:
+ASDShellQ4 corners CCW (1:(-1,-1) → 2:(+1,-1) → 3:(+1,+1) → 4:(-1,+1));
+Brick bottom-face CCW then top-face CCW (1..4 at ζ=-1, 5..8 at ζ=+1).
+Override these per-class if a particular model uses a different node
+order.
+"""
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional, Tuple
+
+import numpy as np
+
+
+__all__ = [
+    "SHAPE_FUNCTIONS",
+    "get_shape_functions",
+    "compute_physical_coords",
+    "compute_jacobian_dets",
+]
+
+
+ShapeFn = Callable[[np.ndarray], np.ndarray]
+GeomKind = str  # "line" | "shell" | "solid"
+
+
+# --------------------------------------------------------------------- #
+# ASDShellQ4 — 4-node bilinear quad in 3-D space (shell)                #
+# --------------------------------------------------------------------- #
+#
+# Node ordering (natural):
+#   1: (-1, -1)
+#   2: (+1, -1)
+#   3: (+1, +1)
+#   4: (-1, +1)
+
+
+def _asd_shell_q4_N(nat: np.ndarray) -> np.ndarray:
+    """N_i(ξ, η) for i=1..4 at each row of ``nat`` shape (n_ip, 2)."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    return 0.25 * np.stack(
+        [
+            (1 - xi) * (1 - eta),
+            (1 + xi) * (1 - eta),
+            (1 + xi) * (1 + eta),
+            (1 - xi) * (1 + eta),
+        ],
+        axis=1,
+    )
+
+
+def _asd_shell_q4_dN(nat: np.ndarray) -> np.ndarray:
+    """∂N_i/∂(ξ, η) — shape (n_ip, 4, 2)."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 4, 2), dtype=np.float64)
+    # ∂N/∂ξ
+    out[:, 0, 0] = -0.25 * (1 - eta)
+    out[:, 1, 0] = +0.25 * (1 - eta)
+    out[:, 2, 0] = +0.25 * (1 + eta)
+    out[:, 3, 0] = -0.25 * (1 + eta)
+    # ∂N/∂η
+    out[:, 0, 1] = -0.25 * (1 - xi)
+    out[:, 1, 1] = -0.25 * (1 + xi)
+    out[:, 2, 1] = +0.25 * (1 + xi)
+    out[:, 3, 1] = +0.25 * (1 - xi)
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Brick — 8-node trilinear hex (solid)                                  #
+# --------------------------------------------------------------------- #
+#
+# Node ordering (natural):
+#   1: (-1, -1, -1)        5: (-1, -1, +1)
+#   2: (+1, -1, -1)        6: (+1, -1, +1)
+#   3: (+1, +1, -1)        7: (+1, +1, +1)
+#   4: (-1, +1, -1)        8: (-1, +1, +1)
+
+
+_BRICK_NODE_SIGNS = np.array(
+    [
+        [-1, -1, -1],
+        [+1, -1, -1],
+        [+1, +1, -1],
+        [-1, +1, -1],
+        [-1, -1, +1],
+        [+1, -1, +1],
+        [+1, +1, +1],
+        [-1, +1, +1],
+    ],
+    dtype=np.float64,
+)
+
+
+def _brick_N(nat: np.ndarray) -> np.ndarray:
+    """N_i(ξ, η, ζ) for i=1..8 — shape (n_ip, 8)."""
+    # nat: (n_ip, 3); _BRICK_NODE_SIGNS: (8, 3)
+    # Broadcast: (n_ip, 1, 3) * (1, 8, 3) → (n_ip, 8, 3)
+    factors = 1.0 + _BRICK_NODE_SIGNS[None, :, :] * nat[:, None, :]
+    return 0.125 * np.prod(factors, axis=2)
+
+
+def _brick_dN(nat: np.ndarray) -> np.ndarray:
+    """∂N_i/∂(ξ, η, ζ) — shape (n_ip, 8, 3)."""
+    # ∂N_i/∂x_k = (sign_ik / 8) * ∏_{j != k} (1 + sign_ij * x_j)
+    factors = 1.0 + _BRICK_NODE_SIGNS[None, :, :] * nat[:, None, :]
+    # full_prod: (n_ip, 8) — product over the 3 axes
+    full_prod = np.prod(factors, axis=2)
+    # ∂/∂x_k pulls out factor (1 + sign_ik * x_k); divide it out.
+    # Avoid division by zero when (1 + sign_ik * x_k) == 0 (only at the
+    # opposite face) by recomputing those rows manually.
+    out = np.empty((nat.shape[0], 8, 3), dtype=np.float64)
+    for k in range(3):
+        # Other two axes' factors product
+        other = np.delete(factors, k, axis=2).prod(axis=2)  # (n_ip, 8)
+        out[:, :, k] = 0.125 * _BRICK_NODE_SIGNS[None, :, k] * other
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Linear line element — 2-node (line)                                   #
+# --------------------------------------------------------------------- #
+#
+# Node ordering (natural):
+#   1: (-1)
+#   2: (+1)
+
+
+def _line2_N(nat: np.ndarray) -> np.ndarray:
+    """N_i(ξ) for i=1..2 — shape (n_ip, 2)."""
+    xi = nat[:, 0]
+    return 0.5 * np.stack([1 - xi, 1 + xi], axis=1)
+
+
+def _line2_dN(nat: np.ndarray) -> np.ndarray:
+    """∂N_i/∂ξ — shape (n_ip, 2, 1)."""
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 2, 1), dtype=np.float64)
+    out[:, 0, 0] = -0.5
+    out[:, 1, 0] = +0.5
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Catalog                                                               #
+# --------------------------------------------------------------------- #
+#
+# Keys are the *base* element name carried in MPCO connectivity datasets
+# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
+
+SHAPE_FUNCTIONS: Dict[str, Tuple[ShapeFn, ShapeFn, GeomKind]] = {
+    "203-ASDShellQ4": (_asd_shell_q4_N, _asd_shell_q4_dN, "shell"),
+    "56-Brick":       (_brick_N, _brick_dN, "solid"),
+    # Beam/disp-based-beam line elements use 2-node linear interpolation
+    # for the geometric mapping (the integration scheme is independent;
+    # custom rules carry their own GP_X). Only used here when the user
+    # asks for physical coordinates of beam IPs.
+    "5-ElasticBeam3d":      (_line2_N, _line2_dN, "line"),
+    "64-DispBeamColumn3d":  (_line2_N, _line2_dN, "line"),
+}
+
+
+def get_shape_functions(
+    element_class_base: str,
+) -> Optional[Tuple[ShapeFn, ShapeFn, GeomKind]]:
+    """Look up shape functions for a base element class.
+
+    Returns
+    -------
+    (N, dN_dnat, geom_kind) or None
+        ``None`` if the class is not in the catalog. The caller should
+        leave physical coords / Jacobians unset and surface a clear
+        message rather than guessing.
+    """
+    return SHAPE_FUNCTIONS.get(element_class_base)
+
+
+# --------------------------------------------------------------------- #
+# Vectorized mapping                                                    #
+# --------------------------------------------------------------------- #
+
+
+def compute_physical_coords(
+    natural_coords: np.ndarray,
+    element_node_coords: np.ndarray,
+    N_fn: ShapeFn,
+) -> np.ndarray:
+    """Map natural-coord IP positions to physical (x, y, z).
+
+    Parameters
+    ----------
+    natural_coords : np.ndarray, shape (n_ip, parent_dim)
+        IP positions in the parent domain (output of
+        :mod:`STKO_to_python.utilities.gauss_points`).
+    element_node_coords : np.ndarray, shape (n_elements, n_nodes_per, 3)
+        Physical coordinates of each element's nodes, in node-ordering
+        consistent with the shape function.
+    N_fn : callable
+        Shape-function evaluator returning ``(n_ip, n_nodes_per)``.
+
+    Returns
+    -------
+    np.ndarray, shape (n_elements, n_ip, 3)
+        Physical position of each IP for each element.
+    """
+    N = N_fn(natural_coords)  # (n_ip, n_nodes)
+    # einsum: (i,n) @ (e,n,3) → (e,i,3)
+    return np.einsum("in,enj->eij", N, element_node_coords)
+
+
+def compute_jacobian_dets(
+    natural_coords: np.ndarray,
+    element_node_coords: np.ndarray,
+    dN_fn: ShapeFn,
+    geom_kind: GeomKind,
+) -> np.ndarray:
+    """Jacobian determinants at each IP for each element.
+
+    Returns
+    -------
+    np.ndarray, shape (n_elements, n_ip)
+        - ``"solid"``: ``det(J)`` where ``J`` is the 3x3 ∂x/∂ξ matrix.
+        - ``"shell"``: surface measure ``||∂x/∂ξ × ∂x/∂η||``.
+        - ``"line"``: line measure ``||∂x/∂ξ||``.
+
+    All three are non-negative scalars; multiplying a Gauss-point value
+    by ``weight * |J|`` produces a contribution to the integral over
+    the physical element.
+    """
+    dN = dN_fn(natural_coords)  # (n_ip, n_nodes, parent_dim)
+    # J: ∂x_a/∂ξ_k for a ∈ physical (3), k ∈ parent.
+    # einsum: (i,n,k) @ (e,n,a) → (e,i,k,a)
+    J = np.einsum("ink,ena->eika", dN, element_node_coords)
+    # J shape: (n_elements, n_ip, parent_dim, 3)
+
+    if geom_kind == "solid":
+        # J is (e, i, 3, 3) — square matrix per IP; take det.
+        return np.abs(np.linalg.det(J))
+    if geom_kind == "shell":
+        # J is (e, i, 2, 3); cross product of the two parent rows.
+        cross = np.cross(J[..., 0, :], J[..., 1, :])
+        return np.linalg.norm(cross, axis=-1)
+    if geom_kind == "line":
+        # J is (e, i, 1, 3); norm of the single row.
+        return np.linalg.norm(J[..., 0, :], axis=-1)
+    raise ValueError(
+        f"Unknown geom_kind {geom_kind!r}; expected 'solid', 'shell', or 'line'."
+    )

--- a/tests/integration/test_fixture_snapshots.py
+++ b/tests/integration/test_fixture_snapshots.py
@@ -86,8 +86,9 @@ SNAPSHOTS = [
         "results_name": "section.force",
         "element_type": "203-ASDShellQ4",
         "n_cols": 32,
-        "n_ip": 0,  # shell connectivity carries no GP_X attribute
-        "gp_xi": None,
+        "n_ip": 4,                     # 2x2 Gauss-Legendre, from catalog
+        "gp_xi": None,                 # multi-D — gp_xi is line-element only
+        "gp_natural_shape": (4, 2),    # in-plane (ξ, η)
         "first3": ("Fxx_ip0", "Fyy_ip0", "Fxy_ip0"),
         "last3": ("Mxy_ip3", "Vxz_ip3", "Vyz_ip3"),
     },
@@ -99,8 +100,9 @@ SNAPSHOTS = [
         "results_name": "section.deformation",
         "element_type": "203-ASDShellQ4",
         "n_cols": 32,
-        "n_ip": 0,
+        "n_ip": 4,
         "gp_xi": None,
+        "gp_natural_shape": (4, 2),
         "first3": ("epsXX_ip0", "epsYY_ip0", "epsXY_ip0"),
         "last3": ("kappaXY_ip3", "gammaXZ_ip3", "gammaYZ_ip3"),
     },
@@ -139,8 +141,9 @@ SNAPSHOTS = [
         "results_name": "material.stress",
         "element_type": "56-Brick",
         "n_cols": 48,
-        "n_ip": 0,  # no GP_X on Brick connectivity
-        "gp_xi": None,
+        "n_ip": 8,                     # 2x2x2 Gauss-Legendre, from catalog
+        "gp_xi": None,                 # multi-D — gp_xi is line-element only
+        "gp_natural_shape": (8, 3),    # 3-D (ξ, η, ζ)
         "first3": ("sigma11_ip0", "sigma22_ip0", "sigma33_ip0"),
         "last3": ("sigma12_ip7", "sigma23_ip7", "sigma13_ip7"),
     },
@@ -258,6 +261,17 @@ def test_bucket_snapshot(snap, request, _ds_cache):
             rtol=1e-6,
             atol=1e-7,
             err_msg=f"{snap['id']}: gp_xi snapshot mismatch",
+        )
+
+    expected_nat_shape = snap.get("gp_natural_shape")
+    if expected_nat_shape is not None:
+        assert er.gp_natural is not None, (
+            f"{snap['id']}: expected gp_natural shape {expected_nat_shape}, "
+            f"got None"
+        )
+        assert er.gp_natural.shape == expected_nat_shape, (
+            f"{snap['id']}: gp_natural shape "
+            f"{er.gp_natural.shape} != {expected_nat_shape}"
         )
 
 

--- a/tests/integration/test_gp_xi_and_at_ip.py
+++ b/tests/integration/test_gp_xi_and_at_ip.py
@@ -165,12 +165,13 @@ def test_compressed_fiber_at_ip_returns_all_fibers_for_ip(solid_partition_dir: P
     assert all(c.startswith("sigma11_f") for c in sub.columns)
 
 
-def test_continuum_class_has_no_gp_xi_even_with_ips(solid_partition_dir: Path):
-    """Brick continuum has 8 Gauss IPs but no ``GP_X`` on its
-    connectivity (custom-rule attribute is force/disp-beam-only). The
-    bucket parses fine and shows named columns; ``gp_xi`` is ``None``
-    because we don't synthesize coordinates from a class-level catalog
-    yet (that's the B7 ResponseLayout work).
+def test_continuum_class_uses_catalog_gauss_points(solid_partition_dir: Path):
+    """Brick continuum has 8 Gauss IPs and no ``GP_X`` attribute on its
+    connectivity. The natural coordinates of those IPs are *fixed by
+    the element class* and come from the static catalog at
+    :mod:`STKO_to_python.utilities.gauss_points` (B7a). The 1-D ``gp_xi``
+    stays ``None`` (it's line-element-only); the multi-D ``gp_natural``
+    carries the (8, 3) array of (ξ, η, ζ) Gauss-Legendre points.
     """
     ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
     brick_ids = ds.elements_info["dataframe"].query(
@@ -183,11 +184,23 @@ def test_continuum_class_has_no_gp_xi_even_with_ips(solid_partition_dir: Path):
         model_stage="MODEL_STAGE[1]",
         element_ids=brick_ids,
     )
+    # 1-D ξ stays None (multi-D bucket).
     assert er.gp_xi is None
-    assert er.n_ip == 0
-    # at_ip is gated on gp_xi presence — even though columns have _ip suffixes
-    with pytest.raises(ValueError, match="closed-form"):
-        er.at_ip(0)
+    # 3-D natural coords from catalog.
+    assert er.n_ip == 8
+    assert er.gp_dim == 3
+    assert er.gp_natural is not None
+    assert er.gp_natural.shape == (8, 3)
+    # Standard 2x2x2 Gauss-Legendre points are at ±1/sqrt(3) per axis.
+    assert np.allclose(np.abs(er.gp_natural), 1.0 / np.sqrt(3.0))
+    # Weights are uniform 1.0 on a [-1,1]^3 cube → sum = 8.
+    assert er.gp_weights is not None
+    assert er.gp_weights.shape == (8,)
+    assert er.gp_weights.sum() == pytest.approx(8.0)
+    # at_ip now works for continuum gauss-level buckets too.
+    sub = er.at_ip(0)
+    assert sub.shape[1] == 6  # 6 stress components per Gauss point
+    assert all(c.endswith("_ip0") for c in sub.columns)
 
 
 # ----- pickle round-trip preserves gp_xi --------------------------------- #

--- a/tests/integration/test_physical_coords.py
+++ b/tests/integration/test_physical_coords.py
@@ -1,0 +1,253 @@
+"""End-to-end tests for B7b — ``physical_coords()`` and
+``jacobian_dets()`` on :class:`ElementResults`.
+
+Every assertion targets engineering-meaningful invariants:
+volume / area / length recovery via numerical integration of `1` over
+the physical element. If shape functions or node-coord plumbing
+regress, these break loudly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# Brick (8-IP solid)                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_brick_physical_coords_inside_node_bbox(solid_partition_dir: Path):
+    """Each IP's physical position lies inside the bounding box of its
+    element's nodes (true for any well-formed convex brick)."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    phys = er.physical_coords()
+    assert phys is not None
+    assert phys.shape == (1, 8, 3)
+
+    nc = er.element_node_coords[0]   # (8, 3)
+    lo = nc.min(axis=0)
+    hi = nc.max(axis=0)
+    for ip in phys[0]:
+        assert np.all(ip >= lo - 1e-9)
+        assert np.all(ip <= hi + 1e-9)
+
+
+def test_brick_volume_matches_bbox_for_axis_aligned(solid_partition_dir: Path):
+    """Sum of (weight × |J|) integrates 1 over the parent — for an
+    axis-aligned brick (all 8 nodes at the corners of an axis-aligned
+    box) this equals the bounding-box volume."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    dets = er.jacobian_dets()
+    volume = (er.gp_weights * dets[0]).sum()
+
+    nc = er.element_node_coords[0]
+    bbox_vol = float(
+        (nc[:, 0].max() - nc[:, 0].min())
+        * (nc[:, 1].max() - nc[:, 1].min())
+        * (nc[:, 2].max() - nc[:, 2].min())
+    )
+    # Should match exactly for axis-aligned bricks (which the fixture
+    # uses); allow a small tolerance for the general case.
+    assert volume == pytest.approx(bbox_vol, rel=1e-6)
+
+
+def test_brick_volume_is_positive_per_element(solid_partition_dir: Path):
+    """All bricks in the fixture have positive volume (no degenerate
+    elements)."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    df_idx = ds.elements_info["dataframe"]
+    brick_ids = df_idx.query("element_type == '56-Brick'")["element_id"].head(20).tolist()
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=brick_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    dets = er.jacobian_dets()           # (n_e, 8)
+    vols = (er.gp_weights[None, :] * dets).sum(axis=1)
+    assert np.all(vols > 0)
+
+
+# ---------------------------------------------------------------------- #
+# Shell (4-IP, 2-D in 3-D space)                                           #
+# ---------------------------------------------------------------------- #
+
+
+def test_shell_area_positive_and_consistent(quad_frame_dir: Path):
+    """Per-element shell area is positive and equals diagonal*diagonal/2
+    × 2 = bounding box area for an axis-aligned flat quad. The
+    QuadFrame fixture uses such quads."""
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    df_idx = ds.elements_info["dataframe"]
+    shell_ids = df_idx.query(
+        "element_type == '203-ASDShellQ4'"
+    )["element_id"].head(10).tolist()
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=shell_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    dets = er.jacobian_dets()                          # (n_e, 4)
+    areas = (er.gp_weights[None, :] * dets).sum(axis=1)
+    assert np.all(areas > 0)
+
+
+def test_shell_physical_coords_lie_on_the_shell_plane(quad_frame_dir: Path):
+    """For a flat quad, every IP physical position lies in the plane
+    defined by the four nodes."""
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=[shell_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    phys = er.physical_coords()[0]                    # (4, 3)
+    nc = er.element_node_coords[0]                    # (4, 3)
+    # Plane normal from first three nodes
+    v1 = nc[1] - nc[0]
+    v2 = nc[2] - nc[0]
+    n = np.cross(v1, v2)
+    n /= np.linalg.norm(n)
+    for ip in phys:
+        signed_dist = np.dot(ip - nc[0], n)
+        assert abs(signed_dist) < 1e-6
+
+
+# ---------------------------------------------------------------------- #
+# Beam (5-IP line)                                                         #
+# ---------------------------------------------------------------------- #
+
+
+def test_beam_physical_coords_align_with_axis():
+    """A 5-IP disp-based beam from the displacement-based fixture lies
+    along the global Z axis; physical IP coords should reflect that."""
+    p = (
+        Path(__file__).resolve().parents[2]
+        / "stko_results_examples"
+        / "elasticFrame"
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    if not (p / "results.mpco").exists():
+        pytest.skip("disp-based fixture missing")
+    ds = MPCODataSet(str(p), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    phys = er.physical_coords()[0]                    # (5, 3)
+    nc = er.element_node_coords[0]                    # (2, 3)
+    # Beam length
+    L = float(np.linalg.norm(nc[1] - nc[0]))
+
+    # Each IP physical position equals node0 + (xi+1)/2 * (node1-node0)
+    direction = nc[1] - nc[0]
+    for i, xi in enumerate(er.gp_xi):
+        expected = nc[0] + 0.5 * (1.0 + xi) * direction
+        np.testing.assert_allclose(phys[i], expected, rtol=1e-9)
+
+    dets = er.jacobian_dets()[0]
+    assert np.allclose(dets, L / 2)
+
+
+# ---------------------------------------------------------------------- #
+# Closed-form: physical_coords / jacobian_dets are None                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_closed_form_returns_none(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="force",     # closed-form, GAUSS_IDS=[[-1]]
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    assert er.physical_coords() is None
+    assert er.jacobian_dets() is None
+
+
+def test_unknown_class_returns_none_gracefully(elastic_frame_dir: Path):
+    """Asking physical_coords on an ElasticBeam3d *closed-form* result
+    just returns None (no IPs)."""
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    # Closed-form: no gp_natural, so physical_coords is None.
+    assert er.physical_coords() is None
+
+
+# ---------------------------------------------------------------------- #
+# Pickle round-trip                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_physical_coords_survive_pickle(solid_partition_dir: Path, tmp_path: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    phys_before = er.physical_coords()
+    dets_before = er.jacobian_dets()
+
+    pkl_path = tmp_path / "er.pkl"
+    er.save_pickle(pkl_path)
+    from STKO_to_python.elements.element_results import ElementResults
+
+    er2 = ElementResults.load_pickle(pkl_path)
+    np.testing.assert_array_equal(er2.element_node_coords, er.element_node_coords)
+    np.testing.assert_array_equal(er2.element_node_ids, er.element_node_ids)
+    np.testing.assert_allclose(er2.physical_coords(), phys_before)
+    np.testing.assert_allclose(er2.jacobian_dets(), dets_before)

--- a/tests/unit/test_element_bucket_grouping.py
+++ b/tests/unit/test_element_bucket_grouping.py
@@ -37,7 +37,9 @@ def _chunk(cols):
     return (
         "bucket/" + "_".join(cols[:1]),
         list(cols),
-        None,
+        None,  # gp_xi
+        None,  # gp_natural
+        None,  # gp_weights
         pd.DataFrame(),
     )
 

--- a/tests/unit/test_gauss_points.py
+++ b/tests/unit/test_gauss_points.py
@@ -1,0 +1,193 @@
+"""Unit tests for :mod:`STKO_to_python.utilities.gauss_points`.
+
+Validates the 1-D / 2-D / 3-D Gauss-Legendre primitives and the
+catalog lookups used to fill in ``ElementResults.gp_natural`` for
+fixed-class elements (shells, plane elements, solids).
+
+Ordering convention (per the module docstring): ξ varies fastest, then
+η, then ζ. Tests pin this so a future refactor that flips the
+iteration order breaks loudly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.utilities.gauss_points import (
+    ELEMENT_IP_CATALOG,
+    gauss_legendre_1d,
+    get_ip_layout,
+    tensor_product_2d,
+    tensor_product_3d,
+)
+
+
+# ---------------------------------------------------------------------- #
+# 1-D Gauss-Legendre primitives                                           #
+# ---------------------------------------------------------------------- #
+
+
+def test_gl1d_n2_points_and_weights():
+    pts, wts = gauss_legendre_1d(2)
+    assert np.allclose(pts, [-1.0 / np.sqrt(3.0), 1.0 / np.sqrt(3.0)])
+    assert np.allclose(wts, [1.0, 1.0])
+
+
+def test_gl1d_n3_points_and_weights():
+    pts, wts = gauss_legendre_1d(3)
+    assert np.allclose(pts, [-np.sqrt(3 / 5), 0.0, np.sqrt(3 / 5)])
+    assert np.allclose(wts, [5 / 9, 8 / 9, 5 / 9])
+
+
+def test_gl1d_weights_sum_to_2():
+    """Sum of weights on the parent interval [-1, +1] is 2."""
+    for n in range(1, 6):
+        _, wts = gauss_legendre_1d(n)
+        assert wts.sum() == pytest.approx(2.0), n
+
+
+def test_gl1d_invalid_n_raises():
+    with pytest.raises(ValueError, match="≥ 1"):
+        gauss_legendre_1d(0)
+
+
+def test_gl1d_is_cached():
+    """lru_cache on the public function — same array object returned."""
+    a, _ = gauss_legendre_1d(2)
+    b, _ = gauss_legendre_1d(2)
+    assert a is b
+
+
+# ---------------------------------------------------------------------- #
+# 2-D tensor product                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_tensor_product_2d_n2_shape_and_ordering():
+    coords, weights = tensor_product_2d(2)
+    a = 1.0 / np.sqrt(3.0)
+    expected = np.array(
+        [
+            [-a, -a],
+            [+a, -a],
+            [-a, +a],
+            [+a, +a],
+        ]
+    )
+    assert coords.shape == (4, 2)
+    assert weights.shape == (4,)
+    np.testing.assert_allclose(coords, expected, rtol=1e-12)
+    assert weights.sum() == pytest.approx(4.0)  # area of [-1,1]^2
+
+
+def test_tensor_product_2d_n3_count_and_weights_sum():
+    coords, weights = tensor_product_2d(3)
+    assert coords.shape == (9, 2)
+    assert weights.sum() == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------- #
+# 3-D tensor product                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_tensor_product_3d_n2_shape_and_ordering():
+    coords, weights = tensor_product_3d(2)
+    a = 1.0 / np.sqrt(3.0)
+    expected = np.array(
+        [
+            [-a, -a, -a],
+            [+a, -a, -a],
+            [-a, +a, -a],
+            [+a, +a, -a],
+            [-a, -a, +a],
+            [+a, -a, +a],
+            [-a, +a, +a],
+            [+a, +a, +a],
+        ]
+    )
+    assert coords.shape == (8, 3)
+    assert weights.shape == (8,)
+    np.testing.assert_allclose(coords, expected, rtol=1e-12)
+    assert weights.sum() == pytest.approx(8.0)  # volume of [-1,1]^3
+
+
+def test_tensor_product_3d_n3_count():
+    coords, weights = tensor_product_3d(3)
+    assert coords.shape == (27, 3)
+    assert weights.sum() == pytest.approx(8.0)
+
+
+# ---------------------------------------------------------------------- #
+# Numerical-integration sanity                                             #
+# ---------------------------------------------------------------------- #
+
+
+def test_2d_gauss_legendre_integrates_polynomials_exactly():
+    """Gauss-Legendre n=2 integrates polynomials of degree ≤ 3 exactly."""
+    coords, weights = tensor_product_2d(2)
+    # ∫∫ (xi^2 + eta^2) dxi deta over [-1,1]^2
+    #   = ∫(2 xi^2) dxi + ∫(2 eta^2) deta
+    #   = 2*(2/3) + 2*(2/3) = 8/3
+    f = coords[:, 0] ** 2 + coords[:, 1] ** 2
+    integral = (f * weights).sum()
+    assert integral == pytest.approx(8 / 3)
+
+
+def test_3d_gauss_legendre_integrates_polynomials_exactly():
+    coords, weights = tensor_product_3d(2)
+    # ∫∫∫ (xi*eta*zeta + 1) over [-1,1]^3 = 0 + 8 = 8
+    f = coords[:, 0] * coords[:, 1] * coords[:, 2] + 1.0
+    integral = (f * weights).sum()
+    assert integral == pytest.approx(8.0)
+
+
+# ---------------------------------------------------------------------- #
+# Catalog lookups                                                          #
+# ---------------------------------------------------------------------- #
+
+
+def test_catalog_lookup_asd_shell_q4():
+    layout = get_ip_layout("203-ASDShellQ4", 4)
+    assert layout is not None
+    coords, weights = layout
+    assert coords.shape == (4, 2)
+    assert weights.shape == (4,)
+    assert weights.sum() == pytest.approx(4.0)
+
+
+def test_catalog_lookup_brick_8ip():
+    coords, weights = get_ip_layout("56-Brick", 8)
+    assert coords.shape == (8, 3)
+    assert weights.sum() == pytest.approx(8.0)
+
+
+def test_catalog_lookup_brick_27ip():
+    coords, weights = get_ip_layout("56-Brick", 27)
+    assert coords.shape == (27, 3)
+    assert weights.sum() == pytest.approx(8.0)
+
+
+def test_catalog_unknown_class_returns_none():
+    assert get_ip_layout("99-MysteryElement", 4) is None
+
+
+def test_catalog_unknown_n_ip_returns_none():
+    """Class is in the catalog but the requested IP count isn't."""
+    assert get_ip_layout("56-Brick", 12) is None
+
+
+def test_catalog_consistency_n_ip_matches_coords_length():
+    """Every catalog entry advertises the right n_ip in its key."""
+    for class_name, schemes in ELEMENT_IP_CATALOG.items():
+        for n_ip, (coords, weights) in schemes.items():
+            assert coords.shape[0] == n_ip, (class_name, n_ip)
+            assert weights.shape[0] == n_ip, (class_name, n_ip)
+
+
+def test_catalog_dim_per_class():
+    """Spot-check that 2-D classes return 2-vectors and 3-D return 3-vectors."""
+    coords, _ = get_ip_layout("203-ASDShellQ4", 4)
+    assert coords.shape[1] == 2
+    coords, _ = get_ip_layout("56-Brick", 8)
+    assert coords.shape[1] == 3

--- a/tests/unit/test_shape_functions.py
+++ b/tests/unit/test_shape_functions.py
@@ -1,0 +1,254 @@
+"""Unit tests for :mod:`STKO_to_python.utilities.shape_functions`.
+
+Validates shape-function evaluations and Jacobian determinants on
+simple analytic geometries:
+
+* Unit cube and scaled brick — square Jacobian.
+* Flat shell rectangle — surface Jacobian (area measure).
+* Line element — line Jacobian (length measure).
+
+Plus interpolation sanity (shape functions sum to 1 at every IP and
+exactly recover node coords at parametric corners).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.utilities.gauss_points import (
+    gauss_legendre_1d,
+    tensor_product_2d,
+    tensor_product_3d,
+)
+from STKO_to_python.utilities.shape_functions import (
+    SHAPE_FUNCTIONS,
+    compute_jacobian_dets,
+    compute_physical_coords,
+    get_shape_functions,
+)
+
+
+# ---------------------------------------------------------------------- #
+# Catalog                                                                  #
+# ---------------------------------------------------------------------- #
+
+
+def test_catalog_has_known_classes():
+    assert "203-ASDShellQ4" in SHAPE_FUNCTIONS
+    assert "56-Brick" in SHAPE_FUNCTIONS
+    assert "5-ElasticBeam3d" in SHAPE_FUNCTIONS
+    assert "64-DispBeamColumn3d" in SHAPE_FUNCTIONS
+
+
+def test_get_shape_functions_unknown_returns_none():
+    assert get_shape_functions("99-MysteryElement") is None
+
+
+def test_get_shape_functions_geom_kinds():
+    assert get_shape_functions("56-Brick")[2] == "solid"
+    assert get_shape_functions("203-ASDShellQ4")[2] == "shell"
+    assert get_shape_functions("5-ElasticBeam3d")[2] == "line"
+
+
+# ---------------------------------------------------------------------- #
+# Brick (8-node trilinear hex)                                             #
+# ---------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def unit_brick_nodes():
+    """Cube centered at origin, sides length 2 — node coords match
+    natural coords exactly. Used so that physical_coords should equal
+    the natural coords for any IP."""
+    return np.array(
+        [[
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ]],
+        dtype=np.float64,
+    )
+
+
+def test_brick_shape_functions_partition_of_unity():
+    """Σ N_i = 1 at every IP (consistency test)."""
+    N_fn, _, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nat, _ = tensor_product_3d(2)
+    N = N_fn(nat)
+    assert np.allclose(N.sum(axis=1), 1.0)
+
+
+def test_brick_shape_functions_recover_node_at_corner():
+    """At the parametric corner (-1,-1,-1), only N_1 should be 1."""
+    N_fn, _, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nat = np.array([[-1, -1, -1]], dtype=np.float64)
+    N = N_fn(nat)
+    assert N[0, 0] == pytest.approx(1.0)
+    for j in range(1, 8):
+        assert N[0, j] == pytest.approx(0.0)
+
+
+def test_brick_physical_coords_unit_cube_match_natural(unit_brick_nodes):
+    """Identity mapping: physical coords equal natural coords."""
+    N_fn, _, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nat, _ = tensor_product_3d(2)
+    phys = compute_physical_coords(nat, unit_brick_nodes, N_fn)
+    np.testing.assert_allclose(phys[0], nat)
+
+
+def test_brick_jacobian_unit_cube_is_identity(unit_brick_nodes):
+    _, dN_fn, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nat, _ = tensor_product_3d(2)
+    detJ = compute_jacobian_dets(nat, unit_brick_nodes, dN_fn, "solid")
+    assert np.allclose(detJ[0], 1.0)
+
+
+def test_brick_volume_recovery_unit_cube(unit_brick_nodes):
+    """∫ 1 dV over [-1,1]^3 = 8."""
+    _, dN_fn, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nat, weights = tensor_product_3d(2)
+    detJ = compute_jacobian_dets(nat, unit_brick_nodes, dN_fn, "solid")
+    volume = (1.0 * weights * detJ[0]).sum()
+    assert volume == pytest.approx(8.0)
+
+
+def test_brick_volume_recovery_scaled():
+    """Scaled brick of size 4×6×10 → volume 240."""
+    N_fn, dN_fn, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nodes = np.array(
+        [[
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ]],
+        dtype=np.float64,
+    ) * np.array([2.0, 3.0, 5.0])  # half-widths
+    nat, weights = tensor_product_3d(2)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "solid")
+    volume = (1.0 * weights * detJ[0]).sum()
+    assert volume == pytest.approx(240.0)
+
+
+def test_brick_volume_invariant_under_shear():
+    """Shearing the top face doesn't change the volume."""
+    _, dN_fn, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nodes = np.array(
+        [[
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ]],
+        dtype=np.float64,
+    )
+    nodes[0, 4:, 0] += 1.0  # translate top face +x
+    nat, weights = tensor_product_3d(2)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "solid")
+    volume = (1.0 * weights * detJ[0]).sum()
+    assert volume == pytest.approx(8.0)
+
+
+# ---------------------------------------------------------------------- #
+# ASDShellQ4 (4-node bilinear)                                             #
+# ---------------------------------------------------------------------- #
+
+
+def test_shell_shape_functions_partition_of_unity():
+    N_fn, _, _ = SHAPE_FUNCTIONS["203-ASDShellQ4"]
+    nat, _ = tensor_product_2d(2)
+    N = N_fn(nat)
+    assert np.allclose(N.sum(axis=1), 1.0)
+
+
+def test_shell_area_recovery_xy_rectangle():
+    """4×6 rectangle in the xy plane → area 24."""
+    _, dN_fn, _ = SHAPE_FUNCTIONS["203-ASDShellQ4"]
+    nodes = np.array(
+        [[[-2, -3, 0], [+2, -3, 0], [+2, +3, 0], [-2, +3, 0]]],
+        dtype=np.float64,
+    )
+    nat, weights = tensor_product_2d(2)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "shell")
+    area = (1.0 * weights * detJ[0]).sum()
+    assert area == pytest.approx(24.0)
+
+
+def test_shell_area_independent_of_orientation():
+    """Same 4×6 rectangle rotated to lie in the xz plane should give
+    the same area."""
+    _, dN_fn, _ = SHAPE_FUNCTIONS["203-ASDShellQ4"]
+    nodes = np.array(
+        [[[-2, 0, -3], [+2, 0, -3], [+2, 0, +3], [-2, 0, +3]]],
+        dtype=np.float64,
+    )
+    nat, weights = tensor_product_2d(2)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "shell")
+    area = (1.0 * weights * detJ[0]).sum()
+    assert area == pytest.approx(24.0)
+
+
+# ---------------------------------------------------------------------- #
+# Line element (2-node)                                                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_line_jacobian_equals_half_length():
+    """For a 2-node line of length L, |J| = L/2 at every IP."""
+    _, dN_fn, _ = SHAPE_FUNCTIONS["5-ElasticBeam3d"]
+    L = 7.5
+    nodes = np.array([[[0, 0, 0], [L, 0, 0]]], dtype=np.float64)
+    nat_pts, _ = gauss_legendre_1d(3)
+    nat = nat_pts.reshape(-1, 1)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "line")
+    assert np.allclose(detJ[0], L / 2)
+
+
+def test_line_length_recovery():
+    _, dN_fn, _ = SHAPE_FUNCTIONS["5-ElasticBeam3d"]
+    L = 12.0
+    nodes = np.array([[[0, 0, 0], [L, 0, 0]]], dtype=np.float64)
+    nat_pts, weights = gauss_legendre_1d(3)
+    nat = nat_pts.reshape(-1, 1)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "line")
+    length = (1.0 * weights * detJ[0]).sum()
+    assert length == pytest.approx(L)
+
+
+def test_line_length_for_arbitrary_orientation():
+    """Length is invariant under direction in 3-D space."""
+    _, dN_fn, _ = SHAPE_FUNCTIONS["5-ElasticBeam3d"]
+    end = np.array([3.0, 4.0, 12.0])  # length √(9+16+144) = √169 = 13
+    nodes = np.array([[[0, 0, 0], end]], dtype=np.float64)
+    nat_pts, weights = gauss_legendre_1d(3)
+    nat = nat_pts.reshape(-1, 1)
+    detJ = compute_jacobian_dets(nat, nodes, dN_fn, "line")
+    length = (1.0 * weights * detJ[0]).sum()
+    assert length == pytest.approx(13.0)
+
+
+# ---------------------------------------------------------------------- #
+# Vectorization across multiple elements                                  #
+# ---------------------------------------------------------------------- #
+
+
+def test_compute_physical_coords_vectorizes_over_elements():
+    N_fn, _, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nat, _ = tensor_product_3d(2)
+    # Two unit bricks centered at different points
+    base = np.array(
+        [
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ],
+        dtype=np.float64,
+    )
+    nodes = np.stack([base + 10.0, base - 5.0], axis=0)  # (2, 8, 3)
+    phys = compute_physical_coords(nat, nodes, N_fn)
+    assert phys.shape == (2, 8, 3)
+    # Element 0 IP positions are natural + 10
+    np.testing.assert_allclose(phys[0], nat + 10.0)
+    np.testing.assert_allclose(phys[1], nat - 5.0)
+
+
+def test_compute_jacobian_dets_unknown_geom_kind_raises():
+    _, dN_fn, _ = SHAPE_FUNCTIONS["56-Brick"]
+    nodes = np.zeros((1, 8, 3))
+    nat, _ = tensor_product_3d(2)
+    with pytest.raises(ValueError, match="Unknown geom_kind"):
+        compute_jacobian_dets(nat, nodes, dN_fn, "fishtail")


### PR DESCRIPTION
## Summary

Closes the loop on **""integrate planes and lines""**. Builds on the Gauss-point catalog from #24:

- ``ElementResults.physical_coords()`` — physical (x, y, z) of each integration point in each element, shape ``(n_elements, n_ip, 3)``.
- ``ElementResults.jacobian_dets()`` — Jacobian determinant per IP, shape ``(n_elements, n_ip)``. Volume measure for solids, surface measure for shells, line measure for line elements.

With these plus ``gp_weights`` (from #24), a stress integral over the physical element is one numpy multiply:

```python
sigma_step = er.df.xs(100, level=""step"")[list(er.canonical_columns(""stress_11""))].to_numpy()
volume_int = (sigma_step * er.gp_weights[None, :] * er.jacobian_dets()).sum(axis=1)
```

### What's new

- **``utilities/shape_functions.py``** — bilinear / trilinear / linear shape functions and derivatives for ASDShellQ4 (shell), Brick (solid), ElasticBeam3d / DispBeamColumn3d (line). Vectorized via einsum so multiple elements process in one numpy call.
- ``ElementResults`` stores ``element_node_coords`` (shape ``(n_elements, n_nodes_per, 3)``) and ``element_node_ids``, populated at fetch time from the cached element index, sorted to match ``element_ids``. Survives pickle.
- Both new methods return ``None`` gracefully when the bucket is closed-form, node coords are unavailable, or the element class isn't in the shape-function catalog.

### Diff note (please read before reviewing)

This PR's branch was cut from ``feat/mpco-meta-parser`` (which has the still-unmerged B7a / [#24](https://github.com/nmorabowen/STKO_to_python/pull/24) changes). Until #24 merges into ``main``, the file-changed view here will include B7a's content too. **Recommended order:** merge #24 first, then GitHub auto-recomputes this diff to show only the B7b additions.

If you'd rather review them as one bundle, that also works — the changes are complementary and the test suite runs green on either ordering.

## Test plan

- [x] **27 new tests**:
  - 18 unit tests in ``test_shape_functions.py`` covering partition-of-unity, corner recovery, volume / area / length recovery via integration of ``1`` over scaled / sheared / rotated geometries, and vectorization across elements.
  - 9 integration tests in ``test_physical_coords.py`` against real fixtures: brick volumes match bounding-box volumes for axis-aligned hexes, IP positions lie inside the element bbox (or on the shell plane), beam IP positions match the analytic interpolation, closed-form returns ``None`` cleanly, and the new arrays survive pickle round-trip.
- [x] **521 → 548 passing**, 0 regressions.
- [x] Smoke-tested end-to-end against ``QuadFrame`` (shells), ``solid_partition_example`` (bricks), and the displacement-based 5-IP beam fixture — volumes / areas / lengths recover to machine precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)