### PR TITLE
Add fixture-specific example scripts (elastic frame, shell, solid+beam)

### DIFF
--- a/examples/elastic_frame_example.py
+++ b/examples/elastic_frame_example.py
@@ -1,0 +1,296 @@
+"""Elastic frame example — single-partition ElasticBeam3d fixture.
+
+Demonstrates the core STKO_to_python workflow against the checked-in
+``stko_results_examples/elasticFrame/results`` fixture:
+
+    1.  Dataset construction and introspection.
+    2.  Fetching nodal DISPLACEMENT results.
+    3.  Engineering aggregations: drift, interstory envelope, residual
+        drift, orbit.
+    4.  XY plotting (per-result and dataset-level facade).
+    5.  NodalResults pickle round-trip.
+    6.  Fetching beam ``force`` and ``localForce`` (closed-form) results.
+    7.  ElementResults broker API: envelope, at_step, to_dataframe.
+    8.  Canonical engineering names on closed-form beam results.
+    9.  ElementResults pickle round-trip.
+
+Run with::
+
+    python examples/elastic_frame_example.py
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.elements.element_results import ElementResults
+from STKO_to_python.results.nodal_results_dataclass import NodalResults
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATASET_DIR = REPO_ROOT / "stko_results_examples" / "elasticFrame" / "results"
+RECORDER = "results"
+
+NODE_IDS = [1, 2, 3, 4]
+ELEMENT_IDS = [1, 2, 3]
+STAGE = "MODEL_STAGE[1]"
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 70)
+    print(f"  {title}")
+    print("=" * 70)
+
+
+# ---------------------------------------------------------------------------
+# 1. Dataset construction and introspection
+# ---------------------------------------------------------------------------
+def section_1_introspect(ds: MPCODataSet) -> None:
+    section("1. Dataset introspection")
+
+    print(f"model_stages:           {ds.model_stages}")
+    print(f"number_of_steps:        {ds.number_of_steps}")
+    print(f"node_results_names:     {ds.node_results_names}")
+    print(f"element_results_names:  {ds.element_results_names}")
+    print(f"unique_element_types:   {ds.unique_element_types}")
+
+    avail = ds.elements.get_available_element_results()
+    for part_id, mapping in avail.items():
+        for rname, types in mapping.items():
+            print(f"  partition {part_id}: {rname!r} -> {types}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Fetch nodal DISPLACEMENT
+# ---------------------------------------------------------------------------
+def section_2_fetch_nodal(ds: MPCODataSet) -> NodalResults:
+    section("2. Fetch NodalResults — DISPLACEMENT")
+
+    nr = ds.nodes.get_nodal_results(
+        results_name="DISPLACEMENT",
+        model_stage=STAGE,
+        node_ids=NODE_IDS,
+    )
+    print(repr(nr))
+    print(f"df.shape:         {nr.df.shape}")
+    print(f"df.index.names:   {list(nr.df.index.names)}")
+    print(f"time (first 3):   {nr.time[:3]}")
+    print(f"list_results():   {nr.list_results()}")
+    print(f"list_components('DISPLACEMENT'): {nr.list_components('DISPLACEMENT')}")
+    return nr
+
+
+# ---------------------------------------------------------------------------
+# 3. Engineering aggregations
+# ---------------------------------------------------------------------------
+def section_3_aggregations(nr: NodalResults) -> None:
+    section("3. Engineering aggregations")
+
+    # Relative drift between two nodes
+    ts = nr.drift(top=4, bottom=1, component=1)
+    print(f"drift(top=4, bottom=1, comp=1):   length={ts.size}, "
+          f"max|.|={abs(ts).max():.3e}")
+
+    # Interstory envelope — uses Z-coordinate sorting internally
+    env = nr.interstory_drift_envelope(
+        component=1, node_ids=NODE_IDS, dz_tol=1e-3,
+    )
+    print(f"interstory_drift_envelope:  {len(env)} story pair(s)")
+    print(f"  columns: {list(env.columns)}")
+    print(env.to_string())
+
+    # Residual drift at the end of the record
+    resid = nr.residual_drift(top=4, bottom=1, component=1, tail=3, agg="mean")
+    print(f"residual_drift (mean of last 3 steps): {resid:.3e}")
+
+    # Orbit — displacement trajectory for a single node
+    sx, sy = nr.orbit(node_ids=1, x_component=1, y_component=2)
+    print(f"orbit(node=1, x=1, y=2):    x-length={len(sx)}, y-length={len(sy)}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Plotting
+# ---------------------------------------------------------------------------
+def section_4_plotting(ds: MPCODataSet, nr: NodalResults) -> None:
+    section("4. Plotting")
+
+    # Per-result XY plot
+    ax, meta = nr.plot.xy(
+        y_results_name="DISPLACEMENT",
+        y_direction=1,
+        y_operation="Max",
+        x_results_name="TIME",
+    )
+    print(f"nr.plot.xy -> ax={ax}, meta keys={list(meta.keys())}")
+    plt.close("all")
+
+    # Dataset-level one-shot plot
+    ax, meta = ds.plot.xy(
+        model_stage=STAGE,
+        results_name="DISPLACEMENT",
+        node_ids=NODE_IDS,
+        y_direction=1,
+        y_operation="Max",
+        x_results_name="TIME",
+    )
+    print(f"ds.plot.xy -> ax={ax}, meta keys={list(meta.keys())}")
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# 5. NodalResults pickle round-trip
+# ---------------------------------------------------------------------------
+def section_5_pickle_nodal(nr: NodalResults) -> None:
+    section("5. NodalResults pickle round-trip")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "nr.pkl"
+        nr.save_pickle(path)
+        loaded = NodalResults.load_pickle(path)
+        print(f"saved:  {path.stat().st_size} bytes")
+        print(f"loaded: {loaded!r}")
+        print(f"shapes match: {loaded.df.shape == nr.df.shape}")
+
+
+# ---------------------------------------------------------------------------
+# 6. Fetch beam `force` results (closed-form)
+# ---------------------------------------------------------------------------
+def section_6_fetch_element(ds: MPCODataSet) -> ElementResults:
+    section("6. Fetch ElementResults — force (closed-form ElasticBeam3d)")
+
+    er = ds.elements.get_element_results(
+        results_name="force",
+        element_type="5-ElasticBeam3d",
+        model_stage=STAGE,
+        element_ids=ELEMENT_IDS,
+    )
+    print(repr(er))
+    print(f"df.shape:          {er.df.shape}")
+    print(f"df.index.names:    {list(er.df.index.names)}")
+    print(f"list_components(): {er.list_components()}")
+    print(f"n_elements:        {er.n_elements}")
+    print(f"n_steps:           {er.n_steps}")
+    print(f"n_components:      {er.n_components}")
+    print(f"gp_xi:             {er.gp_xi}  (None = closed-form, no IPs)")
+    return er
+
+
+# ---------------------------------------------------------------------------
+# 7. ElementResults broker API
+# ---------------------------------------------------------------------------
+def section_7_element_broker(er: ElementResults) -> None:
+    section("7. ElementResults broker API")
+
+    # fetch() — explicit component + element filter
+    sub = er.fetch(component="Pz_1", element_ids=[1, 2])
+    print(f"fetch('Pz_1', [1,2]):   Series length {len(sub)}")
+
+    # Dynamic attribute access
+    view = er.Pz_1[[1, 2]]
+    print(f"er.Pz_1[[1,2]]:         type={type(view).__name__}")
+
+    # Envelope over all elements and all steps
+    env = er.envelope(component="Pz_1")
+    print(f"envelope('Pz_1'):       columns={list(env.columns)}")
+    print(env)
+
+    # Step snapshot
+    snap = er.at_step(5)
+    print(f"\nat_step(5):  shape={snap.shape}")
+
+    # Time snapshot (nearest recorded step to t=0.5)
+    snap_t = er.at_time(0.5)
+    print(f"at_time(0.5): shape={snap_t.shape}")
+
+    # Flat DataFrame with time column included
+    flat = er.to_dataframe(include_time=True)
+    print(f"to_dataframe(): first 5 cols={list(flat.columns)[:5]}, "
+          f"total={len(flat.columns)}")
+
+
+# ---------------------------------------------------------------------------
+# 8. Canonical engineering names
+# ---------------------------------------------------------------------------
+def section_8_canonical_names(ds: MPCODataSet) -> None:
+    section("8. Canonical engineering names")
+
+    er = ds.elements.get_element_results(
+        results_name="localForce",
+        element_type="5-ElasticBeam3d",
+        model_stage=STAGE,
+        element_ids=ELEMENT_IDS,
+    )
+    print(f"localForce columns:    {er.list_components()}")
+    print(f"list_canonicals():     {er.list_canonicals()}")
+
+    # Per-canonical column mapping
+    for canon in er.list_canonicals():
+        cols = er.canonical_columns(canon)
+        print(f"  {canon!r:30s} -> {cols}")
+
+    # Full DataFrame for a canonical quantity
+    first_canon = er.list_canonicals()[0]
+    df = er.canonical(first_canon)
+    print(f"\ncanonical({first_canon!r}) shape: {df.shape}")
+    print(df.head(3))
+
+    # closed-form → integrate_canonical raises (no gp_weights)
+    try:
+        er.integrate_canonical("axial_force")
+    except ValueError as exc:
+        print(f"\nintegrate_canonical on closed-form raises: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# 9. ElementResults pickle round-trip
+# ---------------------------------------------------------------------------
+def section_9_pickle_element(er: ElementResults) -> None:
+    section("9. ElementResults pickle round-trip")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "er.pkl"
+        er.save_pickle(path)
+        loaded = ElementResults.load_pickle(path)
+        print(f"saved:  {path.stat().st_size} bytes")
+        print(f"loaded: {loaded!r}")
+        print(f"shapes match: {loaded.df.shape == er.df.shape}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def main() -> None:
+    if not (DATASET_DIR / "results.mpco").exists():
+        raise FileNotFoundError(
+            f"elasticFrame fixture not found at {DATASET_DIR}.\n"
+            "Check that stko_results_examples/ is present in the repo root."
+        )
+
+    ds = MPCODataSet(str(DATASET_DIR), RECORDER, verbose=False)
+
+    section_1_introspect(ds)
+    nr = section_2_fetch_nodal(ds)
+    section_3_aggregations(nr)
+    section_4_plotting(ds, nr)
+    section_5_pickle_nodal(nr)
+    er = section_6_fetch_element(ds)
+    section_7_element_broker(er)
+    section_8_canonical_names(ds)
+    section_9_pickle_element(er)
+
+    print()
+    print("elastic_frame_example complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quad_frame_shell_example.py
+++ b/examples/quad_frame_shell_example.py
@@ -1,0 +1,285 @@
+"""Quad-frame shell example — multi-partition ASDShellQ4 fixture.
+
+Demonstrates multi-partition datasets and Gauss-point integration
+against the checked-in ``stko_results_examples/elasticFrame/QuadFrame_results``
+fixture (two .part-N.mpco files, ``203-ASDShellQ4`` shell elements).
+
+    1.  Multi-partition dataset construction and introspection.
+    2.  Discovering shell element IDs from the element index.
+    3.  Shell ``section.force`` — 4 Gauss points, gp_natural (4, 2).
+    4.  Canonical names for shell section forces (membrane, bending,
+        transverse shear).
+    5.  ``at_ip()`` — per-Gauss-point DataFrame slice.
+    6.  ``physical_coords()`` — IP physical positions in 3-D space.
+    7.  ``jacobian_dets()`` — surface Jacobian for each IP.
+    8.  Element area computation via numerical quadrature.
+    9.  ``integrate_canonical("membrane_xx")`` — surface-integrated
+        axial membrane force per element per step.
+   10.  ElementResults pickle round-trip (gp_natural survives).
+
+Run with::
+
+    python examples/quad_frame_shell_example.py
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.elements.element_results import ElementResults
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATASET_DIR = (
+    REPO_ROOT / "stko_results_examples" / "elasticFrame" / "QuadFrame_results"
+)
+RECORDER = "results"
+STAGE = "MODEL_STAGE[1]"
+N_SHELL_ELEMENTS = 5  # number of shells to fetch for the demo
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 70)
+    print(f"  {title}")
+    print("=" * 70)
+
+
+# ---------------------------------------------------------------------------
+# 1. Dataset construction and introspection
+# ---------------------------------------------------------------------------
+def section_1_introspect(ds: MPCODataSet) -> None:
+    section("1. Multi-partition dataset introspection")
+
+    print(f"model_stages:          {ds.model_stages}")
+    print(f"node_results_names:    {ds.node_results_names}")
+    print(f"element_results_names: {ds.element_results_names}")
+    print(f"unique_element_types:  {ds.unique_element_types}")
+    print(f"total elements:        {len(ds.elements_info['dataframe'])}")
+    print(f"total nodes:           {len(ds.nodes_info['dataframe'])}")
+
+    # Because there are two partition files (part-0 and part-1), the library
+    # merges them transparently. The user never needs to know about partitions.
+    avail = ds.elements.get_available_element_results()
+    print("\nAvailable element results by partition:")
+    for part_id, mapping in avail.items():
+        for rname, types in mapping.items():
+            print(f"  partition {part_id}: {rname!r} -> {types}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Discover shell element IDs
+# ---------------------------------------------------------------------------
+def _get_shell_ids(ds: MPCODataSet, n: int) -> list[int]:
+    df = ds.elements_info["dataframe"]
+    ids = (
+        df.query("element_type == '203-ASDShellQ4'")["element_id"]
+        .head(n)
+        .tolist()
+    )
+    return [int(i) for i in ids]
+
+
+def section_2_discover_elements(ds: MPCODataSet) -> list[int]:
+    section("2. Discovering shell element IDs from the element index")
+
+    df = ds.elements_info["dataframe"]
+    shell_count = (df["element_type"] == "203-ASDShellQ4").sum()
+    print(f"Total 203-ASDShellQ4 elements: {shell_count}")
+
+    shell_ids = _get_shell_ids(ds, N_SHELL_ELEMENTS)
+    print(f"Using first {N_SHELL_ELEMENTS} IDs for demos: {shell_ids}")
+    return shell_ids
+
+
+# ---------------------------------------------------------------------------
+# 3. Fetch shell section.force with 4 Gauss points
+# ---------------------------------------------------------------------------
+def section_3_fetch_section_force(
+    ds: MPCODataSet, shell_ids: list[int]
+) -> ElementResults:
+    section("3. Shell section.force — 4-IP Gauss-level bucket")
+
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        model_stage=STAGE,
+        element_ids=shell_ids,
+    )
+    print(repr(er))
+    print(f"df.shape:              {er.df.shape}")
+    print(f"n_elements={er.n_elements}, n_steps={er.n_steps}, "
+          f"n_components={er.n_components}")
+    print(f"n_ip:                  {er.n_ip}")
+    print(f"gp_xi:                 {er.gp_xi}  (None for 2-D shells)")
+    print(f"gp_natural.shape:      {er.gp_natural.shape}")
+    print(f"gp_natural (2x2 Gauss-Legendre in xi-eta):\n{er.gp_natural}")
+    print(f"gp_weights:            {er.gp_weights}  (sum={er.gp_weights.sum():.3f})")
+    print(f"list_components():     {er.list_components()}")
+    return er
+
+
+# ---------------------------------------------------------------------------
+# 4. Canonical names for shell section forces
+# ---------------------------------------------------------------------------
+def section_4_canonical_names(er: ElementResults) -> None:
+    section("4. Canonical engineering names (shell section forces)")
+
+    print(f"list_canonicals(): {er.list_canonicals()}")
+    for canon in er.list_canonicals():
+        cols = er.canonical_columns(canon)
+        print(f"  {canon!r:30s} -> {cols}")
+
+    # Pull a full DataFrame for membrane_xx across all elements and steps
+    df_mxx = er.canonical("membrane_xx")
+    print(f"\ncanonical('membrane_xx') shape: {df_mxx.shape}")
+    print(f"columns: {list(df_mxx.columns)}")
+    print(df_mxx.head(3))
+
+
+# ---------------------------------------------------------------------------
+# 5. Per-IP slicing via at_ip()
+# ---------------------------------------------------------------------------
+def section_5_at_ip(er: ElementResults) -> None:
+    section("5. Per-Gauss-point slicing — at_ip()")
+
+    for ip in range(er.n_ip):
+        sub = er.at_ip(ip)
+        print(f"at_ip({ip}): shape={sub.shape}, columns={list(sub.columns)}")
+
+    # Detailed look at IP 0 for the first element
+    sub0 = er.at_ip(0)
+    eid = er.element_ids[0]
+    print(f"\nIP 0 data for element {eid} (first 3 steps):")
+    print(sub0.xs(eid, level="element_id").head(3))
+
+
+# ---------------------------------------------------------------------------
+# 6. Physical coordinates of Gauss points
+# ---------------------------------------------------------------------------
+def section_6_physical_coords(er: ElementResults) -> None:
+    section("6. physical_coords() — IP physical positions in 3-D space")
+
+    phys = er.physical_coords()   # (n_e, 4, 3)
+    print(f"physical_coords() shape: {phys.shape}")
+
+    # Verify each IP lies inside its element's node bounding box
+    all_inside = True
+    for i, eid in enumerate(er.element_ids):
+        nc = er.element_node_coords[i]   # (4 nodes, 3)
+        lo = nc.min(axis=0) - 1e-9
+        hi = nc.max(axis=0) + 1e-9
+        for ip_xyz in phys[i]:
+            if not (np.all(ip_xyz >= lo) and np.all(ip_xyz <= hi)):
+                all_inside = False
+    print(f"All IPs inside their element bounding box: {all_inside}")
+
+    # Show physical coords for the first element
+    eid = er.element_ids[0]
+    print(f"\nElement {eid} node coords:\n{er.element_node_coords[0]}")
+    print(f"Element {eid} Gauss-point physical coords:\n{phys[0]}")
+
+
+# ---------------------------------------------------------------------------
+# 7. Jacobian determinants (surface Jacobian)
+# ---------------------------------------------------------------------------
+def section_7_jacobian_dets(er: ElementResults) -> None:
+    section("7. jacobian_dets() — surface Jacobian determinant per IP")
+
+    dets = er.jacobian_dets()   # (n_e, 4)
+    print(f"jacobian_dets() shape: {dets.shape}")
+    print(f"All dets positive: {np.all(dets > 0)}")
+
+    # Compute element areas via quadrature: A = Σ w_i * |J_i|
+    areas = (er.gp_weights[np.newaxis, :] * dets).sum(axis=1)  # (n_e,)
+    print(f"\nElement areas (from quadrature):")
+    for eid, area in zip(er.element_ids, areas):
+        print(f"  element {eid:4d}: area = {area:.6f}")
+
+
+# ---------------------------------------------------------------------------
+# 8. Surface-integrated membrane force
+# ---------------------------------------------------------------------------
+def section_8_integrate_canonical(er: ElementResults) -> None:
+    section("8. integrate_canonical('membrane_xx') — surface resultant")
+
+    s = er.integrate_canonical("membrane_xx")
+    print(f"integrate_canonical series: shape={s.shape}, name={s.name!r}")
+    print(f"Index names: {list(s.index.names)}")
+
+    # Reshape to (n_steps, n_elements) matrix
+    mtx = s.unstack("element_id")
+    print(f"\nStep × element matrix shape: {mtx.shape}")
+    print(f"(rows = time steps, columns = element IDs)")
+    print(mtx.head(4).to_string())
+
+    # Manual verification for one element at step 1
+    cols = list(er.canonical_columns("membrane_xx"))
+    dets = er.jacobian_dets()
+    eid = er.element_ids[0]
+    step = 1
+    eid_idx = er.element_ids.index(eid)
+    sigma = er.df.xs((eid, step))[cols].to_numpy(dtype=np.float64)
+    manual = float((sigma * er.gp_weights * dets[eid_idx]).sum())
+    helper = float(s.loc[eid, step])
+    match = abs(manual - helper) < 1e-12 * max(abs(manual), 1e-12)
+    print(f"\nManual verification (element {eid}, step {step}):")
+    print(f"  manual = {manual:.6e}, integrate_canonical = {helper:.6e}")
+    print(f"  Match: {match}")
+
+
+# ---------------------------------------------------------------------------
+# 9. Pickle round-trip — gp_natural survives
+# ---------------------------------------------------------------------------
+def section_9_pickle(er: ElementResults) -> None:
+    section("9. ElementResults pickle round-trip (gp_natural survives)")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "shell_er.pkl"
+        er.save_pickle(path)
+        loaded = ElementResults.load_pickle(path)
+        print(f"saved: {path.stat().st_size} bytes")
+        print(f"loaded: {loaded!r}")
+        print(f"df match:             {loaded.df.shape == er.df.shape}")
+        print(f"gp_natural preserved: "
+              f"{np.allclose(loaded.gp_natural, er.gp_natural)}")
+        print(f"gp_weights preserved: "
+              f"{np.allclose(loaded.gp_weights, er.gp_weights)}")
+        # integrate_canonical still works after reload
+        s_after = loaded.integrate_canonical("membrane_xx")
+        print(f"integrate_canonical after pickle: shape={s_after.shape}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def main() -> None:
+    if not (DATASET_DIR / "results.part-0.mpco").exists():
+        raise FileNotFoundError(
+            f"QuadFrame fixture not found at {DATASET_DIR}.\n"
+            "Check that stko_results_examples/ is present in the repo root."
+        )
+
+    ds = MPCODataSet(str(DATASET_DIR), RECORDER, verbose=False)
+
+    section_1_introspect(ds)
+    shell_ids = section_2_discover_elements(ds)
+    er = section_3_fetch_section_force(ds, shell_ids)
+    section_4_canonical_names(er)
+    section_5_at_ip(er)
+    section_6_physical_coords(er)
+    section_7_jacobian_dets(er)
+    section_8_integrate_canonical(er)
+    section_9_pickle(er)
+
+    print()
+    print("quad_frame_shell_example complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/solid_mixed_example.py
+++ b/examples/solid_mixed_example.py
@@ -1,0 +1,383 @@
+"""Solid + fiber beam example — mixed-element multi-partition fixture.
+
+Demonstrates the full integration-point API against the checked-in
+``stko_results_examples/solid_partition_example`` fixture:
+
+    Two-partition dataset containing:
+    * ``56-Brick`` — 8-node hexahedral continuum, 8 Gauss points (3-D).
+    * ``64-DispBeamColumn3d`` — displacement-based beam, 2 integration
+      stations (Lobatto end-points), with compressed fiber sections.
+
+Sections:
+
+    1.  Dataset construction and element discovery.
+    2.  Brick ``material.stress`` — 8 Gauss points, gp_natural (8, 3).
+    3.  ``at_ip()`` on Brick — per-IP stress slice.
+    4.  ``physical_coords()`` on Brick — IP positions inside element bbox.
+    5.  ``jacobian_dets()`` and element volume via quadrature.
+    6.  ``integrate_canonical("stress_11")`` — volume-integrated σ₁₁.
+    7.  Beam ``section.force`` — 2-IP line-station, gp_xi at ±1.
+    8.  Beam fiber section — ``section.fiber.stress``, 6 fibers × 2 IPs.
+    9.  ``at_ip()`` on fiber result — all 6 fibers at one station.
+   10.  Why ``integrate_canonical`` is not available for fiber buckets.
+   11.  ElementResults pickle round-trip.
+
+Run with::
+
+    python examples/solid_mixed_example.py
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.elements.element_results import ElementResults
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATASET_DIR = REPO_ROOT / "stko_results_examples" / "solid_partition_example"
+RECORDER = "Recorder"
+STAGE = "MODEL_STAGE[1]"
+N_BRICK = 3     # number of Brick elements to fetch
+N_BEAM = 2      # number of DispBeamColumn3d elements to fetch
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 70)
+    print(f"  {title}")
+    print("=" * 70)
+
+
+# ---------------------------------------------------------------------------
+# 1. Dataset construction and element discovery
+# ---------------------------------------------------------------------------
+def section_1_introspect(ds: MPCODataSet) -> tuple[list[int], list[int]]:
+    section("1. Dataset construction and element discovery")
+
+    print(f"model_stages:          {ds.model_stages}")
+    print(f"element_results_names: {ds.element_results_names}")
+    print(f"unique_element_types:  {ds.unique_element_types}")
+
+    df = ds.elements_info["dataframe"]
+    brick_count = (df["element_type"] == "56-Brick").sum()
+    beam_count = (df["element_type"] == "64-DispBeamColumn3d").sum()
+    print(f"56-Brick elements:              {brick_count}")
+    print(f"64-DispBeamColumn3d elements:   {beam_count}")
+
+    brick_ids = [int(i) for i in df.query("element_type == '56-Brick'")
+                 ["element_id"].head(N_BRICK).tolist()]
+    beam_ids = [int(i) for i in df.query("element_type == '64-DispBeamColumn3d'")
+                ["element_id"].head(N_BEAM).tolist()]
+    print(f"Brick IDs for demos:  {brick_ids}")
+    print(f"Beam IDs for demos:   {beam_ids}")
+
+    avail = ds.elements.get_available_element_results()
+    print("\nAvailable element results by partition:")
+    for part_id, mapping in avail.items():
+        for rname, types in mapping.items():
+            print(f"  partition {part_id}: {rname!r} -> {types}")
+
+    return brick_ids, beam_ids
+
+
+# ---------------------------------------------------------------------------
+# 2. Brick material.stress — 8 Gauss points
+# ---------------------------------------------------------------------------
+def section_2_brick_stress(ds: MPCODataSet, brick_ids: list[int]) -> ElementResults:
+    section("2. Brick material.stress - 8 Gauss points, gp_natural (8, 3)")
+
+    er = ds.elements.get_element_results(
+        results_name="material.stress",
+        element_type="56-Brick",
+        model_stage=STAGE,
+        element_ids=brick_ids,
+    )
+    print(repr(er))
+    print(f"df.shape:           {er.df.shape}")
+    print(f"n_ip:               {er.n_ip}")
+    print(f"gp_dim:             {er.gp_dim}")
+    print(f"gp_xi:              {er.gp_xi}  (None - multi-D, no 1-D xi)")
+    print(f"gp_natural.shape:   {er.gp_natural.shape}")
+    print(f"gp_natural (8 Gauss-Legendre pts in xi-eta-zeta):")
+    print(er.gp_natural)
+    print(f"\ngp_weights:         {er.gp_weights}")
+    print(f"gp_weights.sum():   {er.gp_weights.sum():.3f}  (= 8 for [-1,1]^3)")
+
+    # Standard 2x2x2 Gauss-Legendre rule: all coords are +-1/sqrt(3)
+    expected_coords = 1.0 / np.sqrt(3.0)
+    print(f"\nAll |gp_natural| approx 1/sqrt(3) ({expected_coords:.6f}): "
+          f"{np.allclose(np.abs(er.gp_natural), expected_coords)}")
+    print(f"list_canonicals():  {er.list_canonicals()}")
+    return er
+
+
+# ---------------------------------------------------------------------------
+# 3. at_ip() — per-Gauss-point stress slice
+# ---------------------------------------------------------------------------
+def section_3_at_ip_brick(er: ElementResults) -> None:
+    section("3. at_ip() on Brick - per-IP stress slice")
+
+    # Show column layout for IP 0 and IP 7
+    sub0 = er.at_ip(0)
+    sub7 = er.at_ip(7)
+    print(f"at_ip(0) columns: {list(sub0.columns)}")
+    print(f"at_ip(7) columns: {list(sub7.columns)}")
+    print(f"at_ip(0) shape:   {sub0.shape}")
+
+    # Examine stress at Gauss point 0 for the first element
+    eid = er.element_ids[0]
+    step = 1
+    print(f"\nsigma_11 at each Gauss point for element {eid}, step {step}:")
+    for ip in range(er.n_ip):
+        sub = er.at_ip(ip)
+        col = [c for c in sub.columns if "sigma11" in c]
+        if col:
+            val = float(sub.loc[(eid, step), col[0]])
+            print(f"  IP {ip}: sigma_11 = {val:.4e}")
+
+
+# ---------------------------------------------------------------------------
+# 4. physical_coords() — IP positions in physical space
+# ---------------------------------------------------------------------------
+def section_4_physical_coords(er: ElementResults) -> None:
+    section("4. physical_coords() - Gauss-point physical positions")
+
+    phys = er.physical_coords()    # (n_e, 8, 3)
+    print(f"physical_coords() shape: {phys.shape}")
+
+    # Verify all IPs lie inside the element bounding box
+    all_inside = True
+    for i, eid in enumerate(er.element_ids):
+        nc = er.element_node_coords[i]   # (8 nodes, 3) for Brick
+        lo = nc.min(axis=0) - 1e-9
+        hi = nc.max(axis=0) + 1e-9
+        for ip_xyz in phys[i]:
+            if not (np.all(ip_xyz >= lo) and np.all(ip_xyz <= hi)):
+                all_inside = False
+    print(f"All IPs inside element bounding box: {all_inside}")
+
+    eid = er.element_ids[0]
+    print(f"\nElement {eid} node bounding box:")
+    nc = er.element_node_coords[0]
+    print(f"  x: [{nc[:, 0].min():.4f}, {nc[:, 0].max():.4f}]")
+    print(f"  y: [{nc[:, 1].min():.4f}, {nc[:, 1].max():.4f}]")
+    print(f"  z: [{nc[:, 2].min():.4f}, {nc[:, 2].max():.4f}]")
+    print(f"Element {eid} Gauss-point physical coords:\n{phys[0]}")
+
+
+# ---------------------------------------------------------------------------
+# 5. jacobian_dets() and element volume
+# ---------------------------------------------------------------------------
+def section_5_volumes(er: ElementResults) -> None:
+    section("5. jacobian_dets() - element volume via numerical quadrature")
+
+    dets = er.jacobian_dets()   # (n_e, 8)
+    print(f"jacobian_dets() shape: {dets.shape}")
+    print(f"All determinants positive: {np.all(dets > 0)}")
+
+    # V = sum(w_i * |J_i|) - integrates the constant function 1 over the element
+    vols = (er.gp_weights[np.newaxis, :] * dets).sum(axis=1)  # (n_e,)
+    print(f"\nElement volumes (from quadrature):")
+    for eid, vol in zip(er.element_ids, vols):
+        # Cross-check with bounding box (exact for axis-aligned bricks)
+        i = er.element_ids.index(eid)
+        nc = er.element_node_coords[i]
+        bbox_vol = float(
+            (nc[:, 0].max() - nc[:, 0].min())
+            * (nc[:, 1].max() - nc[:, 1].min())
+            * (nc[:, 2].max() - nc[:, 2].min())
+        )
+        print(f"  element {eid:4d}: V_quadrature={vol:.6f}, V_bbox={bbox_vol:.6f}")
+
+
+# ---------------------------------------------------------------------------
+# 6. integrate_canonical("stress_11") — volume-integrated σ₁₁
+# ---------------------------------------------------------------------------
+def section_6_integrate_canonical(er: ElementResults) -> None:
+    section("6. integrate_canonical('stress_11') — sum sigma_11 * w * |J| over IPs")
+
+    s = er.integrate_canonical("stress_11")
+    print(f"Series shape: {s.shape}, name: {s.name!r}")
+    print(f"Index names:  {list(s.index.names)}")
+
+    # Reshape to (n_steps, n_elements) for easy inspection
+    mtx = s.unstack("element_id")
+    print("\nStep x element matrix:")
+    print(mtx.to_string())
+
+    # Manual verification for element[0], step 1
+    cols = list(er.canonical_columns("stress_11"))
+    dets = er.jacobian_dets()
+    eid = er.element_ids[0]
+    step = 1
+    eid_idx = er.element_ids.index(eid)
+    sigma = er.df.xs((eid, step))[cols].to_numpy(dtype=np.float64)
+    manual = float((sigma * er.gp_weights * dets[eid_idx]).sum())
+    helper = float(s.loc[eid, step])
+    print(f"\nManual check (element {eid}, step {step}):")
+    print(f"  sum sigma_11 * w * |J| = {manual:.6e}")
+    print(f"  integrate_canonical = {helper:.6e}")
+    print(f"  Match: {abs(manual - helper) < 1e-12 * max(abs(manual), 1e-12)}")
+
+
+# ---------------------------------------------------------------------------
+# 7. Beam section.force — 2-IP line-station
+# ---------------------------------------------------------------------------
+def section_7_beam_section_force(
+    ds: MPCODataSet, beam_ids: list[int]
+) -> ElementResults:
+    section("7. Beam section.force - 2-IP line-station (gp_xi at +-1)")
+
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="64-DispBeamColumn3d",
+        model_stage=STAGE,
+        element_ids=beam_ids,
+    )
+    print(repr(er))
+    print(f"n_ip:               {er.n_ip}")
+    print(f"gp_xi:              {er.gp_xi}")
+    print(f"  (Lobatto end-points: xi=-1 is node i, xi=+1 is node j)")
+    print(f"gp_natural:         {er.gp_natural}  (None for line elements)")
+    print(f"gp_weights:         {er.gp_weights}  (None for custom-rule beams)")
+    print(f"list_components():  {er.list_components()}")
+    print(f"list_canonicals():  {er.list_canonicals()}")
+
+    # at_ip() slices by integration station
+    sub_i = er.at_ip(0)   # section forces at node i end
+    sub_j = er.at_ip(1)   # section forces at node j end
+    print(f"\nat_ip(0) columns: {list(sub_i.columns)}")
+    print(f"at_ip(1) columns: {list(sub_j.columns)}")
+
+    eid = beam_ids[0]
+    step = 1
+    print(f"\nAxial force P at element {eid}, step {step}:")
+    print(f"  node-i end (IP 0): {float(sub_i.loc[(eid, step), 'P_ip0']):.4e}")
+    print(f"  node-j end (IP 1): {float(sub_j.loc[(eid, step), 'P_ip1']):.4e}")
+    return er
+
+
+# ---------------------------------------------------------------------------
+# 8. Beam section.fiber.stress — 6 fibers × 2 integration stations
+# ---------------------------------------------------------------------------
+def section_8_fiber_stress(ds: MPCODataSet, beam_ids: list[int]) -> ElementResults:
+    section("8. section.fiber.stress - compressed fiber bucket (6 fibers x 2 IPs)")
+
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        model_stage=STAGE,
+        element_ids=beam_ids,
+    )
+    print(repr(er))
+    print(f"df.shape:          {er.df.shape}")
+    print(f"n_ip:              {er.n_ip}")
+    print(f"gp_xi:             {er.gp_xi}")
+    print(f"list_components(): {er.list_components()}")
+    print(f"  Column naming:   sigma11_f<fiber>_ip<station>")
+    print(f"  6 fibers x 2 stations = {er.n_components} columns total")
+    return er
+
+
+# ---------------------------------------------------------------------------
+# 9. at_ip() on fiber result — all fibers at one station
+# ---------------------------------------------------------------------------
+def section_9_at_ip_fiber(er: ElementResults) -> None:
+    section("9. at_ip() on fiber result — all fibers at station 0 (xi=-1)")
+
+    sub0 = er.at_ip(0)   # all 6 fibers at node-i end
+    sub1 = er.at_ip(1)   # all 6 fibers at node-j end
+    print(f"at_ip(0) shape:   {sub0.shape}  (n_el x n_steps, 6 fibers)")
+    print(f"at_ip(0) columns: {list(sub0.columns)}")
+    print(f"at_ip(1) columns: {list(sub1.columns)}")
+
+    # Show fiber stresses at station 0 for the first element, step 1
+    eid = er.element_ids[0]
+    step = 1
+    fiber_vals = sub0.loc[(eid, step)]
+    print(f"\nFiber stresses at xi=-1 (IP 0), element {eid}, step {step}:")
+    for col, val in fiber_vals.items():
+        print(f"  {col}: {float(val):.4e}")
+
+
+# ---------------------------------------------------------------------------
+# 10. Why integrate_canonical is not available for fiber buckets
+# ---------------------------------------------------------------------------
+def section_10_fiber_integrate_raises(er: ElementResults) -> None:
+    section("10. integrate_canonical - not available for fiber buckets")
+
+    print("Fiber buckets have gp_weights=None (custom rule, no standard weights).")
+    print("integrate_canonical raises ValueError to explain this clearly.\n")
+    try:
+        er.integrate_canonical("stress_11")
+    except ValueError as exc:
+        print(f"ValueError: {exc}")
+    print(
+        "\nFor manual fiber integration, iterate over at_ip(k) and apply"
+        " your own fiber-area weights:\n"
+        "    sub_ip0 = er.at_ip(0)\n"
+        "    # fiber_areas is a (6,) array you provide\n"
+        "    result = (sub_ip0.to_numpy() * fiber_areas[None, :]).sum(axis=1)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. Pickle round-trip
+# ---------------------------------------------------------------------------
+def section_11_pickle(er_brick: ElementResults) -> None:
+    section("11. ElementResults pickle round-trip")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "brick.pkl"
+        er_brick.save_pickle(path)
+        loaded = ElementResults.load_pickle(path)
+        print(f"saved: {path.stat().st_size} bytes")
+        print(f"loaded: {loaded!r}")
+        print(f"df match:             {loaded.df.shape == er_brick.df.shape}")
+        print(f"gp_natural preserved: "
+              f"{np.allclose(loaded.gp_natural, er_brick.gp_natural)}")
+        print(f"gp_weights preserved: "
+              f"{np.allclose(loaded.gp_weights, er_brick.gp_weights)}")
+        print(f"element_node_coords preserved: "
+              f"{np.allclose(loaded.element_node_coords, er_brick.element_node_coords)}")
+        # integrate_canonical still works after reload
+        s = loaded.integrate_canonical("stress_11")
+        print(f"integrate_canonical after pickle: shape={s.shape}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def main() -> None:
+    if not (DATASET_DIR / "Recorder.part-0.mpco").exists():
+        raise FileNotFoundError(
+            f"solid_partition fixture not found at {DATASET_DIR}.\n"
+            "Check that stko_results_examples/ is present in the repo root."
+        )
+
+    ds = MPCODataSet(str(DATASET_DIR), RECORDER, verbose=False)
+
+    brick_ids, beam_ids = section_1_introspect(ds)
+    er_brick = section_2_brick_stress(ds, brick_ids)
+    section_3_at_ip_brick(er_brick)
+    section_4_physical_coords(er_brick)
+    section_5_volumes(er_brick)
+    section_6_integrate_canonical(er_brick)
+    section_7_beam_section_force(ds, beam_ids)
+    er_fiber = section_8_fiber_stress(ds, beam_ids)
+    section_9_at_ip_fiber(er_fiber)
+    section_10_fiber_integrate_raises(er_fiber)
+    section_11_pickle(er_brick)
+
+    print()
+    print("solid_mixed_example complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds three runnable demo scripts — one per checked-in fixture — each focused on the capabilities unique to that element family:

- **`examples/elastic_frame_example.py`** — `elasticFrame/results` (single partition, `5-ElasticBeam3d`): nodal results, drift/envelope/orbit aggregations, closed-form beam force/localForce, canonical names, XY plotting, pickle round-trip.

- **`examples/quad_frame_shell_example.py`** — `elasticFrame/QuadFrame_results` (two partitions, `203-ASDShellQ4`): multi-partition introspection, shell `section.force` with 4 Gauss points (`gp_natural` (4,2)), canonical names (`membrane_xx`, `bending_moment_xx`, …), `at_ip()`, `physical_coords()`, `jacobian_dets()`, element area via quadrature, `integrate_canonical()`, pickle.

- **`examples/solid_mixed_example.py`** — `solid_partition_example` (two partitions, `56-Brick` + `64-DispBeamColumn3d`): `material.stress` (8 Gauss points, `gp_natural` (8,3)), `at_ip()` on solid continuum, physical coords + volume via quadrature, `integrate_canonical("stress_11")`, beam `section.force` (`gp_xi` at ±1), `section.fiber.stress` (6 fibers × 2 IPs), `at_ip()` on fiber result, explanation of why fiber buckets can't use `integrate_canonical`.

## Test plan

- [x] `python examples/elastic_frame_example.py` runs to completion
- [x] `python examples/quad_frame_shell_example.py` runs to completion
- [x] `python examples/solid_mixed_example.py` runs to completion (verified against main repo fixture)
- [x] All sections produce correct output (shapes, canonical mappings, quadrature values verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)