### PR TITLE
Fill documentation gaps: AggregationEngine, MPCOResults, canonical names

### DIFF
--- a/docs/api/aggregation-engine.md
+++ b/docs/api/aggregation-engine.md
@@ -1,14 +1,521 @@
 # AggregationEngine
 
-Stateless engineering-aggregation engine. Holds every drift /
-envelope / rocking / torsion / orbit method that `NodalResults`
-exposes. `NodalResults._aggregation_engine` is a class-level
-singleton — one instance shared across every `NodalResults` in the
-process, pickle-safe (not persisted in state).
-
-Every method takes the `NodalResults` as its first positional
-argument. Callers usually invoke the forwarders on `NodalResults`
-instead (e.g. `nr.drift(...)` rather than
+Stateless engineering-aggregation engine. Holds every drift / envelope /
+rocking / torsion / orbit calculation that `NodalResults` exposes as a
+forwarder. One shared instance lives at
+`NodalResults._aggregation_engine`; callers normally invoke the thin
+wrappers on `NodalResults` instead (e.g. `nr.drift(...)` rather than
 `engine.drift(nr, ...)`).
+
+The engine holds **no dataset state** and is pickle-safe (not persisted
+with `NodalResults`).
+
+---
+
+## Node selection convention
+
+Several methods accept exactly **one** of these four node-selection inputs:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `node_ids` | `list[int]` | Explicit node IDs |
+| `selection_set_id` | `int \| list[int]` | ID from `.cdata` |
+| `selection_set_name` | `str \| list[str]` | Name from `.cdata` |
+| `coordinates` | `list[list[float]]` | (x,y) or (x,y,z) resolved to nearest nodes |
+
+Providing more than one raises `ValueError`.
+
+---
+
+## Pair-wise utilities
+
+### `delta_u`
+
+```python
+nr.delta_u(
+    top,           # node ID (int) or coordinates (x,y) / (x,y,z)
+    bottom,        # node ID (int) or coordinates
+    component,     # result component (int or str)
+    result_name="DISPLACEMENT",
+    stage=None,    # required for multi-stage results
+    signed=True,
+    reduce="series",  # "series" → pd.Series | "abs_max" → float
+)
+```
+
+Relative displacement `u_top(t) - u_bottom(t)`. Returns a `pd.Series`
+(one value per step) when `reduce="series"`, or a single `float` when
+`reduce="abs_max"`.
+
+```python
+du = nr.delta_u(top=42, bottom=10, component=1)
+peak = nr.delta_u(top=42, bottom=10, component=1, reduce="abs_max")
+```
+
+---
+
+### `drift`
+
+```python
+nr.drift(
+    top,
+    bottom,
+    component,
+    result_name="DISPLACEMENT",
+    stage=None,
+    signed=True,
+    reduce="series",  # "series" → pd.Series | "abs_max" → float
+)
+```
+
+Interstory drift ratio between two nodes:
+
+```
+drift(t) = (u_top(t) - u_bottom(t)) / (z_top - z_bottom)
+```
+
+Raises `ValueError` if `z_top == z_bottom`.
+
+```python
+dr = nr.drift(top=42, bottom=10, component=1)
+peak = nr.drift(top=42, bottom=10, component=1, reduce="abs_max")
+
+# Coordinates instead of node IDs
+dr = nr.drift(top=(10.0, 0.0, 6.0), bottom=(10.0, 0.0, 3.0), component=1)
+```
+
+---
+
+### `residual_drift`
+
+```python
+nr.residual_drift(
+    top,
+    bottom,
+    component,
+    result_name="DISPLACEMENT",
+    stage=None,
+    signed=True,
+    tail=1,       # number of end-of-record steps to average
+    agg="mean",   # "mean" or "median" over the tail window
+)
+```
+
+Returns a single `float` — the drift ratio averaged over the last `tail`
+steps. Increasing `tail` reduces end-of-record noise.
+
+```python
+rd = nr.residual_drift(top=42, bottom=10, component=1, tail=5, agg="mean")
+```
+
+---
+
+## Story-profile methods
+
+All story-profile methods use **z-tolerance clustering**: nodes are
+sorted by z-coordinate and grouped into stories when their z-values are
+within `dz_tol` of each other. Provide exactly one of
+`selection_set_id`, `selection_set_name`, `node_ids`, or `coordinates`.
+
+---
+
+### `interstory_drift_envelope`
+
+```python
+nr.interstory_drift_envelope(
+    component,
+    selection_set_id=None,
+    selection_set_name=None,
+    node_ids=None,
+    coordinates=None,
+    result_name="DISPLACEMENT",
+    stage=None,
+    dz_tol=1e-3,
+    representative="min_id",  # "min_id" | "max_abs_peak"
+)
+```
+
+Returns a `pd.DataFrame` indexed by `(z_lower, z_upper)`:
+
+| Column | Description |
+|---|---|
+| `z_lower`, `z_upper` | Story elevation bounds (also in index) |
+| `lower_node`, `upper_node` | Representative node IDs |
+| `dz` | Story height |
+| `max_drift` | Maximum (signed) drift over all steps |
+| `min_drift` | Minimum (signed) drift |
+| `max_abs_drift` | Peak absolute drift |
+
+`representative` controls which node is selected per story:
+- `"min_id"` — smallest node ID (deterministic)
+- `"max_abs_peak"` — node with the largest absolute peak response
+
+```python
+env = nr.interstory_drift_envelope(
+    component=1,
+    selection_set_name="ControlPoints",
+    dz_tol=1e-3,
+)
+print(env["max_abs_drift"].max())
+```
+
+---
+
+### `interstory_drift_envelope_pd`
+
+```python
+nr.interstory_drift_envelope_pd(
+    component,
+    selection_set_name=None,
+    selection_set_id=None,
+    node_ids=None,
+    coordinates=None,
+    result_name="DISPLACEMENT",
+    stage=None,
+    dz_tol=1e-3,
+    representative="max_abs",  # "max_abs" | "max" | "min"
+)
+```
+
+Flat variant of `interstory_drift_envelope` — returns a regular
+`pd.DataFrame` (no MultiIndex) sorted by `z_lower`, suitable for
+statistics or histograms. Adds a `representative_drift` column chosen
+by the `representative` parameter:
+
+| `representative` | `representative_drift` value |
+|---|---|
+| `"max_abs"` | `max_abs_drift` |
+| `"max"` | `max_drift` |
+| `"min"` | `min_drift` |
+
+```python
+df = nr.interstory_drift_envelope_pd(
+    component=1,
+    selection_set_name="ControlPoints",
+    representative="max_abs",
+)
+df.plot.barh(x="z_upper", y="representative_drift")
+```
+
+---
+
+### `residual_interstory_drift_profile`
+
+```python
+nr.residual_interstory_drift_profile(
+    component,
+    selection_set_id=None,
+    selection_set_name=None,
+    node_ids=None,
+    coordinates=None,
+    result_name="DISPLACEMENT",
+    stage=None,
+    dz_tol=1e-3,
+    representative="min_id",
+    signed=True,
+    tail=1,
+    agg="mean",
+)
+```
+
+Residual interstory drift per story. Returns a `pd.DataFrame` indexed by
+`(z_lower, z_upper)` with columns `lower_node`, `upper_node`, `dz`,
+`residual_drift`.
+
+```python
+prof = nr.residual_interstory_drift_profile(
+    component=1,
+    selection_set_name="ControlPoints",
+    tail=5,
+)
+```
+
+---
+
+### `residual_drift_envelope`
+
+```python
+nr.residual_drift_envelope(
+    component,
+    selection_set_id=None,
+    selection_set_name=None,
+    node_ids=None,
+    coordinates=None,
+    result_name="DISPLACEMENT",
+    stage=None,
+    dz_tol=1e-3,
+    representative="min_id",
+    tail=1,
+    agg="mean",
+)
+```
+
+Summary metrics over the residual interstory drift profile. Returns a
+`dict`:
+
+```python
+{
+    "max_abs_residual_story_drift": float,
+    "max_pos_residual_story_drift": float,
+    "max_neg_residual_story_drift": float,
+}
+```
+
+```python
+res = nr.residual_drift_envelope(
+    component=1,
+    selection_set_name="ControlPoints",
+    tail=5,
+)
+print(f"Max residual drift: {res['max_abs_residual_story_drift']:.4f}")
+```
+
+---
+
+### `story_pga_envelope`
+
+```python
+nr.story_pga_envelope(
+    component,
+    selection_set_id=None,
+    selection_set_name=None,
+    node_ids=None,
+    coordinates=None,
+    result_name="ACCELERATION",
+    stage=None,
+    dz_tol=1e-3,
+    to_g=False,           # divide by g_value to convert to g
+    g_value=9810,         # mm/s² (set to 9.81 for m/s²)
+    reduce_nodes="max_abs",  # "max_abs" | "max" | "min"
+)
+```
+
+Peak floor acceleration (PFA) profile. Returns a `pd.DataFrame` indexed
+by `story_z`:
+
+| Column | Description |
+|---|---|
+| `n_nodes` | Nodes requested at this story |
+| `n_nodes_present` | Nodes found in the results |
+| `max_acc` | Max acceleration (signed) |
+| `min_acc` | Min acceleration (signed) |
+| `pga` | Peak absolute acceleration |
+| `ctrl_node_max/min/pga` | Controlling node IDs |
+
+```python
+pga = nr.story_pga_envelope(
+    component=1,
+    selection_set_name="ControlPoints",
+    result_name="ACCELERATION",
+    to_g=True,
+    g_value=9810,
+)
+print(pga[["pga"]])
+```
+
+---
+
+## Torsion and rocking
+
+### `roof_torsion`
+
+```python
+nr.roof_torsion(
+    node_a_id=None,         # or node_a_coord=(x, y)
+    node_b_id=None,         # or node_b_coord=(x, y)
+    node_a_coord=None,
+    node_b_coord=None,
+    result_name="DISPLACEMENT",
+    ux_component=1,
+    uy_component=2,
+    stage=None,
+    signed=True,
+    reduce="series",          # "series" | "abs_max" | "max" | "min"
+    return_residual=False,
+    return_quality=False,
+)
+```
+
+Estimates roof rotation about the vertical axis (z) using the
+small-rotation formula from two plan-view nodes A and B:
+
+```
+θ(t) = ([du, dv] · [-dy, dx]) / (dx² + dy²)
+```
+
+Provide exactly one of `node_a_id` or `node_a_coord` (same for B).
+
+Returns a `pd.Series` (time history of θ in radians) or a `float` when
+`reduce != "series"`. When `return_quality=True`, also returns a debug
+`pd.DataFrame` with columns `du, dv, du_rot, dv_rot, ru, rv, rel_norm,
+res_norm, rigidity_ratio`.
+
+```python
+theta = nr.roof_torsion(
+    node_a_id=100,
+    node_b_id=200,
+    reduce="abs_max",
+)
+print(f"Peak roof rotation: {theta:.6f} rad")
+
+# Full time history + quality check
+theta_ts, debug = nr.roof_torsion(
+    node_a_coord=(0.0, 0.0),
+    node_b_coord=(20.0, 0.0),
+    return_quality=True,
+)
+print(debug[["rigidity_ratio"]].describe())
+```
+
+---
+
+### `base_rocking`
+
+```python
+nr.base_rocking(
+    node_coords_xy,    # list of exactly 3 (x, y) points
+    z_coord,           # base elevation; nodes resolved at (x, y, z_coord)
+    result_name="DISPLACEMENT",
+    uz_component=3,
+    stage=None,
+    reduce="series",   # "series" → DataFrame | "abs_max" → dict
+    det_tol=1e-12,     # singularity tolerance for the geometry matrix
+)
+```
+
+Estimates foundation rocking from vertical displacements Uz at 3 base
+nodes using small-rotation kinematics:
+
+```
+w(x,y) = w₀ + θx·y - θy·x
+```
+
+When `reduce="series"` returns a `pd.DataFrame` indexed by step with
+columns `w0, theta_x_rad, theta_y_rad, theta_mag_rad, is_singular`.
+When `reduce="abs_max"` returns a `dict` with
+`theta_x_abs_max, theta_y_abs_max, theta_mag_abs_max`.
+
+If the 3 points are collinear or duplicate (singular geometry matrix),
+the method falls back gracefully: angles are zero and `is_singular=True`.
+
+```python
+rocking = nr.base_rocking(
+    node_coords_xy=[(0, 0), (10, 0), (5, 8)],
+    z_coord=0.0,
+    reduce="abs_max",
+)
+print(f"Max rocking: {rocking['theta_mag_abs_max']:.6f} rad")
+```
+
+---
+
+### `asce_torsional_irregularity`
+
+```python
+nr.asce_torsional_irregularity(
+    component,
+    side_a_top,      # (x, y, z) of top of side-A story
+    side_a_bottom,   # (x, y, z) of bottom of side-A story
+    side_b_top,      # (x, y, z) of top of side-B story
+    side_b_bottom,   # (x, y, z) of bottom of side-B story
+    result_name="DISPLACEMENT",
+    stage=None,
+    reduce_time="abs_max",     # "abs_max" | "max" | "min"
+    definition="max_over_avg", # "max_over_avg" | "max_over_min"
+    eps=1e-16,
+    signed=True,
+    tail=None,   # drop last N steps before reducing (None = keep all)
+)
+```
+
+ASCE 7 torsional irregularity ratio comparing edge drifts at a story.
+All four corner points are `(x, y, z)` tuples resolved to the nearest
+nodes.
+
+Returns a `dict`:
+
+```python
+{
+    "drift_A": float,       # reduced drift magnitude at side A
+    "drift_B": float,       # reduced drift magnitude at side B
+    "drift_avg": float,     # 0.5 * (drift_A + drift_B)
+    "drift_max": float,     # max(drift_A, drift_B)
+    "ratio": float,         # torsional irregularity ratio
+    "ctrl_side": "A" | "B",
+    "node_ids": {
+        "A_top": int, "A_bottom": int,
+        "B_top": int, "B_bottom": int,
+    },
+    "metadata": { ... },
+}
+```
+
+`definition` controls the denominator:
+- `"max_over_avg"` — ASCE 7 §12.3.2.1: ratio > 1.2 → Type 1a, > 1.4 → Type 1b
+- `"max_over_min"` — alternative for stricter checks
+
+```python
+result = nr.asce_torsional_irregularity(
+    component=1,
+    side_a_top=(0.0, 0.0, 6.0),
+    side_a_bottom=(0.0, 0.0, 3.0),
+    side_b_top=(20.0, 0.0, 6.0),
+    side_b_bottom=(20.0, 0.0, 3.0),
+)
+print(f"Torsional irregularity ratio: {result['ratio']:.3f}")
+if result["ratio"] > 1.2:
+    print("Type 1a torsional irregularity (ASCE 7 §12.3.2.1)")
+```
+
+---
+
+## Orbit
+
+### `orbit`
+
+```python
+nr.orbit(
+    result_name="DISPLACEMENT",
+    x_component=1,
+    y_component=2,
+    node_ids=None,           # exactly one of these four
+    selection_set_id=None,
+    selection_set_name=None,
+    coordinates=None,
+    stage=None,
+    reduce_nodes="none",     # "none" | "mean" | "median" | "max_abs"
+    signed=True,
+    return_nodes=False,
+)
+```
+
+Builds an x-y displacement orbit `(sx, sy)` from two components of the
+same result. Returns `(pd.Series, pd.Series)`, or
+`(pd.Series, pd.Series, list[int])` when `return_nodes=True`.
+
+`reduce_nodes` collapses multiple selected nodes into a single pair per
+step:
+- `"none"` — no reduction; returned Series have MultiIndex `(node_id, step)`
+- `"mean"` / `"median"` — average/median over nodes at each step
+- `"max_abs"` — per-component node with the largest absolute value at each step
+
+```python
+sx, sy = nr.orbit(
+    x_component=1,
+    y_component=2,
+    selection_set_name="RoofCenter",
+    reduce_nodes="mean",
+)
+
+import matplotlib.pyplot as plt
+plt.plot(sx, sy)
+plt.xlabel("Ux"); plt.ylabel("Uy")
+plt.axis("equal")
+plt.show()
+```
+
+---
+
+## API reference
 
 ::: STKO_to_python.dataprocess.aggregation.AggregationEngine

--- a/docs/api/canonical-names.md
+++ b/docs/api/canonical-names.md
@@ -1,0 +1,175 @@
+# Canonical element result names
+
+The on-disk MPCO shortnames for the same engineering quantity vary by
+element family: `P` for axial force in a line-station beam bucket, `N`
+in a closed-form `localForce` bucket, `sigma11` in a continuum stress
+bucket. The canonical-name layer provides a stable vocabulary that works
+across all families.
+
+Source: [`STKO_to_python/elements/canonical.py`](../../src/STKO_to_python/elements/canonical.py)
+
+---
+
+## The canonical map
+
+| Canonical name | MPCO shortnames | Description |
+|---|---|---|
+| `axial_force` | `P`, `N` | Beam axial / normal force |
+| `bending_moment_z` | `Mz` | Bending moment about local z |
+| `bending_moment_y` | `My` | Bending moment about local y |
+| `torsion` | `T` | Torsional moment |
+| `shear_y` | `Vy` | Shear force in local y |
+| `shear_z` | `Vz` | Shear force in local z |
+| `axial_strain` | `eps` | Beam section axial strain |
+| `curvature_z` | `kappaZ` | Beam section curvature about z |
+| `curvature_y` | `kappaY` | Beam section curvature about y |
+| `twist` | `theta` | Beam section twist |
+| `membrane_xx` | `Fxx` | Shell membrane force Fxx |
+| `membrane_yy` | `Fyy` | Shell membrane force Fyy |
+| `membrane_xy` | `Fxy` | Shell membrane force Fxy |
+| `bending_moment_xx` | `Mxx` | Shell bending moment Mxx |
+| `bending_moment_yy` | `Myy` | Shell bending moment Myy |
+| `bending_moment_xy` | `Mxy` | Shell bending moment Mxy |
+| `transverse_shear_xz` | `Vxz` | Shell transverse shear Vxz |
+| `transverse_shear_yz` | `Vyz` | Shell transverse shear Vyz |
+| `membrane_strain_xx` | `epsXX` | Shell membrane strain |
+| `membrane_strain_yy` | `epsYY` | Shell membrane strain |
+| `membrane_strain_xy` | `epsXY` | Shell membrane strain |
+| `curvature_xx` | `kappaXX` | Shell curvature |
+| `curvature_yy` | `kappaYY` | Shell curvature |
+| `curvature_xy` | `kappaXY` | Shell curvature |
+| `transverse_shear_strain_xz` | `gammaXZ` | Shell transverse shear strain |
+| `transverse_shear_strain_yz` | `gammaYZ` | Shell transverse shear strain |
+| `stress_11` | `sigma11` | Continuum normal stress σ₁₁ |
+| `stress_22` | `sigma22` | Continuum normal stress σ₂₂ |
+| `stress_33` | `sigma33` | Continuum normal stress σ₃₃ |
+| `stress_12` | `sigma12` | Continuum shear stress σ₁₂ |
+| `stress_23` | `sigma23` | Continuum shear stress σ₂₃ |
+| `stress_13` | `sigma13` | Continuum shear stress σ₁₃ |
+| `strain_11` | `eps11` | Continuum normal strain ε₁₁ |
+| `strain_22` | `eps22` | Continuum normal strain ε₂₂ |
+| `strain_33` | `eps33` | Continuum normal strain ε₃₃ |
+| `strain_12` | `eps12` | Continuum shear strain ε₁₂ |
+| `strain_23` | `eps23` | Continuum shear strain ε₂₃ |
+| `strain_13` | `eps13` | Continuum shear strain ε₁₃ |
+| `damage_pos` | `d+` | Tensile damage variable |
+| `damage_neg` | `d-` | Compressive damage variable |
+| `plastic_strain_pos` | `PLE+` | Tensile plastic strain |
+| `plastic_strain_neg` | `PLE-` | Compressive plastic strain |
+| `crack_width` | `cw` | Crack width |
+| `force_x_global` | `Px` | Closed-form global X force |
+| `force_y_global` | `Py` | Closed-form global Y force |
+| `force_z_global` | `Pz` | Closed-form global Z force |
+| `moment_x_global` | `Mx` | Closed-form global X moment |
+
+!!! note "My / Mz collision"
+    `My` and `Mz` appear in both `globalForce` (global axes) and
+    `localForce` (element-local axes). These are **not** registered as
+    canonical names to avoid ambiguity. Fetch the correct bucket
+    (`globalForces` vs `localForce`) and access columns directly by
+    shortname.
+
+---
+
+## Column-name suffix conventions
+
+Column names produced by the META parser end in one of three suffix
+patterns; `shortname_of()` strips them to recover the MPCO shortname:
+
+| Suffix | Pattern | Example |
+|---|---|---|
+| Closed-form (per node) | `_<int>` | `Px_1`, `N_2` |
+| Line-station / Gauss-level | `_ip<int>` | `P_ip0`, `sigma11_ip7` |
+| Compressed fiber | `_f<int>_ip<int>` | `sigma11_f3_ip0` |
+
+---
+
+## Public functions
+
+### `available_canonicals`
+
+```python
+from STKO_to_python.elements.canonical import available_canonicals
+
+names = available_canonicals()
+# ('axial_force', 'axial_strain', 'bending_moment_xx', ...)
+```
+
+Returns a sorted tuple of all registered canonical names.
+
+---
+
+### `shortname_of`
+
+```python
+from STKO_to_python.elements.canonical import shortname_of
+
+shortname_of("Px_1")          # "Px"
+shortname_of("P_ip3")         # "P"
+shortname_of("sigma11_f5_ip0") # "sigma11"
+shortname_of("Mz_2")          # "Mz"
+```
+
+Strips the suffix from a flat column name and returns the MPCO shortname.
+Works on all three suffix patterns.
+
+---
+
+### `match_canonical_columns`
+
+```python
+from STKO_to_python.elements.canonical import match_canonical_columns
+
+# Line-station beam: columns are P_ip0..P_ip4, Mz_ip0..Mz_ip4, ...
+cols = ["P_ip0", "Mz_ip0", "My_ip0", "T_ip0", "P_ip1", "Mz_ip1"]
+match_canonical_columns("axial_force", cols)
+# ["P_ip0", "P_ip1"]
+
+match_canonical_columns("bending_moment_z", cols)
+# ["Mz_ip0", "Mz_ip1"]
+```
+
+Returns the subset of `columns` whose MPCO shortname matches the
+registered shortnames for the given canonical name. Raises `ValueError`
+if the canonical name is unknown.
+
+---
+
+### `list_canonical_for_columns`
+
+```python
+from STKO_to_python.elements.canonical import list_canonical_for_columns
+
+cols = ["P_ip0", "Mz_ip0", "My_ip0", "T_ip0"]
+list_canonical_for_columns(cols)
+# ('axial_force', 'bending_moment_y', 'bending_moment_z', 'torsion')
+```
+
+Returns the canonical names whose shortnames are present in the given
+column list. Used by `ElementResults.list_canonicals()`.
+
+---
+
+## Via `ElementResults`
+
+These functions are also exposed as methods on `ElementResults`:
+
+```python
+er.list_canonicals()
+# ('axial_force', 'bending_moment_z', ...)
+
+er.canonical_columns("axial_force")
+# ('P_ip0', 'P_ip1', 'P_ip2', 'P_ip3', 'P_ip4')
+
+er.canonical("bending_moment_z")
+# pd.DataFrame with columns Mz_ip0 ... Mz_ip4
+```
+
+See [ElementResults.md](../ElementResults.md#canonical-engineering-friendly-names)
+for the full workflow.
+
+---
+
+## API reference
+
+::: STKO_to_python.elements.canonical

--- a/docs/api/mpco-dataset.md
+++ b/docs/api/mpco-dataset.md
@@ -1,7 +1,130 @@
 # MPCODataSet
 
-Top-level entry point. Construct one per recorder output; the
-dataset wires together the partition pool, readers, resolvers,
-managers, and query engines.
+Top-level entry point. Construct one per recorder output; the dataset
+wires together the partition pool, readers, resolvers, managers, and
+query engines.
+
+```python
+from STKO_to_python import MPCODataSet
+
+ds = MPCODataSet(
+    r"C:\path\to\results",  # directory containing .mpco / .cdata files
+    "results",              # recorder base name (without extension)
+    name="RC_Building",     # optional label
+    verbose=False,
+)
+```
+
+---
+
+## Key attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `ds.model_stages` | `list[str]` | Model stage names, e.g. `['MODEL_STAGE[1]']` |
+| `ds.node_results_names` | `list[str]` | Available nodal result names |
+| `ds.element_results_names` | `list[str]` | Available element result names |
+| `ds.unique_element_types` | `list[str]` | Decorated element type names |
+| `ds.element_types` | `dict` | Full breakdown: `{element_types_dict, unique_element_types}` |
+| `ds.nodes_info` | `dict` | Node index `{array, dataframe}` |
+| `ds.elements_info` | `dict` | Element index `{array, dataframe}` |
+| `ds.selection_set` | `dict` | Named selection sets from `.cdata` |
+| `ds.number_of_steps` | `int` | Total recorded steps |
+| `ds.time` | `pd.DataFrame` | Time array per stage |
+| `ds.nodes` | `NodeManager` | Nodal result manager |
+| `ds.elements` | `ElementManager` | Element result manager |
+| `ds.plot` | plot facade | Dataset-level XY plotter |
+
+---
+
+## Logging / print helpers
+
+All `print_*` methods emit at `logging.INFO` level on the module logger.
+Enable with `verbose=True` on construction, or configure logging
+beforehand:
+
+```python
+import logging
+logging.basicConfig(level=logging.INFO)
+```
+
+### `print_summary`
+
+Emits a full overview: partitions, stages, nodal results, element
+results, element types, node/element counts, selection sets.
+
+```python
+ds.print_summary()
+```
+
+### `print_model_stages`
+
+```python
+ds.print_model_stages()
+# INFO  Number of model stages: 1
+# INFO    - MODEL_STAGE[1]
+```
+
+### `print_nodal_results`
+
+```python
+ds.print_nodal_results()
+# INFO  Number of nodal results: 3
+# INFO    - ACCELERATION
+# INFO    - DISPLACEMENT
+# INFO    - REACTION
+```
+
+### `print_element_results`
+
+```python
+ds.print_element_results()
+# INFO  Number of element results: 2
+# INFO    - force
+# INFO    - section.force
+```
+
+### `print_element_types`
+
+Emits each result name and the decorated element types that carry it:
+
+```python
+ds.print_element_types()
+# INFO  Number of unique element types: 1
+# INFO    - force
+# INFO      - 5-ElasticBeam3d[1000:1]
+```
+
+### `print_unique_element_types`
+
+```python
+ds.print_unique_element_types()
+# INFO  Number of unique element types: 1
+# INFO    - 5-ElasticBeam3d[1000:1]
+```
+
+### `print_selection_set_info`
+
+```python
+ds.print_selection_set_info()
+# INFO  Selection set: 1
+# INFO  Selection Set name: roof_diaphragm
+```
+
+---
+
+## Context manager
+
+`MPCODataSet` supports the context-manager protocol to ensure the
+partition pool is released:
+
+```python
+with MPCODataSet(r"C:\results", "Recorder") as ds:
+    nr = ds.nodes.get_nodal_results(...)
+```
+
+---
+
+## API reference
 
 ::: STKO_to_python.core.dataset.MPCODataSet

--- a/docs/api/mpco-results.md
+++ b/docs/api/mpco-results.md
@@ -1,21 +1,355 @@
 # MPCOResults
 
-Multi-case container for a tree of `NodalResults` (typically keyed by
-Tier / Case / station / rupture). Offers a family of MPCO-specific
-DataFrame extractors (drift, PGA, torsion, base rocking, with
-``_long`` / ``_mod`` variants) reachable through the
-**`.df` accessor** introduced in Phase 4.5.
+Multi-case orchestration wrapper for a collection of `NodalResults`
+objects keyed by `(model, station, rupture)`. Designed for ensembles of
+ground-motion analyses — e.g., 11 records per model, multiple structural
+configurations.
 
-`mpco_results.df` and `mpco_results.create_df` reference the same
-`MPCO_df` instance; `.df` is the preferred spelling.
+---
 
-## MPCOResults
+## Construction
+
+### From a dict
+
+```python
+from STKO_to_python.MPCOList.MPCOResults import MPCOResults
+
+results = MPCOResults(
+    {
+        ("Model1A", "CHY101", "GM01"): nr_1,
+        ("Model1A", "TCU052", "GM02"): nr_2,
+        ("Model2B", "CHY101", "GM01"): nr_3,
+    },
+    name="RC_Building_Suite",
+)
+```
+
+Each key is a 3-tuple `(model, station, rupture)` and each value is a
+`NodalResults` instance (or a lazy proxy — see `load_dir`).
+
+### From a directory of pickles — `load_dir`
+
+```python
+results = MPCOResults.load_dir(
+    out_dir=Path("./outputs"),
+    lazy=True,   # defer pickle loading until first access (default)
+    name="Suite",
+)
+```
+
+Scans `out_dir` for `.pkl` and `.pkl.gz` files whose names match the
+pattern `<model>__<station>__<rupture>.pkl[.gz]`. Lazy mode wraps each
+file in a proxy that loads on first attribute access — useful for large
+suites.
+
+---
+
+## Collection protocol
+
+`MPCOResults` behaves like a read-only mapping:
+
+```python
+len(results)          # number of cases
+list(results)         # list of (model, station, rupture) keys
+results.keys()        # key iterable
+results.values()      # NodalResults iterable
+results.items()       # (key, NodalResults) iterable
+results[("Model1A", "CHY101", "GM01")]  # direct lookup
+```
+
+---
+
+## Filtering — `select`
+
+```python
+pairs = results.select(
+    model="Model1A",           # exact match (case-insensitive)
+    station="*CHY*",           # glob: contains "CHY"
+    rupture=None,              # None / "all" → match everything
+)
+# Returns list of ((model, station, rupture), NodalResults) tuples
+```
+
+Filter patterns follow shell-glob rules:
+- `"*val*"` — contains
+- `"*val"` — ends with
+- `"val*"` — starts with
+- `"exact"` — exact match (case-insensitive)
+- `None` / `"all"` — match everything
+
+Multiple values can be passed as a list (OR logic):
+
+```python
+pairs = results.select(station=["CHY101", "TCU052"])
+```
+
+---
+
+## `.df` accessor (MPCO_df)
+
+`results.df` gives access to the DataFrame-extractor family. The legacy
+alias `results.create_df` points to the same object.
+
+### `drift_df` — wide drift table
+
+```python
+df = results.df.drift_df(
+    top=(10.0, 0.0, 6.0),       # (x, y, z) of the top point
+    bottom=(10.0, 0.0, 3.0),    # (x, y, z) of the bottom point
+    components=(1, 2),           # list of displacement components
+    result_name="DISPLACEMENT",
+    relative_drift=True,         # True → drift ratio, False → delta_u
+    reduce_time="abs_max",       # "abs_max" | "max" | "min" | "rms"
+    stage=None,
+    combine="srss",              # "srss" | "maxabs" | "none"
+    op="raw",                    # "raw" | "log"
+    model=None,
+    station=None,
+    rupture=None,
+)
+```
+
+Returns a **wide** `pd.DataFrame` with columns
+`Tier | Case | sta | rup | EDP` — one row per `(model, station, rupture)`
+case. `combine` controls how multi-component drifts are merged:
+- `"srss"` — SRSS of the components' peak values
+- `"maxabs"` — max of the absolute component peaks
+- `"none"` — single component (requires `len(components) == 1`)
+
+### `drift_df_long` — long/tidy drift table
+
+```python
+df_long = results.df.drift_df_long(
+    top=..., bottom=...,
+    components=(1, 2),
+    reduce_time="abs_max",
+    combine="srss",
+    # ... same kwargs as drift_df
+)
+```
+
+Converts the wide table to a tidy long format with columns
+`Tier | Case | sta | rup | runkey | component | result_name |
+reduce_time | relative_drift | op | edp` — ready for seaborn / plotnine
+strip plots and statistical summaries.
+
+### `pga_df` — wide PGA table
+
+```python
+df = results.df.pga_df(
+    component=1,
+    selection_set_name="ControlPoints",
+    result_name="ACCELERATION",
+    dz_tol=1e-3,
+    to_g=True,
+    g_value=9810,
+    reduce_nodes="max_abs",
+    model=None, station=None, rupture=None,
+)
+```
+
+Returns a wide table with one column per story elevation and one row per
+case. Also available as `pga_df_long`, `pga_df_mod`, `pga_df_long_mod`.
+
+### `torsion_df` — wide roof torsion table
+
+```python
+df = results.df.torsion_df(
+    node_a_coord=(0.0, 0.0),
+    node_b_coord=(20.0, 0.0),
+    ux_component=1,
+    uy_component=2,
+    reduce="abs_max",
+    model=None, station=None, rupture=None,
+)
+```
+
+Also available as `torsion_df_long`.
+
+### `base_rocking_df` — wide base rocking table
+
+```python
+df = results.df.base_rocking_df(
+    node_coords_xy=[(0, 0), (10, 0), (5, 8)],
+    z_coord=0.0,
+    uz_component=3,
+    reduce="abs_max",
+    model=None, station=None, rupture=None,
+)
+```
+
+Returns a wide table with columns `theta_x_abs_max, theta_y_abs_max,
+theta_mag_abs_max` per case. Also available as `base_rocking_df_long`.
+
+### `wide_to_long` — general wide→long conversion
+
+```python
+df_long = results.df.wide_to_long(
+    df_wide,
+    id_cols=("Tier", "Case", "sta", "rup"),
+    value_col="EDP",
+    runkey_col="runkey",
+    runkey_from=("sta", "rup"),
+    runkey_sep=":",
+    result_name=None,
+    component=None,
+    reduce_time=None,
+    relative_drift=None,
+    op="raw",
+)
+```
+
+General-purpose WIDE → LONG normalizer. Adds metadata columns
+(`result_name`, `component`, `reduce_time`, `relative_drift`, `op`) and
+a `runkey` composite column from the specified source columns.
+
+---
+
+## Plotting
+
+### `plot_drift`
+
+```python
+results.plot_drift(
+    top=(10.0, 0.0, 6.0),     # (x, y, z) of the top point
+    bottom=(10.0, 0.0, 3.0),  # (x, y, z) of the bottom point
+    component=1,
+    relative_drift=True,       # True → drift ratio, False → delta_u
+    model=None, station=None, rupture=None,
+    overlay=True,              # True → one figure; False → one per case
+    figsize=(10, 6),
+    running_envelope=None,     # None | "abs" | "signed"
+    envelope_alpha=0.35,
+    envelope_only=False,
+    xlim=None, ylim=None,
+    legend_fontsize=7,
+)
+```
+
+Plots drift time histories for all (filtered) cases. When `overlay=True`
+all records appear on a single axes. `running_envelope="abs"` overlays a
+running-maximum envelope band.
+
+### `plot_drift_envelope`
+
+```python
+results.plot_drift_envelope(
+    component=1,
+    selection_set_name="ControlPoints",
+    dz_tol=1e-3,
+    model=None, station=None, rupture=None,
+    overlay=True,
+    figsize=(6, 10),
+    xlim=None, ylim=None,
+)
+```
+
+Plots the interstory drift envelope profile (drift vs. story height) as
+a step plot for each case.
+
+---
+
+## Static helpers
+
+### `parse_tier_letter`
+
+```python
+tier, letter = MPCOResults.parse_tier_letter("2B_tall")
+# tier=2, letter="B"
+```
+
+Extracts the tier number (int) and letter (str) from a model label
+string using a regex `(\d+)([A-Z])`.
+
+### `compute_table`
+
+```python
+df = results.compute_table(
+    fn,           # Callable[[NodalResults], float | dict]
+    model=None, station=None, rupture=None,
+)
+```
+
+Applies an arbitrary function to every selected `NodalResults` and
+assembles the results into a wide table. `fn` may return a `float` (one
+column `value`) or a `dict` (one column per key).
+
+```python
+df = results.compute_table(
+    lambda nr: nr.drift(top=42, bottom=10, component=1, reduce="abs_max"),
+)
+```
+
+---
+
+## Full example
+
+```python
+from pathlib import Path
+from STKO_to_python.MPCOList.MPCOResults import MPCOResults
+
+# Load all pickled NodalResults from a directory
+results = MPCOResults.load_dir(out_dir=Path("./ground_motion_outputs"), lazy=True)
+
+print(f"Loaded {len(results)} cases")
+
+# Filter to a specific model
+pairs = results.select(model="Model1A")
+for (model, sta, rup), nr in pairs:
+    print(f"  {model} | {sta} | {rup}  -> {nr.n_steps} steps")
+
+# Drift EDP table (wide)
+drift_wide = results.df.drift_df(
+    top=(10.0, 0.0, 6.0),
+    bottom=(10.0, 0.0, 3.0),
+    components=(1, 2),
+    reduce_time="abs_max",
+    combine="srss",
+)
+print(drift_wide.head())
+
+# Convert to long for plotting
+drift_long = results.df.wide_to_long(drift_wide, result_name="DISPLACEMENT", op="raw")
+
+# PGA profile
+pga = results.df.pga_df(
+    component=1,
+    selection_set_name="ControlPoints",
+    result_name="ACCELERATION",
+    to_g=True,
+)
+
+# Overlay drift histories for one station
+results.plot_drift(
+    top=(10.0, 0.0, 6.0),
+    bottom=(10.0, 0.0, 3.0),
+    component=1,
+    station="CHY101",
+    running_envelope="abs",
+)
+
+# ASCE torsional irregularity across all cases
+torsion = results.compute_table(
+    lambda nr: nr.asce_torsional_irregularity(
+        component=1,
+        side_a_top=(0.0, 0.0, 6.0),
+        side_a_bottom=(0.0, 0.0, 3.0),
+        side_b_top=(20.0, 0.0, 6.0),
+        side_b_bottom=(20.0, 0.0, 3.0),
+    )["ratio"]
+)
+print(torsion.describe())
+```
+
+---
+
+## API reference
 
 ::: STKO_to_python.MPCOList.MPCOResults.MPCOResults
 
 ## MPCO_df
 
-The DataFrame-extractor accessor. Reach it via
-`mpco_results.df` (preferred) or `mpco_results.create_df` (legacy).
+The DataFrame-extractor accessor. Reach it via `mpco_results.df`
+(preferred) or `mpco_results.create_df` (legacy).
 
 ::: STKO_to_python.MPCOList.MPCOdf.MPCO_df

--- a/examples/usage_tour.py
+++ b/examples/usage_tour.py
@@ -16,6 +16,11 @@ Covers:
     7. Fetching an ``ElementResults`` view.
     8. The ElementResults broker API (envelope, at_step, to_dataframe).
     9. Selection sets as an alternative to explicit IDs.
+   10. Element discovery (get_available_element_results).
+   11. Canonical engineering names on ElementResults.
+   12. Integration-point extraction (at_ip, gp_xi, physical_x).
+   13. Dataset introspection print helpers.
+   14. Element result discovery workflow (full pattern).
 
 Run with::
 
@@ -225,6 +230,113 @@ def section_10_selection_sets(ds: MPCODataSet) -> None:
     print("    )")
 
 
+def section_11_element_discovery(ds: MPCODataSet) -> None:
+    section("11. Element discovery — get_available_element_results")
+
+    avail = ds.elements.get_available_element_results()
+    for part_id, mapping in avail.items():
+        for rname, decorated_types in mapping.items():
+            print(
+                f"partition {part_id!r}: result={rname!r}  "
+                f"types={decorated_types}"
+            )
+
+    # Filter to a specific base type
+    avail_beam = ds.elements.get_available_element_results(
+        element_type="5-ElasticBeam3d"
+    )
+    print(f"\nfiltered to 5-ElasticBeam3d: {avail_beam}")
+
+
+def section_12_canonical_names(ds: MPCODataSet) -> None:
+    section("12. Canonical engineering names")
+
+    er = ds.elements.get_element_results(
+        results_name="force",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+
+    print(f"list_canonicals():  {er.list_canonicals()}")
+
+    for canon in er.list_canonicals():
+        cols = er.canonical_columns(canon)
+        print(f"  {canon!r:30s} -> {cols}")
+
+    # Full DataFrame for one canonical name
+    first_canon = er.list_canonicals()[0]
+    df = er.canonical(first_canon)
+    print(f"\ncanonical({first_canon!r}) shape: {df.shape}")
+
+    # Module-level helpers
+    from STKO_to_python.elements.canonical import (
+        available_canonicals,
+        shortname_of,
+    )
+    print(f"\navailable_canonicals() count: {len(available_canonicals())}")
+    print(f"shortname_of('Pz_1') = {shortname_of('Pz_1')!r}")
+    print(f"shortname_of('P_ip3') = {shortname_of('P_ip3')!r}")
+
+
+def section_13_integration_points(ds: MPCODataSet) -> None:
+    section("13. Integration-point access (gp_xi / at_ip)")
+
+    # Closed-form bucket — gp_xi is None
+    er_cf = ds.elements.get_element_results(
+        results_name="force",
+        element_type="5-ElasticBeam3d",
+        model_stage="MODEL_STAGE[1]",
+        element_ids=[1, 2, 3],
+    )
+    print(f"Closed-form:  gp_xi={er_cf.gp_xi}  n_ip={er_cf.n_ip}")
+    print("  (at_ip() raises ValueError for closed-form buckets)")
+
+    # Line-station bucket — gp_xi is populated if section.force exists
+    avail = ds.elements.get_available_element_results(
+        element_type="5-ElasticBeam3d"
+    )
+    all_results = [
+        r for mapping in avail.values() for r in mapping
+    ]
+    line_station_name = next(
+        (r for r in all_results if "section" in r), None
+    )
+
+    if line_station_name:
+        er_ls = ds.elements.get_element_results(
+            results_name=line_station_name,
+            element_type="5-ElasticBeam3d",
+            model_stage="MODEL_STAGE[1]",
+            element_ids=[1, 2, 3],
+        )
+        print(f"\nLine-station ({line_station_name!r}):")
+        print(f"  gp_xi={er_ls.gp_xi}  n_ip={er_ls.n_ip}")
+        if er_ls.n_ip:
+            sub = er_ls.at_ip(0)
+            print(f"  at_ip(0) columns: {list(sub.columns)}")
+            phys = er_ls.physical_x(length=3.0)
+            print(f"  physical_x(L=3.0): {phys}")
+    else:
+        print(
+            "\n(No line-station result in this fixture; "
+            "see test_gp_xi_and_at_ip.py for a full demo.)"
+        )
+
+
+def section_14_print_helpers(ds: MPCODataSet) -> None:
+    section("14. Dataset print helpers")
+    print("All print_* methods log at INFO level — enable with verbose=True")
+    print("or logging.basicConfig(level=logging.INFO).\n")
+    print("ds.print_summary()              -> stages + nodal + element overview")
+    print("ds.print_model_stages()         -> list of model stages")
+    print("ds.print_nodal_results()        -> available nodal result names")
+    print("ds.print_element_results()      -> available element result names")
+    print("ds.print_element_types()        -> result → decorated type mapping")
+    print("ds.print_unique_element_types() -> flat list of all decorated types")
+    print("ds.print_selection_set_info()   -> named selection sets from .cdata")
+
+
 # ---------------------------------------------------------------------- #
 # Entry point
 # ---------------------------------------------------------------------- #
@@ -242,6 +354,10 @@ def run(dataset_dir: Path, recorder: str) -> None:
     section_8_element_broker(er)
     section_9_pickle_element(er)
     section_10_selection_sets(ds)
+    section_11_element_discovery(ds)
+    section_12_canonical_names(ds)
+    section_13_integration_points(ds)
+    section_14_print_helpers(ds)
 
     print()
     print("Tour complete.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Query engines: api/query-engines.md
       - Plotting: api/plotting.md
       - MPCOResults: api/mpco-results.md
+      - Canonical names: api/canonical-names.md
   - Usage guides:
       - MPCODataSet: MPCODataSet.md
       - NodalResults: NodalResults.md


### PR DESCRIPTION
## Summary

- **`docs/api/aggregation-engine.md`** — rewrote from stub to full reference: all 11 methods documented with parameter tables, return shapes, and code examples (`delta_u`, `drift`, `residual_drift`, `interstory_drift_envelope`, `interstory_drift_envelope_pd`, `residual_interstory_drift_profile`, `residual_drift_envelope`, `story_pga_envelope`, `roof_torsion`, `base_rocking`, `asce_torsional_irregularity`, `orbit`)
- **`docs/api/mpco-results.md`** — rewrote from stub: full `MPCOResults` public API (`load_dir`, dict protocol, `select`, `.df` accessor, `drift_df`, `pga_df`, `torsion_df`, `base_rocking_df`, `wide_to_long`, `plot_drift`, `plot_drift_envelope`, `compute_table`, `parse_tier_letter`)
- **`docs/api/canonical-names.md`** — new page: full canonical map table, suffix conventions, and all four public functions (`available_canonicals`, `shortname_of`, `match_canonical_columns`, `list_canonical_for_columns`) with examples
- **`docs/api/mpco-dataset.md`** — added `print_*` helper methods with examples
- **`mkdocs.yml`** — added canonical-names to API reference nav
- **`examples/usage_tour.py`** — added sections 11–14: element discovery, canonical names, `at_ip`/`gp_xi`/`physical_x`, and print helpers

## Test plan

- [ ] `python examples/usage_tour.py` runs clean end-to-end
- [ ] `mkdocs build` completes without broken refs
- [ ] GitHub Pages site shows all new pages in nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)