### PR TITLE
Integration helper + Tri/Tet extension primitives

### DIFF
--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -277,8 +277,37 @@ integration scheme or the OpenSees ordering happens to differ, override
 the catalog entry in `utilities/gauss_points.py`.
 
 **Unknown classes.** Element classes not in the catalog yield
-`gp_natural=None`. Adding an entry is a one-line change — see the
-catalog docstring for the convention.
+`gp_natural=None`. Adding an entry is a one-line change. The library
+ships with shape-function and Gauss-rule primitives for the most
+common parent domains:
+
+| Primitive | Domain | Use for |
+|---|---|---|
+| `gauss_legendre_1d` / `_line2_N` (internal) | bi-unit interval | beam line elements |
+| `tensor_product_2d` / shell shape functions | bi-unit square | quad shells / plane elements |
+| `tensor_product_3d` / brick shape functions | bi-unit cube | hex solids |
+| `gauss_triangle` / `tri3_N`, `tri3_dN` | unit triangle | triangular shells / plane (e.g. `ASDShellT3`) |
+| `gauss_tetrahedron` / `tet4_N`, `tet4_dN` | unit tetrahedron | linear tets (e.g. `FourNodeTetrahedron`) |
+
+To register a new element class observed in your fixtures:
+
+```python
+from STKO_to_python.utilities.gauss_points import (
+    ELEMENT_IP_CATALOG, gauss_triangle,
+)
+from STKO_to_python.utilities.shape_functions import (
+    SHAPE_FUNCTIONS, tri3_N, tri3_dN,
+)
+
+# Suppose your MPCO file has connectivity dataset
+# "204-ASDShellT3[<rule>:<cust>]" with 3 IPs per element.
+ELEMENT_IP_CATALOG["204-ASDShellT3"] = {3: gauss_triangle(3)}
+SHAPE_FUNCTIONS["204-ASDShellT3"] = (tri3_N, tri3_dN, "shell")
+```
+
+After this, `gp_natural`, `gp_weights`, `physical_coords()`,
+`jacobian_dets()`, and `integrate_canonical()` all work for that
+class without further changes.
 
 ### Physical coordinates and Jacobians
 
@@ -296,19 +325,31 @@ For solids the determinant is `|det(∂x/∂ξ)|` (volume measure); for
 shells it's `||∂x/∂ξ × ∂x/∂η||` (surface measure); for line elements
 it's `||∂x/∂ξ||` (line measure).
 
-**Numerical integration.** Multiply value × weight × `|J|` and sum
-over IPs to get a contribution to the integral over the physical
-element. For a brick `material.stress`:
+**Numerical integration.** The convenience method
+`integrate_canonical(name)` does the multiply-and-sum dance over IPs
+and returns a Series indexed by `(element_id, step)` — same shape as
+the rest of the data:
+
+```python
+# Volume integral of σ_11 over each brick element, per step
+s = er.integrate_canonical("stress_11")
+s.unstack("element_id").head()             # tidy step × element matrix
+
+# Same idiom on a shell — integrates over physical surface
+moments = er_shell.integrate_canonical("bending_moment_xx")
+```
+
+Internally the helper applies `value × gp_weights × |J|` over the
+integration points and asserts the canonical resolves to exactly
+`n_ip` columns. Closed-form buckets, missing node coords, unknown
+element classes, and compressed-fiber buckets raise with a pointer
+to manual integration. For full control:
 
 ```python
 cols = er.canonical_columns("stress_11")
 sigma_step = er.df.xs(100, level="step")[list(cols)].to_numpy()  # (n_e, n_ip)
 volume_int_per_elem = (sigma_step * er.gp_weights[None, :] * dets).sum(axis=1)
 ```
-
-For a shell `section.force`, the same pattern integrates a quantity
-over the physical surface. For a line element, over the physical
-length.
 
 **Inputs.** `physical_coords()` and `jacobian_dets()` rely on
 ``element_node_coords`` (populated automatically from the dataset's

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -411,6 +411,117 @@ class ElementResults:
             self.gp_natural, self.element_node_coords, dN_fn, geom_kind
         )
 
+    def integrate_canonical(self, name: str) -> pd.Series:
+        """Integrate a canonical quantity over the *physical* element
+        for every element and step.
+
+        For each ``(element_id, step)``, computes the quadrature sum::
+
+            ∫ value dΩ ≈ Σ_ip value_at_ip * gp_weights * |J|
+
+        where ``gp_weights`` come from the static Gauss-point catalog
+        and ``|J|`` is the appropriate Jacobian measure (volume for
+        solids, surface for shells, length for line elements).
+
+        Parameters
+        ----------
+        name : str
+            Canonical engineering name, e.g. ``"stress_11"``,
+            ``"membrane_xx"``, ``"axial_force"``. Must resolve to
+            exactly one column per integration point — i.e. the same
+            quantity at every IP. Compressed-fiber buckets (with
+            sub-IP fibers) are rejected; integrate them by selecting
+            specific fiber columns directly via :meth:`canonical_columns`.
+
+        Returns
+        -------
+        pd.Series
+            Indexed by ``(element_id, step)`` — same MultiIndex as
+            ``self.df``. Use ``.unstack("element_id")`` for a
+            step × element matrix.
+
+        Raises
+        ------
+        ValueError
+            If the bucket is closed-form, has no ``gp_weights`` (line
+            elements with custom rules), no Jacobian (no node coords
+            or unknown element class), or the canonical name doesn't
+            match exactly ``n_ip`` columns.
+
+        Examples
+        --------
+        Volume-integrate σ_11 over each brick element, get a
+        Series indexed by (element_id, step):
+
+        >>> s = er.integrate_canonical("stress_11")
+        >>> s.unstack("element_id").head()    # step × element matrix
+
+        Area-integrate Mxx (bending moment per unit length) over
+        each shell element to get total internal moment:
+
+        >>> moments = er_shell.integrate_canonical("bending_moment_xx")
+        """
+        if self.gp_weights is None:
+            raise ValueError(
+                f"integrate_canonical({name!r}): no gp_weights on this "
+                f"result. Either the bucket is closed-form (no IPs) "
+                f"or this is a line element with a custom rule whose "
+                f"weights aren't written to MPCO. Catalog-driven "
+                f"shell / solid / plane elements have weights."
+            )
+        dets = self.jacobian_dets()
+        if dets is None:
+            raise ValueError(
+                f"integrate_canonical({name!r}): jacobian_dets() "
+                f"returned None. Likely missing element_node_coords "
+                f"or no shape function registered for "
+                f"element_type={self.element_type!r}."
+            )
+
+        cols = self.canonical_columns(name)
+        if not cols:
+            raise ValueError(
+                f"integrate_canonical({name!r}): no columns matching "
+                f"this canonical name. Present canonicals: "
+                f"{self.list_canonicals()}"
+            )
+        if len(cols) != self.n_ip:
+            # Compressed-fiber bucket (n_fibers * n_ip) or some other
+            # multi-block layout. Per-fiber integration needs section /
+            # fiber metadata we don't carry yet — refuse loudly.
+            raise ValueError(
+                f"integrate_canonical({name!r}): canonical resolves to "
+                f"{len(cols)} columns but the bucket has {self.n_ip} "
+                f"integration points. Likely a fiber bucket — pick the "
+                f"specific columns via canonical_columns() / df[...] "
+                f"and integrate manually."
+            )
+
+        # cols are in IP order (the META parser emits them sorted by
+        # gauss_id for line/gauss-level buckets). values shape: rows
+        # of ``self.df`` × n_ip.
+        values = self.df[list(cols)].to_numpy(dtype=np.float64)
+
+        # Build a per-row (gp_weights * |J|) array. dets is aligned to
+        # ``self.element_ids`` (sorted ascending); look up each row's
+        # element to get the right Jacobian.
+        eids_in_df = (
+            self.df.index.get_level_values("element_id").to_numpy(np.int64)
+        )
+        elem_id_to_row = {int(eid): i for i, eid in enumerate(self.element_ids)}
+        try:
+            row_idx = np.array(
+                [elem_id_to_row[int(e)] for e in eids_in_df], dtype=np.int64
+            )
+        except KeyError as err:
+            raise ValueError(
+                f"integrate_canonical({name!r}): df contains element_id "
+                f"{err.args[0]} not in self.element_ids. Index out of sync."
+            )
+        row_weights = self.gp_weights[None, :] * dets[row_idx]
+        integrals = (values * row_weights).sum(axis=1)
+        return pd.Series(integrals, index=self.df.index, name=f"integral_{name}")
+
     def physical_x(self, length: float) -> np.ndarray:
         """Convert ``self.gp_xi`` (natural ξ ∈ [-1, +1]) to physical
         positions along an element of the given ``length``.

--- a/src/STKO_to_python/utilities/gauss_points.py
+++ b/src/STKO_to_python/utilities/gauss_points.py
@@ -38,6 +38,8 @@ __all__ = [
     "gauss_legendre_1d",
     "tensor_product_2d",
     "tensor_product_3d",
+    "gauss_triangle",
+    "gauss_tetrahedron",
     "ELEMENT_IP_CATALOG",
     "get_ip_layout",
 ]
@@ -119,6 +121,111 @@ def tensor_product_3d(n: int) -> Tuple[np.ndarray, np.ndarray]:
     wxi, weta, wzeta = np.meshgrid(wts, wts, wts, indexing="ij")
     weights = (wxi * weta * wzeta).transpose(2, 1, 0).ravel()
     return coords.astype(np.float64), weights.astype(np.float64)
+
+
+# --------------------------------------------------------------------- #
+# Triangle / tetrahedron quadrature                                     #
+# --------------------------------------------------------------------- #
+#
+# Triangles and tets use barycentric-style natural coords on the
+# **unit** triangle / tetrahedron (vertices at the origin and on the
+# axes). This is a different parent domain than tensor-product
+# rules — the parent measure is 1/2 (triangle) or 1/6 (tet), not 4 / 8
+# — and the corresponding shape functions in
+# :mod:`STKO_to_python.utilities.shape_functions` use the same domain.
+
+# Standard 1-, 3-, 7-point rules on the unit triangle.
+_TRI_RULES: Dict[int, Tuple[np.ndarray, np.ndarray]] = {
+    1: (
+        np.array([[1.0 / 3.0, 1.0 / 3.0]]),
+        np.array([0.5]),
+    ),
+    3: (
+        np.array(
+            [
+                [1.0 / 6.0, 1.0 / 6.0],
+                [2.0 / 3.0, 1.0 / 6.0],
+                [1.0 / 6.0, 2.0 / 3.0],
+            ]
+        ),
+        np.array([1.0 / 6.0] * 3),
+    ),
+}
+
+# Standard 1- and 4-point rules on the unit tetrahedron.
+_TET_A = (5.0 + 3.0 * np.sqrt(5.0)) / 20.0
+_TET_B = (5.0 - np.sqrt(5.0)) / 20.0
+_TET_RULES: Dict[int, Tuple[np.ndarray, np.ndarray]] = {
+    1: (
+        np.array([[0.25, 0.25, 0.25]]),
+        np.array([1.0 / 6.0]),
+    ),
+    4: (
+        np.array(
+            [
+                [_TET_A, _TET_B, _TET_B],
+                [_TET_B, _TET_A, _TET_B],
+                [_TET_B, _TET_B, _TET_A],
+                [_TET_B, _TET_B, _TET_B],
+            ]
+        ),
+        np.array([1.0 / 24.0] * 4),
+    ),
+}
+
+
+def gauss_triangle(n_ip: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Standard Gauss rule on the unit reference triangle.
+
+    Parent domain: vertices at (0,0), (1,0), (0,1); area 1/2.
+    Sum of weights equals the parent area.
+
+    Parameters
+    ----------
+    n_ip : int
+        ``1`` (degree-1, centroid) or ``3`` (degree-2, edge midpoints
+        of the medial triangle). Other rules can be added if needed.
+
+    Returns
+    -------
+    (coords, weights) : (ndarray (n_ip, 2), ndarray (n_ip,))
+
+    Raises
+    ------
+    ValueError if ``n_ip`` is not in the supported set.
+    """
+    if n_ip not in _TRI_RULES:
+        raise ValueError(
+            f"Unsupported n_ip={n_ip!r} for triangle rule. "
+            f"Available: {sorted(_TRI_RULES)}"
+        )
+    coords, weights = _TRI_RULES[n_ip]
+    return coords.copy(), weights.copy()
+
+
+def gauss_tetrahedron(n_ip: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Standard Gauss rule on the unit reference tetrahedron.
+
+    Parent domain: vertices at the origin and the three unit axis
+    points; volume 1/6. Sum of weights equals the parent volume.
+
+    Parameters
+    ----------
+    n_ip : int
+        ``1`` (degree-1, centroid) or ``4`` (degree-2). Other rules
+        (e.g. 5-point degree-3) can be added if needed.
+
+    Returns
+    -------
+    (coords, weights) : (ndarray (n_ip, 3), ndarray (n_ip,))
+    """
+    if n_ip not in _TET_RULES:
+        raise ValueError(
+            f"Unsupported n_ip={n_ip!r} for tetrahedron rule. "
+            f"Available: {sorted(_TET_RULES)}"
+        )
+    coords, weights = _TET_RULES[n_ip]
+    return coords.copy(), weights.copy()
 
 
 # --------------------------------------------------------------------- #

--- a/src/STKO_to_python/utilities/shape_functions.py
+++ b/src/STKO_to_python/utilities/shape_functions.py
@@ -38,6 +38,14 @@ __all__ = [
     "get_shape_functions",
     "compute_physical_coords",
     "compute_jacobian_dets",
+    # Reusable shape-function primitives — exported so users can
+    # register them under their own element-class keys when those
+    # surface in fixtures (e.g. ``SHAPE_FUNCTIONS["204-ASDShellT3"] =
+    # (tri3_N, tri3_dN, "shell")``).
+    "tri3_N",
+    "tri3_dN",
+    "tet4_N",
+    "tet4_dN",
 ]
 
 
@@ -162,6 +170,77 @@ def _line2_dN(nat: np.ndarray) -> np.ndarray:
     out = np.empty((n_ip, 2, 1), dtype=np.float64)
     out[:, 0, 0] = -0.5
     out[:, 1, 0] = +0.5
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Tri3 — 3-node linear triangle (shell or plane)                        #
+# --------------------------------------------------------------------- #
+#
+# Parent domain: unit triangle with vertices at (0,0), (1,0), (0,1).
+# Pair with ``gauss_triangle()`` from :mod:`gauss_points`.
+#
+# Node ordering (natural):
+#   1: (0, 0)
+#   2: (1, 0)
+#   3: (0, 1)
+
+
+def tri3_N(nat: np.ndarray) -> np.ndarray:
+    """Linear-triangle shape functions — shape ``(n_ip, 3)``."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    return np.stack([1.0 - xi - eta, xi, eta], axis=1)
+
+
+def tri3_dN(nat: np.ndarray) -> np.ndarray:
+    """Linear-triangle derivatives — shape ``(n_ip, 3, 2)``.
+
+    Derivatives are constant on the parent triangle; the per-IP
+    repetition just makes the array shape consistent with the rest of
+    the catalog.
+    """
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 3, 2), dtype=np.float64)
+    out[:, 0, 0] = -1.0; out[:, 0, 1] = -1.0  # ∂N1/∂(ξ, η)
+    out[:, 1, 0] = +1.0; out[:, 1, 1] = +0.0  # ∂N2/∂(ξ, η)
+    out[:, 2, 0] = +0.0; out[:, 2, 1] = +1.0  # ∂N3/∂(ξ, η)
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Tet4 — 4-node linear tetrahedron (solid)                              #
+# --------------------------------------------------------------------- #
+#
+# Parent domain: unit tetrahedron with vertices at the origin and the
+# three unit-axis points. Pair with ``gauss_tetrahedron()`` from
+# :mod:`gauss_points`.
+#
+# Node ordering (natural):
+#   1: (0, 0, 0)
+#   2: (1, 0, 0)
+#   3: (0, 1, 0)
+#   4: (0, 0, 1)
+
+
+def tet4_N(nat: np.ndarray) -> np.ndarray:
+    """Linear-tet shape functions — shape ``(n_ip, 4)``."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    zeta = nat[:, 2]
+    return np.stack(
+        [1.0 - xi - eta - zeta, xi, eta, zeta], axis=1
+    )
+
+
+def tet4_dN(nat: np.ndarray) -> np.ndarray:
+    """Linear-tet derivatives — shape ``(n_ip, 4, 3)`` (constant)."""
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 4, 3), dtype=np.float64)
+    out[:, 0, :] = [-1.0, -1.0, -1.0]
+    out[:, 1, :] = [+1.0,  0.0,  0.0]
+    out[:, 2, :] = [ 0.0, +1.0,  0.0]
+    out[:, 3, :] = [ 0.0,  0.0, +1.0]
     return out
 
 

--- a/tests/integration/test_integrate_canonical.py
+++ b/tests/integration/test_integrate_canonical.py
@@ -1,0 +1,214 @@
+"""End-to-end tests for ``ElementResults.integrate_canonical()``.
+
+The helper applies the standard quadrature pattern
+``Σ value * weight * |J|`` across all elements and steps in one call.
+These tests exercise it on the real fixtures the library already
+covers (Brick, ASDShellQ4) and verify it matches a manual numpy
+computation, plus error behavior on closed-form / fiber / unknown-
+canonical inputs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# Brick (8-IP solid) — volume integral                                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_brick_integrate_stress_11_matches_manual(solid_partition_dir: Path):
+    """Helper output equals the manual ``Σ σ * w * |J|`` over IPs."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_ids = (
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .head(3)
+        .tolist()
+    )
+    brick_ids = [int(i) for i in brick_ids]
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=brick_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+
+    s = er.integrate_canonical("stress_11")
+    # Index aligns with self.df.
+    assert isinstance(s, pd.Series)
+    assert list(s.index.names) == ["element_id", "step"]
+    assert s.shape == (len(brick_ids) * er.n_steps,)
+    assert s.name == "integral_stress_11"
+
+    # Manual verification: pick a single (element_id, step) and recompute.
+    cols = list(er.canonical_columns("stress_11"))
+    dets = er.jacobian_dets()
+    eid_to_row = {int(e): i for i, e in enumerate(er.element_ids)}
+
+    eid = brick_ids[0]
+    step = 1
+    sigma = er.df.xs((eid, step))[cols].to_numpy(dtype=np.float64)
+    manual = float((sigma * er.gp_weights * dets[eid_to_row[eid]]).sum())
+    helper = float(s.loc[eid, step])
+    assert manual == pytest.approx(helper, rel=1e-12, abs=1e-12)
+
+
+def test_brick_integrate_unstack_to_step_x_element_matrix(solid_partition_dir: Path):
+    """``.unstack("element_id")`` gives a tidy step × element matrix."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_ids = [
+        int(i)
+        for i in ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .head(2)
+    ]
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=brick_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    s = er.integrate_canonical("stress_11")
+    mtx = s.unstack("element_id")
+    assert mtx.shape == (er.n_steps, len(brick_ids))
+    assert sorted(mtx.columns.tolist()) == sorted(brick_ids)
+
+
+# ---------------------------------------------------------------------- #
+# Shell (4-IP) — surface integral                                         #
+# ---------------------------------------------------------------------- #
+
+
+def test_shell_integrate_membrane_xx(quad_frame_dir: Path):
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_ids = [
+        int(i)
+        for i in ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .head(3)
+    ]
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=shell_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    s = er.integrate_canonical("membrane_xx")
+    assert s.shape == (len(shell_ids) * er.n_steps,)
+    # Result is finite (no NaN from missing JC or weights)
+    assert np.isfinite(s.to_numpy()).all()
+
+
+# ---------------------------------------------------------------------- #
+# Error paths                                                             #
+# ---------------------------------------------------------------------- #
+
+
+def test_closed_form_integrate_raises(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="no gp_weights"):
+        er.integrate_canonical("axial_force")
+
+
+def test_unknown_canonical_raises(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="Unknown canonical name"):
+        er.integrate_canonical("nonexistent_quantity")
+
+
+def test_canonical_present_but_no_match_raises(solid_partition_dir: Path):
+    """Asking for ``membrane_xx`` (shell) on a Brick result — the
+    canonical exists in the global map but no columns in this result
+    match. integrate_canonical inherits from canonical_columns which
+    returns empty tuple; the helper raises with a clear message."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="no columns matching"):
+        er.integrate_canonical("membrane_xx")
+
+
+def test_fiber_bucket_raises_clearly(solid_partition_dir: Path):
+    """``section.fiber.stress`` has cols of the form ``sigma11_f<j>_ip<i>``
+    with multiplicity > 1 — len(cols) != n_ip. Helper raises with a
+    pointer to manual integration."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    beam_ids = [
+        int(i)
+        for i in ds.elements_info["dataframe"]
+        .query("element_type == '64-DispBeamColumn3d'")["element_id"]
+        .head(2)
+    ]
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        element_ids=beam_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    # gp_weights is None for line elements, so the gp_weights branch
+    # raises first. Either error path is acceptable here — both are
+    # informative; this just locks in the contract.
+    with pytest.raises(ValueError):
+        er.integrate_canonical("stress_11")
+
+
+# ---------------------------------------------------------------------- #
+# Pickle round-trip                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_integrate_after_pickle_roundtrip(solid_partition_dir: Path, tmp_path: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=[brick_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    s_before = er.integrate_canonical("stress_11")
+
+    pkl = tmp_path / "er.pkl"
+    er.save_pickle(pkl)
+    from STKO_to_python.elements.element_results import ElementResults
+
+    er2 = ElementResults.load_pickle(pkl)
+    s_after = er2.integrate_canonical("stress_11")
+    pd.testing.assert_series_equal(s_before, s_after, check_names=True)

--- a/tests/unit/test_tri_tet_primitives.py
+++ b/tests/unit/test_tri_tet_primitives.py
@@ -1,0 +1,202 @@
+"""Unit tests for the tri/tet shape-function and Gauss-point primitives.
+
+These primitives are exported as building blocks; users register them
+under their own element-class keys when those classes appear in
+fixtures (e.g. ``SHAPE_FUNCTIONS["204-ASDShellT3"] = (tri3_N, tri3_dN,
+"shell")``). The tests verify the math is correct on the canonical
+parent domains (unit triangle and unit tetrahedron); end-to-end
+integration tests will follow once a real fixture lands.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.utilities.gauss_points import (
+    gauss_tetrahedron,
+    gauss_triangle,
+)
+from STKO_to_python.utilities.shape_functions import (
+    compute_jacobian_dets,
+    compute_physical_coords,
+    tet4_N,
+    tet4_dN,
+    tri3_N,
+    tri3_dN,
+)
+
+
+# ---------------------------------------------------------------------- #
+# gauss_triangle                                                          #
+# ---------------------------------------------------------------------- #
+
+
+def test_gauss_triangle_1pt_centroid():
+    coords, weights = gauss_triangle(1)
+    assert coords.shape == (1, 2)
+    np.testing.assert_allclose(coords, [[1 / 3, 1 / 3]])
+    np.testing.assert_allclose(weights, [0.5])
+
+
+def test_gauss_triangle_3pt_weights_sum_to_half():
+    coords, weights = gauss_triangle(3)
+    assert coords.shape == (3, 2)
+    assert weights.sum() == pytest.approx(0.5)
+
+
+def test_gauss_triangle_unsupported_n_raises():
+    with pytest.raises(ValueError, match="Unsupported"):
+        gauss_triangle(7)
+
+
+# ---------------------------------------------------------------------- #
+# gauss_tetrahedron                                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_gauss_tetrahedron_1pt_centroid():
+    coords, weights = gauss_tetrahedron(1)
+    np.testing.assert_allclose(coords, [[0.25, 0.25, 0.25]])
+    np.testing.assert_allclose(weights, [1.0 / 6.0])
+
+
+def test_gauss_tetrahedron_4pt_weights_sum_to_sixth():
+    coords, weights = gauss_tetrahedron(4)
+    assert coords.shape == (4, 3)
+    assert weights.sum() == pytest.approx(1.0 / 6.0)
+
+
+# ---------------------------------------------------------------------- #
+# tri3 shape functions                                                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_tri3_partition_of_unity():
+    coords, _ = gauss_triangle(3)
+    N = tri3_N(coords)
+    assert np.allclose(N.sum(axis=1), 1.0)
+
+
+def test_tri3_recovers_node_at_corner():
+    """At node 1 (0, 0): N_1=1, others=0."""
+    nat = np.array([[0.0, 0.0]])
+    N = tri3_N(nat)
+    np.testing.assert_allclose(N[0], [1.0, 0.0, 0.0])
+
+    # Node 2 (1, 0)
+    np.testing.assert_allclose(tri3_N(np.array([[1.0, 0.0]]))[0], [0.0, 1.0, 0.0])
+    # Node 3 (0, 1)
+    np.testing.assert_allclose(tri3_N(np.array([[0.0, 1.0]]))[0], [0.0, 0.0, 1.0])
+
+
+def test_tri3_area_recovery_unit_triangle_in_xy():
+    """Map a triangle with vertices at (0,0,0), (1,0,0), (0,1,0) — area
+    1/2. Integrate 1 → 1/2."""
+    nodes = np.array([[[0, 0, 0], [1, 0, 0], [0, 1, 0]]], dtype=np.float64)
+    coords, weights = gauss_triangle(3)
+    detJ = compute_jacobian_dets(coords, nodes, tri3_dN, "shell")
+    area = (1.0 * weights * detJ[0]).sum()
+    assert area == pytest.approx(0.5)
+
+
+def test_tri3_area_scaled_triangle():
+    """Vertices (0,0,0), (3,0,0), (0,4,0) → area = 6."""
+    nodes = np.array([[[0, 0, 0], [3, 0, 0], [0, 4, 0]]], dtype=np.float64)
+    coords, weights = gauss_triangle(3)
+    detJ = compute_jacobian_dets(coords, nodes, tri3_dN, "shell")
+    area = (1.0 * weights * detJ[0]).sum()
+    assert area == pytest.approx(6.0)
+
+
+def test_tri3_area_invariant_under_rotation():
+    """Same triangle rotated into the xz plane gives the same area."""
+    nodes = np.array([[[0, 0, 0], [3, 0, 0], [0, 0, 4]]], dtype=np.float64)
+    coords, weights = gauss_triangle(3)
+    detJ = compute_jacobian_dets(coords, nodes, tri3_dN, "shell")
+    area = (1.0 * weights * detJ[0]).sum()
+    assert area == pytest.approx(6.0)
+
+
+# ---------------------------------------------------------------------- #
+# tet4 shape functions                                                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_tet4_partition_of_unity():
+    coords, _ = gauss_tetrahedron(4)
+    N = tet4_N(coords)
+    assert np.allclose(N.sum(axis=1), 1.0)
+
+
+def test_tet4_recovers_nodes_at_corners():
+    np.testing.assert_allclose(
+        tet4_N(np.array([[0.0, 0.0, 0.0]]))[0], [1.0, 0.0, 0.0, 0.0]
+    )
+    np.testing.assert_allclose(
+        tet4_N(np.array([[1.0, 0.0, 0.0]]))[0], [0.0, 1.0, 0.0, 0.0]
+    )
+    np.testing.assert_allclose(
+        tet4_N(np.array([[0.0, 1.0, 0.0]]))[0], [0.0, 0.0, 1.0, 0.0]
+    )
+    np.testing.assert_allclose(
+        tet4_N(np.array([[0.0, 0.0, 1.0]]))[0], [0.0, 0.0, 0.0, 1.0]
+    )
+
+
+def test_tet4_volume_unit_tet():
+    """Reference unit tet: volume = 1/6."""
+    nodes = np.array(
+        [[[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]]], dtype=np.float64
+    )
+    coords, weights = gauss_tetrahedron(4)
+    detJ = compute_jacobian_dets(coords, nodes, tet4_dN, "solid")
+    volume = (1.0 * weights * detJ[0]).sum()
+    assert volume == pytest.approx(1.0 / 6.0)
+
+
+def test_tet4_volume_scaled_tet():
+    """Tet with edges 3, 4, 5 along axes: volume = (3*4*5)/6 = 10."""
+    nodes = np.array(
+        [[[0, 0, 0], [3, 0, 0], [0, 4, 0], [0, 0, 5]]], dtype=np.float64
+    )
+    coords, weights = gauss_tetrahedron(4)
+    detJ = compute_jacobian_dets(coords, nodes, tet4_dN, "solid")
+    volume = (1.0 * weights * detJ[0]).sum()
+    assert volume == pytest.approx(10.0)
+
+
+def test_tet4_volume_works_with_1pt_rule():
+    """1-pt centroid rule integrates degree-1 exactly — including 1."""
+    nodes = np.array(
+        [[[0, 0, 0], [3, 0, 0], [0, 4, 0], [0, 0, 5]]], dtype=np.float64
+    )
+    coords, weights = gauss_tetrahedron(1)
+    detJ = compute_jacobian_dets(coords, nodes, tet4_dN, "solid")
+    volume = (1.0 * weights * detJ[0]).sum()
+    assert volume == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------- #
+# Registration pattern                                                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_user_registration_pattern_works():
+    """Document the API contract: user adds a class to the catalog by
+    assigning to the SHAPE_FUNCTIONS dict."""
+    from STKO_to_python.utilities.shape_functions import (
+        SHAPE_FUNCTIONS,
+        get_shape_functions,
+    )
+
+    key = "999-MyTestShellT3"
+    SHAPE_FUNCTIONS[key] = (tri3_N, tri3_dN, "shell")
+    try:
+        fns = get_shape_functions(key)
+        assert fns is not None
+        N_fn, dN_fn, kind = fns
+        assert N_fn is tri3_N
+        assert dN_fn is tri3_dN
+        assert kind == "shell"
+    finally:
+        del SHAPE_FUNCTIONS[key]


### PR DESCRIPTION
## Summary

Two complementary additions:

### 1. ``ElementResults.integrate_canonical(name)``

Wraps the standard ``Σ value × gp_weights × |J|`` quadrature pattern into one call. Returns a ``Series`` indexed by ``(element_id, step)`` so the result drops into the same MultiIndex as the rest of the data and you can ``.unstack(""element_id"")`` for a tidy step × element matrix.

```python
# Volume-integrate σ_11 over each brick element, per step
s = er.integrate_canonical(""stress_11"")
s.unstack(""element_id"").head()        # step × element matrix

# Same idiom on a shell — surface integral
moments = er_shell.integrate_canonical(""bending_moment_xx"")
```

Refuses cleanly (with a pointed error message) for: closed-form buckets (no IPs / no weights), line elements with custom rules (weights not in MPCO), compressed-fiber buckets (n_columns ≠ n_ip), missing node coords, unknown element classes, and unknown canonical names.

### 2. Tri / Tet extension primitives

Reusable building blocks for users who hit element classes not in the default catalog:

- ``gauss_triangle(n_ip)`` and ``gauss_tetrahedron(n_ip)`` for the unit-triangle / unit-tet parent domains (parent measures 1/2 and 1/6).
- ``tri3_N`` / ``tri3_dN`` — linear triangle shape functions and constant derivatives.
- ``tet4_N`` / ``tet4_dN`` — linear tet equivalents.

These are exported as standalone helpers. Users register them under their own element-class keys when those classes appear:

```python
from STKO_to_python.utilities.gauss_points import (
    ELEMENT_IP_CATALOG, gauss_triangle,
)
from STKO_to_python.utilities.shape_functions import (
    SHAPE_FUNCTIONS, tri3_N, tri3_dN,
)

ELEMENT_IP_CATALOG[""204-ASDShellT3""] = {3: gauss_triangle(3)}
SHAPE_FUNCTIONS[""204-ASDShellT3""] = (tri3_N, tri3_dN, ""shell"")
```

After registering, ``gp_natural``, ``gp_weights``, ``physical_coords()``, ``jacobian_dets()``, and ``integrate_canonical()`` all work for that class — no library modification needed.

### Diff note

This PR builds on B7a and B7b (PRs #24 / #25). Until those merge into main, the file-changed view here will include their content too. Once they merge, GitHub will recompute and show only the additions in this PR. Recommended merge order: **#26 → #24 → #25 → #27**.

## Test plan

- [x] **24 new tests** (548 → 572 passing):
  - 16 unit tests covering tri/tet shape-function math on canonical parent domains: partition of unity, corner recovery, area / volume recovery via integration of 1, rotation invariance.
  - 8 integration tests for ``integrate_canonical()``: Brick volume integral verified against manual numpy, Shell surface integral, ``unstack`` to step×element matrix, error paths, pickle round-trip.
- [x] All previous tests still pass — 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)