### PR TITLE
Fill API stub pages: NodalResults, Plotting, Query engines

### DIFF
--- a/docs/api/nodal-results.md
+++ b/docs/api/nodal-results.md
@@ -1,15 +1,228 @@
 # NodalResults
 
-Thin view over result data. Holds a reference to a
-[NodalResultsQueryEngine](query-engines.md) and pre-resolved IDs.
-Exposes `fetch`, `list_results`, `list_components`, `save_pickle`,
-`load_pickle`, and a `.plot` accessor; every engineering aggregation
-(`drift`, `interstory_drift_envelope`, `orbit`, `base_rocking`, …) is
-a forwarder to [AggregationEngine](aggregation-engine.md).
+Self-contained view over nodal result data. Returned by
+`ds.nodes.get_nodal_results()`. Holds a reference to a
+`NodalResultsQueryEngine` and pre-resolved IDs. Every engineering
+aggregation (`drift`, `interstory_drift_envelope`, `orbit`, …) is a
+forwarder to [AggregationEngine](aggregation-engine.md).
 
-Pickle-stable since Phase 4.3.3: the class's `(__module__, __qualname__)`
-pair does not change, and `__setstate__` tolerates unknown keys (dropped
-with a DEBUG log) and missing optional fields.
+Pickle-stable: saves and reloads without the original HDF5 files.
+
+For the comprehensive usage guide (with full worked examples) see
+[Usage guides → NodalResults](../NodalResults.md).
+
+---
+
+## Construction
+
+```python
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    model_stage="MODEL_STAGE[1]",
+    node_ids=[1, 2, 3, 4],           # explicit IDs, or…
+    # selection_set_name="roof",      # …named selection set
+    # selection_set_id=2,             # …selection set by index
+)
+```
+
+---
+
+## Key attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `nr.df` | `pd.DataFrame` | MultiIndex `(node_id, step)` × component columns |
+| `nr.time` | `np.ndarray \| dict` | Time per step (dict for multi-stage) |
+| `nr.node_ids` | `tuple[int, ...]` | Node IDs in this result |
+| `nr.n_steps` | `int` | Number of recorded steps |
+
+---
+
+## Introspection
+
+```python
+nr.list_results()                     # tuple of result names, e.g. ('DISPLACEMENT',)
+nr.list_components('DISPLACEMENT')    # tuple of component labels, e.g. ('1', '2', '3')
+```
+
+---
+
+## Fetching data
+
+```python
+# Full result as DataFrame
+df = nr.fetch(result_name="DISPLACEMENT")
+
+# Single component
+s = nr.fetch(result_name="DISPLACEMENT", component=1)
+
+# Filtered by node IDs
+s = nr.fetch(result_name="DISPLACEMENT", component=1, node_ids=[1, 4])
+
+# Dynamic attribute style (equivalent to fetch)
+view = nr.DISPLACEMENT[1]           # all nodes, component 1
+view = nr.DISPLACEMENT[1, [1, 4]]   # nodes [1, 4], component 1
+```
+
+---
+
+## Engineering aggregations
+
+All aggregations forward to [AggregationEngine](aggregation-engine.md).
+
+### Drift
+
+```python
+ts = nr.drift(top=4, bottom=1, component=1)
+# pd.Series indexed by step — relative displacement u_top - u_bottom
+```
+
+### Interstory drift envelope
+
+```python
+env = nr.interstory_drift_envelope(
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    dz_tol=1e-3,          # Z-coordinate tolerance for story pairing
+)
+# DataFrame with columns: z_lower, z_upper, lower_node, upper_node,
+#                         dz, max_drift, min_drift, max_abs_drift
+```
+
+### Residual drift
+
+```python
+resid = nr.residual_drift(
+    top=4, bottom=1, component=1,
+    tail=3,     # number of final steps to average
+    agg="mean", # "mean" | "last"
+)
+# float — mean (or last) drift value at the end of the record
+```
+
+### Interstory drift envelope profile
+
+```python
+pd_env = nr.interstory_drift_envelope_pd(
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    dz_tol=1e-3,
+)
+# Wide DataFrame — one column per story pair, rows are time steps
+```
+
+### Residual interstory drift profile
+
+```python
+profile = nr.residual_interstory_drift_profile(
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    tail=3,
+    agg="mean",
+)
+```
+
+### Story PGA envelope
+
+```python
+pga = nr.story_pga_envelope(
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    dz_tol=1e-3,
+    to_g=True,
+    g_value=9810,
+)
+```
+
+### Roof torsion
+
+```python
+torsion_ts, ratio_ts = nr.roof_torsion(
+    node_a_ids=[10, 11],
+    node_b_ids=[20, 21],
+    component=1,
+    dz_tol=1e-3,
+)
+```
+
+### Base rocking
+
+```python
+theta = nr.base_rocking(
+    component=3,          # vertical DOF
+    node_ids=[1, 2, 3],
+    dz_tol=1e-3,
+)
+```
+
+### ASCE torsional irregularity
+
+```python
+result = nr.asce_torsional_irregularity(
+    component=1,
+    side_a_top=(0.0, 0.0, 6.0),
+    side_a_bottom=(0.0, 0.0, 3.0),
+    side_b_top=(20.0, 0.0, 6.0),
+    side_b_bottom=(20.0, 0.0, 3.0),
+)
+# dict with keys: ratio, delta_a, delta_b, avg_drift, irregular
+```
+
+### Orbit
+
+```python
+sx, sy = nr.orbit(node_ids=1, x_component=1, y_component=2)
+# Two Series — displacement trajectory for a single node
+```
+
+### Residual drift envelope
+
+```python
+env = nr.residual_drift_envelope(
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    tail=3,
+    agg="mean",
+)
+```
+
+---
+
+## Plotting
+
+```python
+ax, meta = nr.plot.xy(
+    y_results_name="DISPLACEMENT",
+    y_direction=1,
+    y_operation="Max",
+    x_results_name="TIME",
+)
+
+fig, meta = nr.plot.plot_TH(
+    result_name="DISPLACEMENT",
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    split_subplots=True,
+)
+```
+
+See [Plotting](plotting.md) for the full parameter reference.
+
+---
+
+## Pickle serialization
+
+```python
+nr.save_pickle("nr.pkl")
+nr.save_pickle("nr.pkl.gz")          # compressed
+
+from STKO_to_python.results.nodal_results_dataclass import NodalResults
+nr = NodalResults.load_pickle("nr.pkl")
+```
+
+---
+
+## API reference
 
 ::: STKO_to_python.results.nodal_results_dataclass.NodalResults
 

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -1,11 +1,146 @@
 # Plotting
 
-Two flavours:
+Two flavours of XY plots:
 
-- **Per-result** (`nr.plot.*`) — use when you'll produce multiple
-  plots off the same `NodalResults`; reuses the cached DataFrame.
+- **Per-result** (`nr.plot.*`) — use when you'll produce multiple plots
+  off the same `NodalResults`; reuses the cached DataFrame.
 - **Dataset-level** (`ds.plot.*`) — one-shot "fetch and plot"
   convenience. Internally fetches a `NodalResults` and delegates.
+
+For element result plots (`er.plot.*`) see
+[ElementResults — plotting](element-results.md#elementresultsplotter).
+
+---
+
+## `xy` — shared parameter reference
+
+Both `nr.plot.xy()` and `ds.plot.xy()` share the same parameter
+structure. The dataset-level version prepends the fetch arguments.
+
+### Y-axis
+
+| Parameter | Default | Description |
+|---|---|---|
+| `y_results_name` | required | Result name, e.g. `"DISPLACEMENT"` |
+| `y_direction` | `None` | Component index (int) or name. If `None`, all components are aggregated by `y_operation`. |
+| `y_operation` | `"Sum"` | Aggregation over nodes/components: `"Sum"`, `"Max"`, `"Min"`, `"Mean"`, `"Percentile"` |
+| `y_scale` | `1.0` | Scalar multiplier applied to the y values |
+
+### X-axis
+
+| Parameter | Default | Description |
+|---|---|---|
+| `x_results_name` | `"TIME"` | `"TIME"`, `"STEP"`, or another result name for an XY scatter |
+| `x_direction` | `None` | Component index / name for the x result |
+| `x_operation` | `"Sum"` | Aggregation for the x result |
+| `x_scale` | `1.0` | Scalar multiplier for x values |
+
+### Aggregation extras
+
+| Parameter | Default | Description |
+|---|---|---|
+| `operation_kwargs` | `None` | Extra kwargs forwarded to the aggregator. Currently only `{"percentile": 95.0}` is accepted. |
+
+### Cosmetics
+
+| Parameter | Default | Description |
+|---|---|---|
+| `ax` | `None` | Existing `matplotlib.Axes` to draw on. If `None`, a new figure is created. |
+| `figsize` | `(10, 6)` | Figure size in inches (ignored when `ax` is supplied) |
+| `linewidth` | `None` | Overrides `PlotSettings.linewidth` |
+| `marker` | `None` | Overrides `PlotSettings.marker` |
+| `label` | `None` | Legend label. Auto-generated when `None`. |
+| `**line_kwargs` | | Forwarded to `ax.plot` |
+
+All methods return `(ax, meta)` where `meta` carries `{"x": ..., "y": ...}`.
+
+---
+
+## Examples
+
+### Time history of maximum displacement
+
+```python
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    model_stage="MODEL_STAGE[1]",
+    node_ids=[1, 2, 3, 4],
+)
+
+ax, meta = nr.plot.xy(
+    y_results_name="DISPLACEMENT",
+    y_direction=1,
+    y_operation="Max",
+    x_results_name="TIME",
+)
+```
+
+### One-shot dataset-level plot
+
+```python
+ax, meta = ds.plot.xy(
+    model_stage="MODEL_STAGE[1]",
+    results_name="DISPLACEMENT",
+    node_ids=[1, 2, 3, 4],
+    y_direction=1,
+    y_operation="Max",
+    x_results_name="TIME",
+)
+```
+
+### XY scatter — roof displacement vs. base shear
+
+```python
+ax, meta = ds.plot.xy(
+    model_stage="MODEL_STAGE[1]",
+    results_name="DISPLACEMENT",
+    node_ids=[4],            # roof node
+    y_direction=1,
+    y_operation="Sum",
+    x_results_name="REACTION_FORCE",
+    x_direction=1,
+    x_operation="Sum",
+)
+```
+
+### Per-node time-history subplots
+
+`plot_TH` is a convenience wrapper that shows one curve per node on
+either a shared axes or one subplot per node:
+
+```python
+fig, meta = nr.plot.plot_TH(
+    result_name="DISPLACEMENT",
+    component=1,
+    node_ids=[1, 2, 3, 4],
+    split_subplots=True,
+    figsize=(8, 10),
+    sharey=True,
+)
+```
+
+---
+
+## Style precedence
+
+Style is resolved in three layers (highest wins):
+
+1. **Model-level `PlotSettings`** — set via `ds.plot_settings` or attached
+   to a `NodalResults` directly.
+2. **Per-call keyword arguments** — `linewidth=`, `marker=`, `label=`.
+3. **`**line_kwargs`** — any extra kwarg forwarded verbatim to `ax.plot`.
+
+```python
+from STKO_to_python.plotting.plot_settings import PlotSettings
+
+nr.plot_settings = PlotSettings(linewidth=1.5, marker="o", color="steelblue")
+ax, _ = nr.plot.xy(y_results_name="DISPLACEMENT", y_direction=1,
+                   y_operation="Max", x_results_name="TIME")
+```
+
+---
+
+## API reference
 
 ## Plot (dataset-level facade)
 
@@ -13,13 +148,14 @@ Two flavours:
 
 ## NodalResultsPlotter
 
-Bound to a `NodalResults` instance. Handles the aggregation dispatch
-(via [Aggregator](https://github.com/nmorabowen/STKO_to_python/blob/main/src/STKO_to_python/dataprocess/aggregator.py))
-and style precedence (model-level `PlotSettings` → explicit kwargs
-→ `**line_kwargs`).
+Bound to a `NodalResults` instance as `nr.plot`. Handles aggregation
+dispatch (via `Aggregator`) and style precedence.
 
 ::: STKO_to_python.results.nodal_results_plotting.NodalResultsPlotter
 
 ## PlotSettings
+
+Dataclass holding per-result style overrides. Attach to `nr.plot_settings`
+or pass to the dataset for model-wide defaults.
 
 ::: STKO_to_python.plotting.plot_settings.PlotSettings

--- a/docs/api/query-engines.md
+++ b/docs/api/query-engines.md
@@ -1,23 +1,89 @@
 # Query engines
 
-Assemble `DataFrame`s with a normalised MultiIndex. Each dataset
-holds one instance per kind (nodal, element) under
-`ds._nodal_query_engine` / `ds._element_query_engine`. The LRU cache
-(default size 32) is on by default; cache keys are
-`(stage, result_name, component, ids_hash, step_slice)`.
+Internal engines that assemble `DataFrame`s with a normalised
+`(id, step)` MultiIndex from the HDF5 partition pool. Each dataset
+holds one instance per kind under `ds._nodal_query_engine` /
+`ds._element_query_engine`.
+
+!!! note "Most users never touch these directly"
+    `NodalResults` and `ElementResults` are the public API.
+    Query engines are documented here for contributors and advanced
+    users who want to understand caching or extend the library.
+
+---
+
+## Architecture
+
+```
+MPCODataSet
+  ├── NodeManager.get_nodal_results()
+  │       └── NodalResultsQueryEngine.query()  ──► NodalResults
+  └── ElementManager.get_element_results()
+          └── ElementResultsQueryEngine.query() ──► ElementResults
+```
+
+Both engines inherit from `BaseResultsQueryEngine`, which provides:
+
+- **MultiIndex construction** — `(node_id, step)` or `(element_id, step)`
+- **Stage iteration** — concatenates results across multiple model stages
+- **LRU result cache** — default size 32; key is `(stage, result_name, ids_hash, step_slice)`. Hit/miss logged at DEBUG level.
+- **Chunk-sorted fancy-index path** — reads HDF5 rows in sorted order for efficient I/O then reorders to match the requested IDs.
+
+---
+
+## Cache behaviour
+
+The LRU cache is on by default. To clear it or adjust its size:
+
+```python
+# Clear the nodal cache
+ds._nodal_query_engine.cache.clear()
+
+# Inspect cache info
+print(ds._nodal_query_engine.cache.cache_info())
+```
+
+If you modify the underlying HDF5 file between calls (unusual outside
+of testing), clear the cache explicitly to avoid stale data.
+
+---
 
 ## BaseResultsQueryEngine
 
 Template-method parent. Holds the MultiIndex / ID-axis caches,
 handles stage iteration, and implements the chunk-sorted fancy-index
-path.
+path used by both subclasses.
 
 ::: STKO_to_python.query.base_query_engine.BaseResultsQueryEngine
 
+---
+
 ## NodalResultsQueryEngine
+
+Specialises the base engine for nodal results. Resolves node IDs from
+the partition pool's node index and maps HDF5 column positions to the
+normalised `(node_id, step)` MultiIndex.
 
 ::: STKO_to_python.query.nodal_query_engine.NodalResultsQueryEngine
 
+---
+
 ## ElementResultsQueryEngine
+
+Specialises the base engine for element results. Resolves element IDs
+and their partition assignments, reads the appropriate bucket from each
+partition, and merges results into a single `(element_id, step)`
+MultiIndex DataFrame.
+
+Also responsible for:
+
+- Determining the bucket shape (closed-form vs. line-station vs.
+  Gauss-level continuum vs. compressed fiber) from the partition's
+  META dataset.
+- Fetching `element_node_coords` and `element_node_ids` from the
+  node index (needed by `physical_coords()` and `jacobian_dets()`).
+- Resolving `gp_xi` from the connectivity `@GP_X` attribute (line
+  elements) or `gp_natural` / `gp_weights` from the static catalog
+  (`utilities/gauss_points.py`) for catalogued element classes.
 
 ::: STKO_to_python.query.element_query_engine.ElementResultsQueryEngine


### PR DESCRIPTION
## Summary

Fills the three API pages that were pure mkdocstrings stubs with prose, parameter tables, and runnable examples.

### `docs/api/nodal-results.md`
- Construction (explicit IDs, selection sets)
- Key attributes table
- Introspection (`list_results`, `list_components`)
- All fetch modes (`fetch()`, dynamic attribute style)
- Complete aggregation reference: `drift`, `interstory_drift_envelope`, `residual_drift`, `interstory_drift_envelope_pd`, `residual_interstory_drift_profile`, `story_pga_envelope`, `roof_torsion`, `base_rocking`, `asce_torsional_irregularity`, `orbit`, `residual_drift_envelope`
- Plotting callout linking to plotting.md
- Pickle serialization

### `docs/api/plotting.md`
- Full `xy()` parameter table with four sections (y-axis, x-axis, aggregation, cosmetics)
- Three worked examples: time history, one-shot dataset plot, XY scatter (roof disp vs. base shear)
- `plot_TH()` per-node time-history subplot API
- Style precedence explanation (PlotSettings → per-call kwargs → line_kwargs)

### `docs/api/query-engines.md`
- Architecture diagram showing the call chain
- Cache behaviour (clear, inspect, stale-data warning)
- Detailed role descriptions for `ElementResultsQueryEngine` (bucket shape resolution, gp_xi/gp_natural, node coord population)

## Test plan
- [ ] `mkdocs build` completes without errors
- [ ] All three pages render with mkdocstrings blocks intact
- [ ] Parameter tables display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)