### PR TITLE
Add elements guide to site nav and landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,9 @@ ds.plot.xy(
 
 ## Where to read next
 
+- **[Elements workflow guide](elements_guide.md)** — end-to-end
+  walkthrough of element results: discovery, selection sets,
+  integration-point access, canonical names, plotting, and pickling.
 - **[Architecture](architecture.md)** — the layered design, what lives
   where, pickle compatibility, and the per-phase refactor history.
 - **[API reference](api/index.md)** — class-by-class docs generated

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,3 +92,4 @@ nav:
       - MPCODataSet: MPCODataSet.md
       - NodalResults: NodalResults.md
       - ElementResults: ElementResults.md
+      - Elements workflow: elements_guide.md


### PR DESCRIPTION
## Summary

- `mkdocs.yml`: adds `elements_guide.md` under **Usage guides** in the site nav
- `docs/index.md`: adds a link to the elements workflow guide in the "Where to read next" section

Once merged, the GitHub Pages workflow will rebuild and the guide will appear in the site navigation.

## Test plan

- [ ] Confirm the page appears under Usage guides in the rendered site
- [ ] Confirm the link on the home page resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)