### PR TITLE
Add ElementResults API reference and Examples nav section

### DIFF
--- a/docs/api/element-results.md
+++ b/docs/api/element-results.md
@@ -1,0 +1,296 @@
+# ElementResults
+
+Self-contained container for element-level results extracted from an
+MPCO HDF5 file. Once created via `ds.elements.get_element_results()`,
+it carries its data, time array, Gauss-point geometry, and node
+coordinates entirely within the object — independent of the original
+dataset. It can be pickled and reloaded without re-opening the HDF5
+files.
+
+---
+
+## Construction
+
+```python
+from STKO_to_python import MPCODataSet
+
+ds = MPCODataSet(r"C:\path\to\results", "results")
+
+er = ds.elements.get_element_results(
+    results_name="section.force",      # HDF5 group name
+    element_type="203-ASDShellQ4",     # base element class
+    model_stage="MODEL_STAGE[1]",      # omit → first stage
+    element_ids=[101, 102, 103],       # explicit IDs, or…
+    # selection_set_name="ShearWall",  # …named selection set
+    # selection_set_id=7,              # …selection set by index
+)
+```
+
+All three selection modes may be combined (their results are unioned).
+
+---
+
+## Key attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `er.df` | `pd.DataFrame` | MultiIndex `(element_id, step)` × component columns |
+| `er.time` | `np.ndarray` | Time value for each step |
+| `er.element_ids` | `tuple[int, ...]` | Element IDs in this result set |
+| `er.element_type` | `str` | Base element class (e.g. `"203-ASDShellQ4"`) |
+| `er.results_name` | `str` | HDF5 result group name (e.g. `"section.force"`) |
+| `er.model_stage` | `str` | Model stage name |
+| `er.n_elements` | `int` | Number of elements |
+| `er.n_steps` | `int` | Number of recorded steps |
+| `er.n_components` | `int` | Number of columns in `df` |
+| `er.n_ip` | `int` | Integration-point count (0 for closed-form) |
+| `er.gp_xi` | `np.ndarray \| None` | 1-D natural coordinates ξ ∈ [-1,+1] (line elements with `GP_X` attribute only) |
+| `er.gp_natural` | `np.ndarray \| None` | Multi-D natural coordinates from static catalog, shape `(n_ip, gp_dim)` |
+| `er.gp_weights` | `np.ndarray \| None` | Quadrature weights, shape `(n_ip,)` (catalog-driven elements only) |
+| `er.gp_dim` | `int` | Spatial dimension of the parent domain (1/2/3) |
+| `er.element_node_coords` | `np.ndarray \| None` | Node coordinates per element, shape `(n_e, n_nodes, 3)` |
+| `er.plot` | `ElementResultsPlotter` | Bound plotting helper — see below |
+
+---
+
+## Introspection
+
+```python
+er.list_components()      # tuple of all column names
+er.list_canonicals()      # tuple of engineering canonical names
+er.n_elements             # int
+er.n_steps                # int
+er.empty                  # bool — True if df is empty
+```
+
+---
+
+## Fetching data
+
+```python
+# All components, all elements
+df = er.fetch()
+
+# Single component
+s = er.fetch("Mz_1")
+s = er.fetch("P_ip2", element_ids=[100, 101])
+
+# Attribute-style access
+s = er.Mz_1.series        # full column
+s = er.Mz_1[[100, 101]]  # filtered
+s = er.Mz_1[100]          # single element
+```
+
+---
+
+## Time snapshots
+
+```python
+df = er.at_step(100)        # all elements at step 100
+df = er.at_time(5.0)        # nearest step to t=5.0
+```
+
+---
+
+## Envelope
+
+```python
+env = er.envelope()              # all components → {col}_min, {col}_max per element
+env = er.envelope("Mz_1")       # single component
+```
+
+---
+
+## Integration-point slicing
+
+```python
+sub = er.at_ip(0)     # columns ending in _ip0 only
+sub = er.at_ip(3)     # columns ending in _ip3 only
+```
+
+Raises `ValueError` for closed-form buckets (`n_ip == 0`) or
+out-of-range indices.
+
+---
+
+## Canonical engineering names
+
+```python
+er.list_canonicals()
+# e.g. ('membrane_xx', 'membrane_yy', 'bending_moment_xx', ...)
+
+er.canonical_columns("membrane_xx")
+# ('Fxx_ip0', 'Fxx_ip1', 'Fxx_ip2', 'Fxx_ip3')
+
+df = er.canonical("bending_moment_z")
+```
+
+See [Canonical names](canonical-names.md) for the full map.
+
+---
+
+## Physical-space integration
+
+```python
+phys = er.physical_coords()   # (n_e, n_ip, 3) — physical (x,y,z) per IP
+dets = er.jacobian_dets()     # (n_e, n_ip) — |J| per IP
+
+# Volume/area/length integral of a canonical quantity per element
+s = er.integrate_canonical("stress_11")  # Series indexed (element_id, step)
+```
+
+`physical_coords()` and `jacobian_dets()` return `None` for closed-form
+buckets, when element class is not in the shape-function catalog, or
+when node coordinates weren't populated at fetch time.
+`integrate_canonical()` raises `ValueError` in those cases with a
+pointer to manual integration.
+
+---
+
+## Time-series statistics
+
+Per-element scalar summaries over the full step history:
+
+```python
+peaks = er.peak_abs()                    # all components — abs peak per element
+peaks = er.peak_abs(component="Mz_1")   # single component
+
+idx = er.time_of_peak("Mz_1")           # step index of abs peak (default)
+idx = er.time_of_peak("Mz_1", abs=False) # step index of signed peak
+
+ce = er.cumulative_envelope("N_1")
+# MultiIndex (element_id, step): N_1_running_min, N_1_running_max
+
+df_summary = er.summary()
+# One row per element: max, min, peak_abs, residual, mean
+```
+
+---
+
+## DataFrame export
+
+```python
+df_flat = er.to_dataframe(include_time=True)
+# Flat DataFrame with 'time' column appended
+```
+
+---
+
+## Pickle serialization
+
+```python
+er.save_pickle("wall_forces.pkl")
+er.save_pickle("wall_forces.pkl.gz")   # compressed
+
+from STKO_to_python.elements.element_results import ElementResults
+er = ElementResults.load_pickle("wall_forces.pkl")
+er = ElementResults.load_pickle("wall_forces.pkl.gz")
+```
+
+Compression is auto-detected from the `.gz` extension. All geometry
+arrays (`element_node_coords`, `gp_natural`, `gp_weights`, `gp_xi`)
+survive the round-trip, so `physical_coords()`, `jacobian_dets()`, and
+`integrate_canonical()` work on reloaded objects without re-opening the
+HDF5 files.
+
+---
+
+## API reference
+
+::: STKO_to_python.elements.element_results.ElementResults
+
+---
+
+# ElementResultsPlotter
+
+Bound to an `ElementResults` instance as `er.plot`. Three engineering
+plot families that mirror the structure of
+[NodalResultsPlotter](plotting.md#nodalresultsplotter).
+
+All methods accept an optional `ax=` to compose into existing figures
+and return `(ax, meta)` for programmatic inspection.
+
+---
+
+## `plot.history` — time history
+
+```python
+ax, meta = er.plot.history("Mz_1", element_ids=[1, 2, 3])
+ax, meta = er.plot.history("P_ip2", x_axis="step")
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `component` | required | Column name (e.g. `"Mz_1"`, `"P_ip2"`, `"sigma11_l0_ip0"`) |
+| `element_ids` | `None` (all) | Restrict to specific elements |
+| `ax` | `None` | Existing axes to draw on |
+| `x_axis` | `"time"` | `"time"` or `"step"` |
+| `**plot_kwargs` | | Forwarded to `ax.plot` |
+
+Returns `(ax, {"x": ..., "y_per_element": {eid: array}})`.
+
+---
+
+## `plot.diagram` — beam force/moment/strain diagram
+
+For line elements only (`gp_dim == 1`). Plots a canonical quantity as
+a function of physical position along the beam at a single step — the
+classic moment/shear/axial diagram.
+
+```python
+ax, meta = er.plot.diagram("bending_moment_z", element_id=1, step=100)
+ax, meta = er.plot.diagram("axial_force", element_id=1, step=100,
+                            x_in_natural=True)  # xi in [-1, +1]
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `component_canonical` | required | Canonical name — must resolve to `n_ip` columns |
+| `element_id` | required | Single element to plot |
+| `step` | required | Step index |
+| `ax` | `None` | Existing axes |
+| `x_in_natural` | `False` | Plot in ξ ∈ [-1,+1]; `False` → physical position along element |
+| `**plot_kwargs` | | Forwarded to `ax.plot` |
+
+Returns `(ax, {"x": ..., "y": ..., "columns": [...]})`.
+
+Raises `ValueError` for non-line elements (use `scatter()` instead),
+missing node coords when `x_in_natural=False`, or when the canonical
+doesn't resolve to exactly `n_ip` columns.
+
+---
+
+## `plot.scatter` — spatial scatter for shells/solids
+
+Scatter integration-point physical positions colored by component value
+at a single step. Lightweight stand-in for contour plots — no mesh
+renderer needed.
+
+```python
+ax, meta = er_shell.plot.scatter("membrane_xx", step=100)
+ax, meta = er_shell.plot.scatter("membrane_xx", step=100, axes=("x", "z"))
+ax, meta = er_brick.plot.scatter("stress_11", step=100)
+
+# Add a colorbar
+fig = ax.figure
+fig.colorbar(meta["scatter"], ax=ax)
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `component_canonical` | required | Canonical name — must resolve to `n_ip` columns |
+| `step` | required | Step index |
+| `ax` | `None` | Existing axes |
+| `axes` | `("x", "y")` | Two of `"x"`, `"y"`, `"z"` for the 2-D projection |
+| `**scatter_kwargs` | | Forwarded to `ax.scatter` (e.g. `cmap`, `s`) |
+
+Returns `(ax, {"x": ..., "y": ..., "values": ..., "scatter": PathCollection})`.
+
+Raises `ValueError` when `physical_coords()` returns `None` (closed-form bucket,
+unknown element class, or missing node coords).
+
+---
+
+## API reference
+
+::: STKO_to_python.elements.element_results_plotting.ElementResultsPlotter

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -9,15 +9,21 @@ resolves its signatures and docstrings directly from the sources under
 
 - **[MPCODataSet](mpco-dataset.md)** — top-level dataset, one per
   recorder output. Holds managers, readers, and query engines.
-- **[NodalResults](nodal-results.md)** — view over result data with
+- **[NodalResults](nodal-results.md)** — nodal result view with
   forwarders for every engineering aggregation.
+- **[ElementResults](element-results.md)** — element result container
+  with Gauss-point integration, canonical names, plotting, and
+  time-series statistics. Pickle-portable.
 - **[MPCOResults](mpco-results.md)** — multi-case container with the
   `.df` accessor for MPCO-specific DataFrame extractors.
 
 ## Layer 3 — plotting
 
 - **[Plotting](plotting.md)** — `Plot` dataset-level facade and
-  `NodalResultsPlotter` result-bound plotter.
+  `NodalResultsPlotter` for nodal result time histories.
+- **[ElementResults → plot](element-results.md#elementresultsplotter)**
+  — `ElementResultsPlotter` with `history()`, `diagram()` (beam
+  moment/shear/axial), and `scatter()` (shell/solid contour-style).
 
 ## Layer 2 — engines
 
@@ -26,6 +32,12 @@ resolves its signatures and docstrings directly from the sources under
 - **[AggregationEngine](aggregation-engine.md)** — stateless
   engineering-aggregation engine. Every `NodalResults.drift(...)` /
   `.interstory_drift_envelope(...)` / etc. forwards here.
+
+## Canonical names
+
+- **[Canonical names](canonical-names.md)** — engineering-friendly
+  quantity aliases (`axial_force`, `stress_11`, `membrane_xx`, …) and
+  the regex rules that strip column suffixes.
 
 ## Layers not exposed here
 

--- a/docs/examples/elastic_frame.md
+++ b/docs/examples/elastic_frame.md
@@ -1,0 +1,102 @@
+# Elastic frame
+
+Demonstrates the core workflow against the single-partition
+`5-ElasticBeam3d` fixture — the recommended first read after the
+[Usage tour](usage_tour.md).
+
+**Script:** [`examples/elastic_frame_example.py`](https://github.com/nmorabowen/STKO_to_python/blob/main/examples/elastic_frame_example.py)
+
+```bash
+python examples/elastic_frame_example.py
+```
+
+---
+
+## Fixture
+
+`stko_results_examples/elasticFrame/results` — single partition,
+recorder `results`. 4 nodes, 3 `5-ElasticBeam3d` elements, 2 model
+stages (`MODEL_STAGE[1]`, `MODEL_STAGE[2]`), 10 steps each.
+
+---
+
+## Sections covered
+
+### 1. Dataset introspection
+
+```python
+ds = MPCODataSet(str(DATASET_DIR), "results")
+ds.model_stages           # ['MODEL_STAGE[1]', 'MODEL_STAGE[2]']
+ds.node_results_names     # DISPLACEMENT, REACTION, ACCELERATION, …
+ds.element_results_names  # force, localForce
+ds.unique_element_types   # ['5-ElasticBeam3d[1:0:0]']
+```
+
+### 2. Nodal results and engineering aggregations
+
+```python
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    model_stage="MODEL_STAGE[1]",
+    node_ids=[1, 2, 3, 4],
+)
+
+ts    = nr.drift(top=4, bottom=1, component=1)
+env   = nr.interstory_drift_envelope(component=1, node_ids=[1,2,3,4], dz_tol=1e-3)
+resid = nr.residual_drift(top=4, bottom=1, component=1, tail=3, agg="mean")
+sx, sy = nr.orbit(node_ids=1, x_component=1, y_component=2)
+```
+
+### 3. XY plotting
+
+```python
+nr.plot.xy(y_results_name="DISPLACEMENT", y_direction=1,
+           y_operation="Max", x_results_name="TIME")
+
+ds.plot.xy(model_stage="MODEL_STAGE[1]", results_name="DISPLACEMENT",
+           node_ids=[1,2,3,4], y_direction=1, y_operation="Max",
+           x_results_name="TIME")
+```
+
+### 4. Closed-form beam results
+
+`force` and `localForce` are closed-form buckets — 12 components each,
+no integration points (`gp_xi=None`, `n_ip=0`).
+
+```python
+er = ds.elements.get_element_results(
+    results_name="force",
+    element_type="5-ElasticBeam3d",
+    model_stage="MODEL_STAGE[1]",
+    element_ids=[1, 2, 3],
+)
+# er.df.shape == (30, 12)  — 3 elements × 10 steps
+# er.list_components() == ('Px_1', 'Py_1', ..., 'Mz_2')
+```
+
+### 5. Canonical names on closed-form results
+
+```python
+er_local = ds.elements.get_element_results("localForce", ...)
+er_local.list_canonicals()
+# ('axial_force', 'bending_moment_y', 'bending_moment_z',
+#  'shear_y', 'shear_z', 'torsion')
+
+er_local.canonical_columns("axial_force")   # ('N_1', 'N_2')
+df = er_local.canonical("bending_moment_z") # columns: Mz_1, Mz_2
+```
+
+!!! note "integrate_canonical on closed-form"
+    Closed-form buckets have no integration points and no `gp_weights`,
+    so `integrate_canonical()` raises `ValueError`. This is by design —
+    the result is already a nodal-force summary, not a field quantity.
+
+### 6. Pickle round-trips
+
+```python
+nr.save_pickle("nr.pkl")
+loaded = NodalResults.load_pickle("nr.pkl")
+
+er.save_pickle("er.pkl")
+loaded = ElementResults.load_pickle("er.pkl")
+```

--- a/docs/examples/quad_frame_shell.md
+++ b/docs/examples/quad_frame_shell.md
@@ -1,0 +1,110 @@
+# Quad-frame shells
+
+Demonstrates multi-partition datasets and the full Gauss-point
+integration API against the `203-ASDShellQ4` fixture.
+
+**Script:** [`examples/quad_frame_shell_example.py`](https://github.com/nmorabowen/STKO_to_python/blob/main/examples/quad_frame_shell_example.py)
+
+```bash
+python examples/quad_frame_shell_example.py
+```
+
+---
+
+## Fixture
+
+`stko_results_examples/elasticFrame/QuadFrame_results` — two
+partition files (`results.part-0.mpco`, `results.part-1.mpco`),
+recorder `results`. 676 nodes, 625 `203-ASDShellQ4` shells + 75
+`5-ElasticBeam3d` columns, 2 model stages, 10 steps.
+
+The library merges the partitions transparently — all element IDs
+appear in a single `ds.elements_info["dataframe"]`.
+
+---
+
+## Sections covered
+
+### 1. Multi-partition introspection
+
+```python
+ds = MPCODataSet(str(DATASET_DIR), "results")
+ds.unique_element_types   # ['203-ASDShellQ4[...]', '5-ElasticBeam3d[...]']
+len(ds.elements_info["dataframe"])  # 700 total elements across both partitions
+```
+
+### 2. Discover shell element IDs
+
+```python
+df = ds.elements_info["dataframe"]
+shell_ids = [int(i) for i in
+    df.query("element_type == '203-ASDShellQ4'")["element_id"].head(5)]
+```
+
+### 3. Shell `section.force` — 4 Gauss points
+
+```python
+er = ds.elements.get_element_results(
+    results_name="section.force",
+    element_type="203-ASDShellQ4",
+    model_stage="MODEL_STAGE[1]",
+    element_ids=shell_ids,
+)
+# er.n_ip == 4
+# er.gp_natural.shape == (4, 2)   — 2×2 Gauss-Legendre in ξη
+# er.gp_weights == [1., 1., 1., 1.]  (sum=4, one integration over [-1,1]²)
+```
+
+### 4. Canonical names for shell section forces
+
+```python
+er.list_canonicals()
+# ('bending_moment_xx', 'bending_moment_xy', 'bending_moment_yy',
+#  'membrane_xx', 'membrane_xy', 'membrane_yy',
+#  'transverse_shear_xz', 'transverse_shear_yz')
+
+er.canonical_columns("membrane_xx")
+# ('Fxx_ip0', 'Fxx_ip1', 'Fxx_ip2', 'Fxx_ip3')
+```
+
+### 5. Per-Gauss-point slicing
+
+```python
+sub0 = er.at_ip(0)   # 8 columns: Fxx_ip0, Fyy_ip0, …, Vyz_ip0
+sub3 = er.at_ip(3)   # 8 columns: Fxx_ip3, …, Vyz_ip3
+```
+
+### 6. Physical coordinates and element areas
+
+```python
+phys = er.physical_coords()    # (n_e, 4, 3) — physical (x,y,z) per IP
+dets = er.jacobian_dets()      # (n_e, 4) — surface Jacobian per IP
+
+# Element area via quadrature: A = sum(w_i * |J_i|)
+areas = (er.gp_weights[None, :] * dets).sum(axis=1)
+```
+
+### 7. Surface-integrated membrane force
+
+```python
+# Σ Fxx_ip * w_ip * |J_ip|  over all 4 IPs — per element, per step
+s = er.integrate_canonical("membrane_xx")
+
+# Reshape to (n_steps, n_elements) matrix
+mtx = s.unstack("element_id")
+```
+
+### 8. Spatial scatter plot
+
+```python
+ax, meta = er.plot.scatter("membrane_xx", step=5, axes=("x", "z"))
+ax.figure.colorbar(meta["scatter"], ax=ax)
+```
+
+### 9. Pickle — `gp_natural` survives
+
+```python
+er.save_pickle("shells.pkl")
+er2 = ElementResults.load_pickle("shells.pkl")
+# er2.gp_natural preserved → integrate_canonical still works
+```

--- a/docs/examples/solid_mixed.md
+++ b/docs/examples/solid_mixed.md
@@ -1,0 +1,141 @@
+# Solid + fiber beam
+
+Demonstrates the full integration-point API on a mixed-element dataset
+containing `56-Brick` continuum solids and `64-DispBeamColumn3d` beams
+with compressed fiber sections.
+
+**Script:** [`examples/solid_mixed_example.py`](https://github.com/nmorabowen/STKO_to_python/blob/main/examples/solid_mixed_example.py)
+
+```bash
+python examples/solid_mixed_example.py
+```
+
+---
+
+## Fixture
+
+`stko_results_examples/solid_partition_example` — two partition files
+(`Recorder.part-0.mpco`, `Recorder.part-1.mpco`), recorder `Recorder`.
+1720 nodes, 647 `56-Brick` + 712 `64-DispBeamColumn3d` elements,
+1 model stage (`MODEL_STAGE[1]`), 1667 steps.
+
+---
+
+## Part 1 — Brick continuum (`56-Brick`)
+
+### Material stress — 8 Gauss points
+
+```python
+er = ds.elements.get_element_results(
+    results_name="material.stress",
+    element_type="56-Brick",
+    model_stage="MODEL_STAGE[1]",
+    element_ids=brick_ids,
+)
+# er.n_ip == 8
+# er.gp_dim == 3
+# er.gp_xi is None   — multi-D bucket, no 1-D ξ
+# er.gp_natural.shape == (8, 3)   — (ξ, η, ζ) at ±1/√3 per axis
+# er.gp_weights.sum() == 8.0      — 2×2×2 Gauss-Legendre over [-1,1]³
+```
+
+Column layout: `sigma11_ip0, sigma22_ip0, …, sigma13_ip7`
+(6 stress components × 8 IPs = 48 columns).
+
+### Per-IP stress slice
+
+```python
+sub0 = er.at_ip(0)
+# columns: ['sigma11_ip0', 'sigma22_ip0', 'sigma33_ip0',
+#           'sigma12_ip0', 'sigma23_ip0', 'sigma13_ip0']
+```
+
+### Physical coordinates inside the element bounding box
+
+```python
+phys = er.physical_coords()    # (n_e, 8, 3)
+# All 8 IPs verified to lie inside element bounding box
+
+dets  = er.jacobian_dets()     # (n_e, 8)
+# V = sum(w_i * |J_i|) matches bounding-box volume for axis-aligned bricks
+vols  = (er.gp_weights[None, :] * dets).sum(axis=1)
+```
+
+### Volume-integrated stress
+
+```python
+s = er.integrate_canonical("stress_11")
+# Series indexed (element_id, step), name='integral_stress_11'
+# Σ σ₁₁_ip * w_ip * |J_ip|
+
+mtx = s.unstack("element_id")   # (n_steps, n_elements) matrix
+```
+
+### Spatial scatter at a step
+
+```python
+ax, meta = er.plot.scatter("stress_11", step=100, axes=("x", "z"))
+```
+
+---
+
+## Part 2 — Displacement-based beam (`64-DispBeamColumn3d`)
+
+### Section forces — 2-IP Lobatto end-stations
+
+```python
+er_sf = ds.elements.get_element_results(
+    results_name="section.force",
+    element_type="64-DispBeamColumn3d",
+    model_stage="MODEL_STAGE[1]",
+    element_ids=beam_ids,
+)
+# er_sf.n_ip == 2
+# er_sf.gp_xi == array([-1.0, 1.0])   — Lobatto rule: ξ=-1 → node i, ξ=+1 → node j
+# er_sf.gp_natural is None              — line elements use gp_xi, not gp_natural
+# er_sf.gp_weights is None              — no catalog weights for custom-rule beams
+```
+
+Column layout: `P_ip0, Mz_ip0, My_ip0, T_ip0, P_ip1, Mz_ip1, My_ip1, T_ip1`.
+
+```python
+sub_i = er_sf.at_ip(0)    # section forces at node-i end
+sub_j = er_sf.at_ip(1)    # section forces at node-j end
+```
+
+### Moment diagram along the beam
+
+```python
+ax, meta = er_sf.plot.diagram("bending_moment_z", element_id=1, step=100)
+```
+
+### Compressed fiber sections — 6 fibers × 2 IPs
+
+```python
+er_fib = ds.elements.get_element_results(
+    results_name="section.fiber.stress",
+    element_type="64-DispBeamColumn3d",
+    model_stage="MODEL_STAGE[1]",
+    element_ids=beam_ids,
+)
+# n_components == 12   (6 fibers × 2 IPs)
+# gp_xi == array([-1.0, 1.0])
+
+sub_ip0 = er_fib.at_ip(0)
+# shape: (n_elements × n_steps, 6)
+# columns: sigma11_f0_ip0, sigma11_f1_ip0, …, sigma11_f5_ip0
+```
+
+### Why `integrate_canonical` is not available for fiber buckets
+
+Fiber buckets have `gp_weights=None` (the custom Lobatto/Gauss rule
+used by `DispBeamColumn3d` isn't written to the MPCO file). Calling
+`integrate_canonical()` raises `ValueError` with a pointer to manual
+integration. For element-level fiber integration supply your own
+fiber-area weights:
+
+```python
+sub_ip0 = er_fib.at_ip(0)           # (n_el × n_steps, 6 fibers)
+fiber_areas = np.array([...])        # (6,) — fiber areas from the model
+result = (sub_ip0.to_numpy() * fiber_areas[None, :]).sum(axis=1)
+```

--- a/docs/examples/usage_tour.md
+++ b/docs/examples/usage_tour.md
@@ -1,0 +1,39 @@
+# Usage tour
+
+End-to-end tour of the complete STKO_to_python API, run against the
+checked-in `elasticFrame` fixture. Every call is real and executable.
+
+**Script:** [`examples/usage_tour.py`](https://github.com/nmorabowen/STKO_to_python/blob/main/examples/usage_tour.py)
+
+```bash
+python examples/usage_tour.py
+python examples/usage_tour.py --dataset-dir path/to/other/output --recorder results
+```
+
+---
+
+## Sections covered
+
+| # | Section | Key calls |
+|---|---|---|
+| 1 | Dataset introspection | `ds.model_stages`, `ds.node_results_names`, `ds.elements.get_available_element_results()` |
+| 2 | Fetch `NodalResults` | `ds.nodes.get_nodal_results()` |
+| 3 | Three ways to pull data | `nr.fetch()`, `nr.DISPLACEMENT[1]`, `nr.list_results()` |
+| 4 | Engineering aggregations | `nr.drift()`, `nr.interstory_drift_envelope()`, `nr.residual_drift()`, `nr.orbit()` |
+| 5 | Plotting | `nr.plot.xy()`, `ds.plot.xy()` |
+| 6 | `NodalResults` pickle | `nr.save_pickle()`, `NodalResults.load_pickle()` |
+| 7 | Fetch `ElementResults` | `ds.elements.get_element_results()` |
+| 8 | ElementResults broker API | `er.fetch()`, `er.envelope()`, `er.at_step()`, `er.at_time()`, `er.to_dataframe()` |
+| 9 | `ElementResults` pickle | `er.save_pickle()`, `ElementResults.load_pickle()` |
+| 10 | Selection sets | `selection_set_name=`, `selection_set_id=` |
+| 11 | Element discovery | `ds.elements.get_available_element_results(element_type=...)` |
+| 12 | Canonical names | `er.list_canonicals()`, `er.canonical_columns()`, `er.canonical()` |
+| 13 | Integration points | `er.gp_xi`, `er.n_ip`, `er.at_ip()`, `er.physical_x()` |
+| 14 | Dataset print helpers | `ds.print_summary()`, `ds.print_nodal_results()`, … |
+
+---
+
+## Fixture used
+
+`stko_results_examples/elasticFrame/results` — single-partition
+`5-ElasticBeam3d` model, 4 nodes, 3 elements, 2 model stages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,12 +71,28 @@ ds.plot.xy(
 - **[Elements workflow guide](elements_guide.md)** — end-to-end
   walkthrough of element results: discovery, selection sets,
   integration-point access, canonical names, plotting, and pickling.
+- **[ElementResults reference](api/element-results.md)** — full API
+  for the element result container, including `physical_coords()`,
+  `integrate_canonical()`, time-series statistics, and the new
+  `plot.history()` / `plot.diagram()` / `plot.scatter()` plotters.
 - **[Architecture](architecture.md)** — the layered design, what lives
   where, pickle compatibility, and the per-phase refactor history.
 - **[API reference](api/index.md)** — class-by-class docs generated
   from the package's docstrings.
-- **[Design spec](architecture-refactor-proposal.md)** — the proposal
-  document that drove the 2026 refactor. Kept for historical context.
+
+## Executable examples
+
+Three runnable scripts — one per fixture — each focused on capabilities
+unique to that element family:
+
+| Script | Fixture | Highlights |
+|---|---|---|
+| [Elastic frame](examples/elastic_frame.md) | `elasticFrame` (single partition) | Nodal aggregations, closed-form beam forces, canonical names, plotting |
+| [Quad-frame shells](examples/quad_frame_shell.md) | `QuadFrame_results` (2 partitions) | 4-IP shells, `physical_coords()`, `integrate_canonical()`, scatter plot |
+| [Solid + fiber beam](examples/solid_mixed.md) | `solid_partition_example` (2 partitions) | 8-IP Brick volume integration, fiber `at_ip()`, beam moment diagram |
+
+The [Usage tour](examples/usage_tour.md) covers all major API
+surfaces in one script (nodal + element + plotting + pickle).
 
 ## Building these docs locally
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Overview: api/index.md
       - MPCODataSet: api/mpco-dataset.md
       - NodalResults: api/nodal-results.md
+      - ElementResults: api/element-results.md
       - AggregationEngine: api/aggregation-engine.md
       - Query engines: api/query-engines.md
       - Plotting: api/plotting.md
@@ -94,3 +95,8 @@ nav:
       - NodalResults: NodalResults.md
       - ElementResults: ElementResults.md
       - Elements workflow: elements_guide.md
+  - Examples:
+      - Usage tour: examples/usage_tour.md
+      - Elastic frame: examples/elastic_frame.md
+      - Quad-frame shells: examples/quad_frame_shell.md
+      - Solid + fiber beam: examples/solid_mixed.md


### PR DESCRIPTION
## Summary

- **`docs/api/element-results.md`** (new) — full API reference for `ElementResults` and `ElementResultsPlotter`, covering: `fetch`, `envelope`, `at_ip`, canonical names, `physical_coords` / `jacobian_dets` / `integrate_canonical`, the new time-series stats (`peak_abs`, `time_of_peak`, `cumulative_envelope`, `summary`), pickle, and all three plot families (`history`, `diagram`, `scatter`).

- **`docs/examples/`** (new directory, 4 pages) — prose overviews for each runnable example script with key API calls, fixture facts, and GitHub links:
  - `usage_tour.md`
  - `elastic_frame.md`
  - `quad_frame_shell.md`
  - `solid_mixed.md`

- **`mkdocs.yml`** — added `ElementResults` under API reference nav; added top-level `Examples` section (4 pages).

- **`docs/api/index.md`** — added ElementResults to Layer 4, ElementResultsPlotter to Layer 3, Canonical names section.

- **`docs/index.md`** — added ElementResults reference to "Where to read next"; added Executable examples table.

## Test plan

- [ ] `mkdocs build` completes without errors
- [ ] All 4 API reference pages render (`ElementResults`, `ElementResultsPlotter`, class members visible)
- [ ] Nav shows `API reference > ElementResults` and `Examples > {4 pages}`
- [ ] Home page examples table links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)