### PR TITLE
ElementResults: time-series helpers + plot namespace

### DIFF
--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -396,6 +396,55 @@ df_flat = er.to_dataframe(include_time=True)
 # Adds a 'time' column mapped from step index to time value
 ```
 
+## Per-element time-series statistics
+
+For pushover and dynamic post-processing:
+
+```python
+# Per-element absolute peak across the full step history
+peaks = er.peak_abs()                       # all components
+peaks = er.peak_abs(component="Mz_1")       # one component
+
+# Step index where a component peaks (per element)
+idx_abs    = er.time_of_peak("Mz_1")              # by |value| (default)
+idx_signed = er.time_of_peak("Mz_1", abs=False)   # by signed value
+
+# Running min/max envelope at every step (monotonic-load workflows)
+ce = er.cumulative_envelope("N_1")
+# MultiIndex (element_id, step) with columns N_1_running_min/max
+
+# One-row-per-element summary: max, min, peak_abs, residual, mean
+s = er.summary()
+```
+
+## Plotting
+
+`ElementResults.plot` is a small wrapper around matplotlib for the
+three engineering views that come up most:
+
+```python
+# Time history of a component for one or more elements
+ax, meta = er.plot.history("Mz_1", element_ids=[1, 2, 3])
+ax, meta = er.plot.history("P_ip2", x_axis="step")  # step instead of time
+
+# Force / moment / strain diagram along a beam (line elements only)
+ax, meta = er.plot.diagram("axial_force", element_id=1, step=100)
+ax, meta = er.plot.diagram("bending_moment_z", element_id=1, step=100,
+                            x_in_natural=True)  # ξ ∈ [-1, +1]
+
+# Spatial scatter for shells / planes / solids (color = component value)
+ax, meta = er_shell.plot.scatter("membrane_xx", step=100)
+ax, meta = er_shell.plot.scatter("membrane_xx", step=100, axes=("x", "z"))
+ax, meta = er_brick.plot.scatter("stress_11", step=100)
+```
+
+Each method returns ``(ax, meta)`` — pass an existing ``ax=`` to compose
+plots, or use ``meta["x"]`` / ``meta["values"]`` directly if you want to
+build your own visualization. ``diagram()`` requires the result to be a
+line element (``gp_dim == 1``); ``scatter()`` requires
+``physical_coords()`` to resolve (so closed-form buckets and unknown
+classes raise loudly).
+
 ## Pickle Serialization
 
 Save and reload without needing the original HDF5 files:

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -184,6 +184,12 @@ class ElementResults:
         self._views: Dict[str, _ElementResultView] = {}
         self._build_views()
 
+        # Plotting helper bound to this result. Imported lazily to
+        # keep the matplotlib dependency optional at import time.
+        from .element_results_plotting import ElementResultsPlotter
+
+        self.plot = ElementResultsPlotter(self)
+
     # ------------------------------------------------------------------ #
     # View construction
     # ------------------------------------------------------------------ #
@@ -707,6 +713,137 @@ class ElementResults:
             return pd.DataFrame()
         return self.df.xs(step, level="step")
 
+    # ------------------------------------------------------------------ #
+    # Per-element time-series statistics                                  #
+    # ------------------------------------------------------------------ #
+
+    def peak_abs(
+        self,
+        component: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Per-element absolute peak value across all time steps.
+
+        For each element, return ``max(|value|)`` over the entire step
+        history. Useful for envelope-style post-processing (e.g.
+        peak shear demand per beam).
+
+        Parameters
+        ----------
+        component : str or None
+            Restrict to one column. If ``None``, every column gets a
+            ``<col>_peak_abs`` entry.
+
+        Returns
+        -------
+        pd.DataFrame
+            Indexed by ``element_id``. Columns: ``<col>_peak_abs``.
+        """
+        df = self.df if component is None else self.df[[component]]
+        if df.empty:
+            return pd.DataFrame()
+        grouped = df.abs().groupby("element_id")
+        return grouped.max().add_suffix("_peak_abs").sort_index()
+
+    def time_of_peak(
+        self,
+        component: str,
+        *,
+        abs: bool = True,
+    ) -> pd.Series:
+        """Per-element step index at which a component peaks.
+
+        Parameters
+        ----------
+        component : str
+            Required — peak time is single-component by definition.
+        abs : bool, default True
+            If ``True``, find the step where ``|value|`` peaks (most
+            useful for cyclic / dynamic loading). If ``False``, find
+            the step where the *signed* value is maximal (useful for
+            monotonic pushover-style analyses).
+
+        Returns
+        -------
+        pd.Series
+            Indexed by ``element_id``, values are step indices (int).
+        """
+        if component not in self.df.columns:
+            raise ValueError(
+                f"Component {component!r} not in this result. "
+                f"Available: {self.list_components()}"
+            )
+        ser = self.df[component].abs() if abs else self.df[component]
+        # idxmax returns the (element_id, step) tuple of the max-row;
+        # we want just the step level.
+        idx_max = ser.groupby("element_id").idxmax()
+        # idx_max is a Series indexed by element_id, values are tuples.
+        steps = pd.Series(
+            [int(t[1]) for t in idx_max.to_numpy()],
+            index=idx_max.index,
+            name=f"{component}_argmax",
+        )
+        return steps.sort_index()
+
+    def cumulative_envelope(
+        self,
+        component: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Running min/max envelope per element over the step axis.
+
+        Like :meth:`envelope` but instead of one ``(min, max)`` pair
+        per element, returns the running envelope at every step —
+        useful for monotonic-load analyses where you want to see when
+        each element first reached its peak.
+
+        Returns
+        -------
+        pd.DataFrame
+            MultiIndex ``(element_id, step)`` matching ``self.df``,
+            with columns ``<col>_running_min`` and ``<col>_running_max``
+            for each input column.
+        """
+        df = self.df if component is None else self.df[[component]]
+        if df.empty:
+            return pd.DataFrame()
+        # Ensure deterministic step ordering before cumulative ops.
+        df = df.sort_index(level=["element_id", "step"])
+        grouped = df.groupby(level="element_id")
+        running_max = grouped.cummax().add_suffix("_running_max")
+        running_min = grouped.cummin().add_suffix("_running_min")
+        return pd.concat([running_min, running_max], axis=1)
+
+    def summary(self) -> pd.DataFrame:
+        """One-row-per-element summary of useful per-element statistics.
+
+        Combines: signed peak (max), trough (min), absolute peak,
+        residual (last step value), and mean — across the full step
+        history, for every component column.
+
+        Returns
+        -------
+        pd.DataFrame
+            Indexed by ``element_id``. For each input column ``<col>``,
+            five output columns: ``<col>_max``, ``<col>_min``,
+            ``<col>_peak_abs``, ``<col>_residual``, ``<col>_mean``.
+        """
+        if self.df.empty:
+            return pd.DataFrame()
+        # Sort so .last() picks the largest step.
+        df = self.df.sort_index(level=["element_id", "step"])
+        grouped = df.groupby(level="element_id")
+        peak_abs = df.abs().groupby(level="element_id").max().add_suffix("_peak_abs")
+        out = pd.concat(
+            [
+                grouped.max().add_suffix("_max"),
+                grouped.min().add_suffix("_min"),
+                peak_abs,
+                grouped.last().add_suffix("_residual"),
+                grouped.mean().add_suffix("_mean"),
+            ],
+            axis=1,
+        )
+        return out.sort_index()
+
     def at_time(self, t: float, tol: float = 1e-10) -> pd.DataFrame:
         """
         Extract results at the time step closest to *t*.
@@ -733,13 +870,20 @@ class ElementResults:
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
+        # ResultView proxies and the plotter hold a back-reference to
+        # ``self``; rebuild them on unpickle rather than serializing
+        # the cycle.
         state["_views"] = None
+        state.pop("plot", None)
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self._views = {}
         self._build_views()
+        from .element_results_plotting import ElementResultsPlotter
+
+        self.plot = ElementResultsPlotter(self)
 
     def save_pickle(
         self,

--- a/src/STKO_to_python/elements/element_results_plotting.py
+++ b/src/STKO_to_python/elements/element_results_plotting.py
@@ -1,0 +1,336 @@
+"""Plotting helper bound to an :class:`ElementResults` instance.
+
+Three plot families covering the most common engineering workflows:
+
+* :meth:`ElementResultsPlotter.history` — time history of a component
+  for one or more elements (and optionally a specific IP).
+* :meth:`ElementResultsPlotter.diagram` — for line elements (beams),
+  plot a component as a function of physical position along the
+  element at a single step. The classic moment / shear / axial
+  diagram.
+* :meth:`ElementResultsPlotter.scatter` — for shells, plane elements,
+  or solids, scatter integration-point physical positions colored by
+  the component value at a step. A lightweight contour-style view
+  that doesn't need triangulation or a mesh-aware renderer.
+
+All methods accept an optional ``ax`` so they compose cleanly with
+user-built figures, and return ``(ax, meta)`` like
+:class:`NodalResultsPlotter` for symmetry.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from .element_results import ElementResults
+
+
+# Map "x"/"y"/"z" to physical_coords axis index.
+_AXIS_NAME_TO_IDX = {"x": 0, "y": 1, "z": 2, 0: 0, 1: 1, 2: 2}
+
+
+class ElementResultsPlotter:
+    """Plotting helper for :class:`ElementResults`.
+
+    Held as ``ElementResults.plot`` and rebuilt on unpickle.
+    """
+
+    __slots__ = ("_results",)
+
+    def __init__(self, results: "ElementResults") -> None:
+        self._results = results
+
+    # ------------------------------------------------------------------ #
+    # Time history                                                        #
+    # ------------------------------------------------------------------ #
+
+    def history(
+        self,
+        component: str,
+        *,
+        element_ids: Union[int, Sequence[int], None] = None,
+        ax: Any = None,
+        x_axis: str = "time",
+        **plot_kwargs: Any,
+    ) -> Tuple[Any, dict]:
+        """Plot the time history of one component for one or more elements.
+
+        Parameters
+        ----------
+        component : str
+            Column name (e.g. ``"Mz_1"``, ``"P_ip2"``,
+            ``"sigma11_l0_ip0"``).
+        element_ids : int, sequence of int, or None
+            Restrict to specific elements. If ``None``, plots every
+            element in the result (one curve each — be wary on large
+            meshes).
+        ax : matplotlib Axes or None
+            Existing axes to draw on. If ``None``, a new figure is
+            created.
+        x_axis : ``"time"`` or ``"step"``
+            x-axis source. ``"time"`` requires ``self._results.time``.
+        **plot_kwargs
+            Forwarded to ``ax.plot``.
+
+        Returns
+        -------
+        (ax, meta) : tuple
+            ``meta`` carries ``{"x", "y_per_element"}`` for inspection.
+        """
+        import matplotlib.pyplot as plt
+
+        er = self._results
+        if component not in er.df.columns:
+            raise ValueError(
+                f"Component {component!r} not in this result. "
+                f"Available: {er.list_components()[:20]}"
+                + (" ..." if len(er.list_components()) > 20 else "")
+            )
+
+        if element_ids is None:
+            ids = list(er.element_ids)
+        elif isinstance(element_ids, (int, np.integer)):
+            ids = [int(element_ids)]
+        else:
+            ids = [int(e) for e in element_ids]
+
+        if x_axis == "time":
+            if not isinstance(er.time, np.ndarray) or er.time.size == 0:
+                raise ValueError(
+                    "x_axis='time' requested but no time array on this "
+                    "result. Use x_axis='step' instead."
+                )
+            x_full = er.time
+            x_label = "Time"
+        elif x_axis == "step":
+            x_full = np.arange(er.n_steps, dtype=np.int64)
+            x_label = "Step"
+        else:
+            raise ValueError(f"x_axis must be 'time' or 'step', got {x_axis!r}")
+
+        if ax is None:
+            fig, ax = plt.subplots()
+
+        ser = er.df[component]
+        per_element: dict[int, np.ndarray] = {}
+        for eid in ids:
+            try:
+                y = ser.xs(eid, level="element_id").sort_index().to_numpy()
+            except KeyError:
+                continue
+            x = x_full[: y.size]
+            label = plot_kwargs.pop("label", None) if len(ids) == 1 else f"e{eid}"
+            ax.plot(x, y, label=label, **plot_kwargs)
+            per_element[eid] = y
+
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(component)
+        if len(ids) > 1 and len(ids) <= 12:
+            ax.legend()
+        return ax, {"x": x_full, "y_per_element": per_element}
+
+    # ------------------------------------------------------------------ #
+    # Beam diagrams (line elements)                                       #
+    # ------------------------------------------------------------------ #
+
+    def diagram(
+        self,
+        component_canonical: str,
+        *,
+        element_id: int,
+        step: int,
+        ax: Any = None,
+        x_in_natural: bool = False,
+        **plot_kwargs: Any,
+    ) -> Tuple[Any, dict]:
+        """Plot a force / moment / strain diagram along a line element.
+
+        For a single element and step, plots the *canonical* quantity
+        (e.g. ``"axial_force"``, ``"bending_moment_z"``) as a function
+        of physical position along the element.
+
+        Only valid for line elements (``gp_dim == 1``) — this is the
+        classic beam diagram. For shells / solids see :meth:`scatter`.
+
+        Parameters
+        ----------
+        component_canonical : str
+            Canonical name. Must resolve to ``self._results.n_ip``
+            columns (one per IP) — same constraint as
+            :meth:`integrate_canonical`.
+        element_id : int
+        step : int
+        ax : matplotlib Axes or None
+        x_in_natural : bool, default False
+            If ``False``, x-axis is physical position along the beam
+            (requires node coords). If ``True``, x-axis is the natural
+            ξ ∈ [-1, +1].
+        **plot_kwargs
+            Forwarded to ``ax.plot``.
+        """
+        import matplotlib.pyplot as plt
+
+        er = self._results
+        if er.gp_dim != 1:
+            raise ValueError(
+                f"diagram() is only valid for line elements (gp_dim=1). "
+                f"This result has gp_dim={er.gp_dim}. Use scatter() for "
+                f"shells / solids."
+            )
+
+        cols = er.canonical_columns(component_canonical)
+        if not cols:
+            raise ValueError(
+                f"Canonical {component_canonical!r} doesn't match any "
+                f"columns in this result. Present canonicals: "
+                f"{er.list_canonicals()}"
+            )
+        if len(cols) != er.n_ip:
+            raise ValueError(
+                f"Canonical {component_canonical!r} resolves to "
+                f"{len(cols)} columns but the bucket has {er.n_ip} IPs. "
+                f"diagram() needs one column per IP."
+            )
+
+        try:
+            row = er.df.xs((int(element_id), int(step)))
+        except KeyError as err:
+            raise ValueError(
+                f"({element_id}, {step}) not in this result"
+            ) from err
+        y = row[list(cols)].to_numpy(dtype=np.float64)
+
+        if x_in_natural:
+            if er.gp_xi is None:
+                raise ValueError(
+                    "x_in_natural=True but gp_xi is None on this result"
+                )
+            x = er.gp_xi
+            x_label = "ξ (natural)"
+        else:
+            if er.element_node_coords is None:
+                raise ValueError(
+                    "Physical x requested but element_node_coords is None. "
+                    "Pass x_in_natural=True to plot in parent coordinates."
+                )
+            # Find the row index for this element_id.
+            try:
+                eid_row = list(er.element_ids).index(int(element_id))
+            except ValueError:
+                raise ValueError(
+                    f"element_id {element_id} not in self.element_ids"
+                )
+            nc = er.element_node_coords[eid_row]
+            length = float(np.linalg.norm(nc[-1] - nc[0]))
+            x = er.physical_x(length)
+            x_label = "Position along element"
+
+        if ax is None:
+            fig, ax = plt.subplots()
+        ax.plot(x, y, marker="o", **plot_kwargs)
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(component_canonical)
+        ax.set_title(f"Element {element_id}, step {step}")
+        ax.grid(True, alpha=0.3)
+        ax.axhline(0.0, color="black", linewidth=0.5)
+        return ax, {"x": x, "y": y, "columns": list(cols)}
+
+    # ------------------------------------------------------------------ #
+    # Spatial scatter (shells / planes / solids)                          #
+    # ------------------------------------------------------------------ #
+
+    def scatter(
+        self,
+        component_canonical: str,
+        *,
+        step: int,
+        ax: Any = None,
+        axes: Tuple[str, str] = ("x", "y"),
+        **scatter_kwargs: Any,
+    ) -> Tuple[Any, dict]:
+        """Scatter integration-point physical positions colored by value.
+
+        For shells, plane elements, and solids: at a given step, plot
+        a 2-D projection of every IP's physical position colored by
+        the canonical value at that IP. Lightweight stand-in for a
+        proper contour plot — no mesh-aware rendering, no
+        triangulation, just a colored scatter.
+
+        Parameters
+        ----------
+        component_canonical : str
+            Canonical name. Must resolve to ``n_ip`` columns.
+        step : int
+        ax : matplotlib Axes or None
+        axes : tuple of two of ``"x"``, ``"y"``, ``"z"``
+            Which physical axes to use for the 2-D plot. Default
+            ``("x", "y")`` (top-down view); use ``("x", "z")`` for an
+            elevation view.
+        **scatter_kwargs
+            Forwarded to ``ax.scatter`` (e.g. ``cmap``, ``s``).
+        """
+        import matplotlib.pyplot as plt
+
+        er = self._results
+        phys = er.physical_coords()
+        if phys is None:
+            raise ValueError(
+                "physical_coords() is None on this result — physical "
+                "scatter unavailable. Either the bucket is closed-form, "
+                "the element class isn't in the shape-function catalog, "
+                "or node coords weren't populated at fetch time."
+            )
+
+        cols = er.canonical_columns(component_canonical)
+        if not cols:
+            raise ValueError(
+                f"Canonical {component_canonical!r} doesn't match any "
+                f"columns. Present canonicals: {er.list_canonicals()}"
+            )
+        if len(cols) != er.n_ip:
+            raise ValueError(
+                f"Canonical {component_canonical!r} resolves to "
+                f"{len(cols)} columns but the bucket has {er.n_ip} IPs. "
+                f"scatter() needs one column per IP."
+            )
+
+        try:
+            ax0_idx = _AXIS_NAME_TO_IDX[axes[0]]
+            ax1_idx = _AXIS_NAME_TO_IDX[axes[1]]
+        except KeyError as err:
+            raise ValueError(f"axes must be from x/y/z, got {axes!r}") from err
+
+        snap = er.at_step(int(step))[list(cols)]
+        # Align IP values to elements (snap is indexed by element_id;
+        # element_ids ordering matches phys's first axis).
+        try:
+            snap_aligned = snap.loc[list(er.element_ids)]
+        except KeyError:
+            raise ValueError(
+                f"step {step}: not all element_ids present"
+            )
+        values = snap_aligned.to_numpy()  # (n_e, n_ip)
+        xs = phys[:, :, ax0_idx].ravel()
+        ys = phys[:, :, ax1_idx].ravel()
+        cs = values.ravel()
+
+        if ax is None:
+            fig, ax = plt.subplots()
+        # Sensible defaults
+        scatter_kwargs.setdefault("cmap", "viridis")
+        scatter_kwargs.setdefault("s", 20)
+        sc = ax.scatter(xs, ys, c=cs, **scatter_kwargs)
+        # Caller can use ax.figure.colorbar(sc) if they want one.
+        ax.set_xlabel(f"{axes[0]} (physical)")
+        ax.set_ylabel(f"{axes[1]} (physical)")
+        ax.set_title(f"{component_canonical} at step {step}")
+        ax.set_aspect("equal", adjustable="datalim")
+        return ax, {
+            "x": xs,
+            "y": ys,
+            "values": cs,
+            "scatter": sc,
+        }

--- a/tests/integration/test_element_plotting.py
+++ b/tests/integration/test_element_plotting.py
@@ -1,0 +1,271 @@
+"""End-to-end tests for ``ElementResults.plot.*``.
+
+Uses the ``Agg`` matplotlib backend so the tests run headlessly. Each
+test asserts the meta dict the plotter returns, since pixel-level
+checks are fragile and unnecessary — the meta carries the same x/y
+arrays that drive the plot.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # before any other matplotlib import
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# history()                                                               #
+# ---------------------------------------------------------------------- #
+
+
+def test_history_single_element(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ax, meta = er.plot.history("N_1", element_ids=1)
+    assert ax is not None
+    assert "x" in meta and "y_per_element" in meta
+    assert list(meta["y_per_element"].keys()) == [1]
+    assert meta["y_per_element"][1].shape == (er.n_steps,)
+
+
+def test_history_multi_element(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ax, meta = er.plot.history("N_1")
+    assert sorted(meta["y_per_element"].keys()) == [1, 2, 3]
+
+
+def test_history_x_axis_step_works_without_time(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ax, meta = er.plot.history("N_1", x_axis="step")
+    np.testing.assert_array_equal(meta["x"], np.arange(er.n_steps))
+
+
+def test_history_unknown_component_raises(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="not in this result"):
+        er.plot.history("nonexistent")
+
+
+# ---------------------------------------------------------------------- #
+# diagram()  — line elements                                              #
+# ---------------------------------------------------------------------- #
+
+
+def test_diagram_line_element_physical_x():
+    p = (
+        Path(__file__).resolve().parents[2]
+        / "stko_results_examples"
+        / "elasticFrame"
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    if not (p / "results.mpco").exists():
+        pytest.skip("disp-based fixture missing")
+    ds = MPCODataSet(str(p), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ax, meta = er.plot.diagram("axial_force", element_id=1, step=5)
+    # Values are one per IP.
+    assert meta["y"].shape == (er.n_ip,)
+    # x-axis spans the beam length.
+    assert meta["x"][0] == pytest.approx(0.0, abs=1e-9)
+    assert meta["x"][-1] > meta["x"][0]
+
+
+def test_diagram_line_element_natural_x():
+    p = (
+        Path(__file__).resolve().parents[2]
+        / "stko_results_examples"
+        / "elasticFrame"
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    if not (p / "results.mpco").exists():
+        pytest.skip("disp-based fixture missing")
+    ds = MPCODataSet(str(p), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ax, meta = er.plot.diagram(
+        "bending_moment_z", element_id=1, step=5, x_in_natural=True
+    )
+    np.testing.assert_allclose(meta["x"], er.gp_xi)
+
+
+def test_diagram_raises_on_shell(quad_frame_dir: Path):
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=[shell_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="line elements"):
+        er.plot.diagram("membrane_xx", element_id=shell_id, step=0)
+
+
+def test_diagram_raises_on_unknown_canonical(elastic_frame_dir: Path):
+    """A canonical that doesn't apply to the bucket should raise even
+    on a line element."""
+    p = (
+        Path(__file__).resolve().parents[2]
+        / "stko_results_examples"
+        / "elasticFrame"
+        / "elasticFrame_mesh_displacementBased_results"
+    )
+    if not (p / "results.mpco").exists():
+        pytest.skip("disp-based fixture missing")
+    ds = MPCODataSet(str(p), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="doesn't match"):
+        er.plot.diagram("membrane_xx", element_id=1, step=0)
+
+
+# ---------------------------------------------------------------------- #
+# scatter()  — shells / solids                                            #
+# ---------------------------------------------------------------------- #
+
+
+def test_scatter_shell(quad_frame_dir: Path):
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_ids = [
+        int(i)
+        for i in ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .head(20)
+    ]
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=shell_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    ax, meta = er.plot.scatter("membrane_xx", step=2)
+    # 20 elements × 4 IPs = 80 points
+    assert meta["x"].shape == (len(shell_ids) * er.n_ip,)
+    assert meta["y"].shape == meta["x"].shape
+    assert meta["values"].shape == meta["x"].shape
+
+
+def test_scatter_brick_with_axis_choice(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    brick_ids = [
+        int(i)
+        for i in ds.elements_info["dataframe"]
+        .query("element_type == '56-Brick'")["element_id"]
+        .head(10)
+    ]
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        element_ids=brick_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    # x/z elevation view
+    ax, meta = er.plot.scatter("stress_11", step=1, axes=("x", "z"))
+    assert meta["x"].shape == (len(brick_ids) * er.n_ip,)
+
+
+def test_scatter_invalid_axis_raises(quad_frame_dir: Path):
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_id = int(
+        ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .iloc[0]
+    )
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=[shell_id],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="axes must be"):
+        er.plot.scatter("membrane_xx", step=0, axes=("u", "v"))
+
+
+def test_scatter_raises_on_closed_form(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="physical_coords"):
+        er.plot.scatter("axial_force", step=0)
+
+
+# ---------------------------------------------------------------------- #
+# Plotter survives pickle roundtrip                                       #
+# ---------------------------------------------------------------------- #
+
+
+def test_plotter_rebuilds_after_pickle(elastic_frame_dir: Path, tmp_path: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2],
+        model_stage="MODEL_STAGE[1]",
+    )
+    pkl = tmp_path / "er.pkl"
+    er.save_pickle(pkl)
+
+    from STKO_to_python.elements.element_results import ElementResults
+
+    er2 = ElementResults.load_pickle(pkl)
+    # plot attribute exists and works
+    assert er2.plot is not None
+    ax, meta = er2.plot.history("N_1")
+    assert ax is not None

--- a/tests/integration/test_time_series_helpers.py
+++ b/tests/integration/test_time_series_helpers.py
@@ -1,0 +1,208 @@
+"""End-to-end tests for the per-element time-series helpers
+(``peak_abs``, ``time_of_peak``, ``cumulative_envelope``, ``summary``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# peak_abs                                                                #
+# ---------------------------------------------------------------------- #
+
+
+def test_peak_abs_returns_per_element_max_abs(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    pa = er.peak_abs()
+    # Every column gets a *_peak_abs.
+    assert all(c.endswith("_peak_abs") for c in pa.columns)
+    assert sorted(pa.index.tolist()) == [1, 2, 3]
+    # peak_abs >= max(|envelope|).
+    env = er.envelope()
+    for col in er.df.columns:
+        peak_col = f"{col}_peak_abs"
+        env_max = env[[f"{col}_min", f"{col}_max"]].abs().max(axis=1)
+        np.testing.assert_array_less(
+            -1e-9 + env_max.values, pa[peak_col].values + 1e-9
+        )
+
+
+def test_peak_abs_single_component_subset(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    pa = er.peak_abs(component="N_1")
+    assert list(pa.columns) == ["N_1_peak_abs"]
+
+
+# ---------------------------------------------------------------------- #
+# time_of_peak                                                            #
+# ---------------------------------------------------------------------- #
+
+
+def test_time_of_peak_indexes_step_axis(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    s = er.time_of_peak("N_1")
+    assert sorted(s.index.tolist()) == [1, 2, 3]
+    # Indices must be valid steps.
+    assert s.between(0, er.n_steps - 1).all()
+    # Cross-check against argmax of |N_1| per element.
+    expected = er.df["N_1"].abs().groupby("element_id").idxmax().apply(lambda t: t[1])
+    pd.testing.assert_series_equal(
+        s.sort_index().rename(None), expected.sort_index().rename(None),
+        check_dtype=False,
+    )
+
+
+def test_time_of_peak_signed_vs_abs_can_differ(elastic_frame_dir: Path):
+    """Most fixtures will agree; this test just locks in that the
+    code-path executes for both modes without error."""
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    s_abs = er.time_of_peak("N_1", abs=True)
+    s_signed = er.time_of_peak("N_1", abs=False)
+    assert s_abs.notna().all()
+    assert s_signed.notna().all()
+
+
+def test_time_of_peak_unknown_component_raises(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="not in this result"):
+        er.time_of_peak("nonexistent")
+
+
+# ---------------------------------------------------------------------- #
+# cumulative_envelope                                                     #
+# ---------------------------------------------------------------------- #
+
+
+def test_cumulative_envelope_has_running_columns(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ce = er.cumulative_envelope("N_1")
+    assert "N_1_running_max" in ce.columns
+    assert "N_1_running_min" in ce.columns
+    # Running max is monotonically non-decreasing per element.
+    arr = ce["N_1_running_max"].xs(1, level="element_id").to_numpy()
+    assert np.all(np.diff(arr) >= -1e-12)
+
+
+def test_cumulative_envelope_last_step_equals_envelope(elastic_frame_dir: Path):
+    """At the final step, running_min/max equals the regular envelope."""
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    ce = er.cumulative_envelope()
+    env = er.envelope()
+    last_step = er.n_steps - 1
+    last = ce.xs(last_step, level="step").sort_index()
+    env_sorted = env.sort_index()
+
+    for col in er.df.columns:
+        np.testing.assert_allclose(
+            last[f"{col}_running_max"].values,
+            env_sorted[f"{col}_max"].values,
+            rtol=1e-12,
+        )
+        np.testing.assert_allclose(
+            last[f"{col}_running_min"].values,
+            env_sorted[f"{col}_min"].values,
+            rtol=1e-12,
+        )
+
+
+# ---------------------------------------------------------------------- #
+# summary                                                                 #
+# ---------------------------------------------------------------------- #
+
+
+def test_summary_has_expected_columns(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1, 2, 3],
+        model_stage="MODEL_STAGE[1]",
+    )
+    s = er.summary()
+    assert sorted(s.index.tolist()) == [1, 2, 3]
+    suffixes = {"_max", "_min", "_peak_abs", "_residual", "_mean"}
+    for col in er.df.columns:
+        for suf in suffixes:
+            assert f"{col}{suf}" in s.columns
+    # Per-element peak_abs >= |max| and >= |min|.
+    for col in er.df.columns:
+        assert (s[f"{col}_peak_abs"] + 1e-12 >= s[f"{col}_max"].abs()).all()
+        assert (s[f"{col}_peak_abs"] + 1e-12 >= s[f"{col}_min"].abs()).all()
+
+
+def test_summary_residual_is_last_step_value(elastic_frame_dir: Path):
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        element_ids=[1],
+        model_stage="MODEL_STAGE[1]",
+    )
+    s = er.summary()
+    last_step_data = er.df.xs(er.n_steps - 1, level="step")
+    for col in er.df.columns:
+        assert s.loc[1, f"{col}_residual"] == pytest.approx(
+            last_step_data.loc[1, col]
+        )
+
+
+# ---------------------------------------------------------------------- #
+# Empty result sanity                                                     #
+# ---------------------------------------------------------------------- #
+
+
+def test_helpers_on_empty_result_return_empty_frames():
+    from STKO_to_python.elements.element_results import ElementResults
+
+    er = ElementResults(df=pd.DataFrame(), time=np.array([]))
+    assert er.peak_abs().empty
+    assert er.cumulative_envelope().empty
+    assert er.summary().empty


### PR DESCRIPTION
## Summary

Closes the post-processing API gap between ``ElementResults`` and ``NodalResults``. Two complementary additions:

### 1. Per-element time-series statistics

For pushover and dynamic post-processing workflows that ``NodalResults`` already supports via ``drift`` / ``residual_drift`` / ``interstory_drift_envelope``:

```python
peaks      = er.peak_abs()                          # per-element max(|value|)
peaks      = er.peak_abs(component=""Mz_1"")          # one component
idx_abs    = er.time_of_peak(""Mz_1"")                # step where |value| peaks
idx_signed = er.time_of_peak(""Mz_1"", abs=False)     # step where signed value peaks
running    = er.cumulative_envelope(""N_1"")          # min/max at every step
s          = er.summary()                           # max/min/peak_abs/residual/mean
```

### 2. ``er.plot`` namespace

Three plot families covering the most common views:

```python
# Time history of a component for one or more elements
ax, meta = er.plot.history(""Mz_1"", element_ids=[1, 2, 3])

# Force / moment / strain diagram along a beam (line elements only)
ax, meta = er.plot.diagram(""axial_force"", element_id=1, step=100)

# Spatial scatter for shells / planes / solids (color = canonical value)
ax, meta = er_shell.plot.scatter(""membrane_xx"", step=100)
ax, meta = er_brick.plot.scatter(""stress_11"", step=100, axes=(""x"", ""z""))
```

Each method returns ``(ax, meta)`` mirroring ``NodalResultsPlotter.xy``. The plotter is rebuilt via ``__setstate__`` so pickle round-trips keep ``er.plot`` working.

### What's not in this PR

- **``material.crackPattern`` / ``material.crackInfo`` canonical names**: the Test_NLShell fixture has these buckets declared but the recorder didn't emit any actual data (empty groups across all 4 partitions × 3 stages). I'll add canonical names when a fixture surfaces real values to know what shape they take.

### Diff note

This PR is stacked on #30 (layered shells), which is stacked on #28, #25, #24. Until those merge, the file-changed view here will include their content too. **Recommended merge order:** #26 → #24 → #25 → #28 → #30 → this PR.

## Test plan

- [x] **23 new tests** (10 time-series helpers + 13 plotting). Cover:
  - peak_abs ≥ |envelope min/max| invariant.
  - time_of_peak matches a manual ``df.abs().groupby().idxmax()``.
  - cumulative_envelope's last step equals the regular envelope.
  - summary residual equals the last-step value.
  - History / diagram / scatter on real fixtures (line beam, shell, brick).
  - Plotter rebuilds after pickle round-trip.
  - Error paths: shell-asks-for-diagram, closed-form-asks-for-scatter, unknown component / canonical, invalid axis name.
- [x] **676 → 699 passing**, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)