### PR TITLE
Polish solid example: add plot demos + expand spatial-query docs

### DIFF
--- a/docs/MPCODataSet.md
+++ b/docs/MPCODataSet.md
@@ -116,30 +116,65 @@ er = ds.elements.get_element_results(
 
 ### Element Spatial Queries
 
-The Elements class provides spatial filtering methods for finding elements at specific elevations:
+Building and bridge models are often post-processed **story by story** — you want forces in all columns at floor level 3.0 m, or the membrane stresses in every shear wall panel at a particular elevation. The spatial query helpers implement this horizontal-slice pattern so you don't have to filter the element DataFrame by hand.
+
+#### What is a "Z-level"?
+
+A Z-level is a specific elevation in the global Z-axis (vertical axis in most OpenSees models). The helper matches elements whose **centroid Z-coordinate** falls within a configurable tolerance of the requested value. A single call with `list_z=[0.0, 3.0, 6.0, 9.0]` partitions the entire element set into per-story buckets in one pass.
+
+#### `get_elements_at_z_levels`
+
+Returns a filtered `DataFrame` — a subset of `ds.elements_info["dataframe"]` — keeping only those elements of the requested type whose centroids are at the given Z-levels.
+
+Use this when you want to **inspect** which elements sit at each floor before fetching results.
 
 ```python
-# Elements at Z-levels (horizontal slicing)
 df_at_z = ds.elements.get_elements_at_z_levels(
     list_z=[0.0, 3.0, 6.0],
     element_type="203-ASDShellQ4",
+    tol=0.1,          # Z-coordinate tolerance (default 0.1 m)
 )
+# Returns a DataFrame with columns: element_id, element_type, z_level, …
+```
 
-# Elements in a selection set at Z-levels
+#### `get_elements_in_selection_at_z_levels`
+
+Same as above but intersects with a named selection set first. Useful for filtering a *specific structural system* (e.g. "only interior shear walls") at each floor.
+
+```python
 df_sel_z = ds.elements.get_elements_in_selection_at_z_levels(
     list_z=[0.0, 3.0],
     selection_set_name="ShearWall",
     element_type="203-ASDShellQ4",
 )
+```
 
-# Combined: filter by selection + Z, then fetch results grouped by type
+#### `get_element_results_by_selection_and_z`
+
+The most powerful variant. It applies the selection + Z-level filter and then **fetches `ElementResults` for each distinct element type found**. The return value is a dictionary keyed by the decorated element-type string (as it appears in the HDF5 file):
+
+```python
 results_by_type = ds.elements.get_element_results_by_selection_and_z(
     results_name="globalForces",
     list_z=[0.0, 3.0],
     selection_set_name="ShearWall",
+    model_stage="MODEL_STAGE[1]",
 )
-# returns: {'203-ASDShellQ4[...details...]': ElementResults, ...}
+# {
+#   '203-ASDShellQ4[...]': ElementResults,   # shells at z=0 and z=3
+#   '5-ElasticBeam3d[...]': ElementResults,  # columns at those floors
+# }
 ```
+
+Iterate the returned dict to process each type independently:
+
+```python
+for type_key, er in results_by_type.items():
+    s = er.integrate_canonical("membrane_xx")
+    print(f"{type_key}: total Fxx = {s.unstack().sum(axis=1).values}")
+```
+
+This pattern is the recommended way to extract **inter-story shear** or **story-level membrane forces** for post-processing workflows.
 
 ### Introspecting Available Element Results
 

--- a/examples/solid_mixed_example.py
+++ b/examples/solid_mixed_example.py
@@ -15,12 +15,14 @@ Sections:
     3.  ``at_ip()`` on Brick — per-IP stress slice.
     4.  ``physical_coords()`` on Brick — IP positions inside element bbox.
     5.  ``jacobian_dets()`` and element volume via quadrature.
-    6.  ``integrate_canonical("stress_11")`` — volume-integrated σ₁₁.
-    7.  Beam ``section.force`` — 2-IP line-station, gp_xi at ±1.
-    8.  Beam fiber section — ``section.fiber.stress``, 6 fibers × 2 IPs.
+    6.  ``integrate_canonical("stress_11")`` — volume-integrated sigma_11.
+    7.  Beam ``section.force`` — 2-IP line-station, gp_xi at +-1.
+    8.  Beam fiber section — ``section.fiber.stress``, 6 fibers x 2 IPs.
     9.  ``at_ip()`` on fiber result — all 6 fibers at one station.
    10.  Why ``integrate_canonical`` is not available for fiber buckets.
-   11.  ElementResults pickle round-trip.
+   11.  ``plot.diagram()`` — bending moment diagram along a beam element.
+   12.  ``plot.scatter()`` — Gauss-point stress scatter for a brick element.
+   13.  ElementResults pickle round-trip.
 
 Run with::
 
@@ -31,6 +33,10 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 import numpy as np
 
 from STKO_to_python import MPCODataSet
@@ -328,10 +334,67 @@ def section_10_fiber_integrate_raises(er: ElementResults) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 11. Pickle round-trip
+# 11. plot.diagram() — bending moment diagram along a beam element
 # ---------------------------------------------------------------------------
-def section_11_pickle(er_brick: ElementResults) -> None:
-    section("11. ElementResults pickle round-trip")
+def section_11_beam_diagram(er_sf: ElementResults) -> None:
+    section("11. plot.diagram() - bending moment diagram along a beam")
+
+    # er_sf is the section.force result (n_ip=2, gp_xi=[-1, +1]).
+    # diagram() requires gp_dim==1 and a canonical that maps to exactly n_ip cols.
+    eid = er_sf.element_ids[0]
+    step = 1
+
+    # Physical x-axis (requires element_node_coords)
+    ax, meta = er_sf.plot.diagram(
+        "bending_moment_z",
+        element_id=eid,
+        step=step,
+    )
+    print(f"diagram('bending_moment_z', element={eid}, step={step})")
+    print(f"  x (physical position): {meta['x']}")
+    print(f"  y (Mz values):         {meta['y']}")
+    print(f"  columns used:          {meta['columns']}")
+    plt.close("all")
+
+    # Natural xi axis (no node coords needed)
+    ax, meta = er_sf.plot.diagram(
+        "axial_force",
+        element_id=eid,
+        step=step,
+        x_in_natural=True,
+    )
+    print(f"\ndiagram('axial_force', x_in_natural=True)")
+    print(f"  xi values: {meta['x']}")
+    print(f"  P values:  {meta['y']}")
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# 12. plot.scatter() — Gauss-point stress scatter for a brick element
+# ---------------------------------------------------------------------------
+def section_12_brick_scatter(er_brick: ElementResults) -> None:
+    section("12. plot.scatter() - stress_11 at Gauss points (x-z view)")
+
+    step = 1
+    ax, meta = er_brick.plot.scatter(
+        "stress_11",
+        step=step,
+        axes=("x", "z"),
+    )
+    print(f"scatter('stress_11', step={step}, axes=('x','z'))")
+    print(f"  x shape:      {meta['x'].shape}  ({er_brick.n_elements} elements x {er_brick.n_ip} IPs)")
+    print(f"  values shape: {meta['values'].shape}")
+    print(f"  values range: [{meta['values'].min():.3e}, {meta['values'].max():.3e}]")
+    # Add a colorbar to the figure for a complete publication-ready result:
+    #   ax.figure.colorbar(meta["scatter"], ax=ax, label="sigma_11")
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# 13. Pickle round-trip
+# ---------------------------------------------------------------------------
+def section_13_pickle(er_brick: ElementResults) -> None:
+    section("13. ElementResults pickle round-trip")
 
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "brick.pkl"
@@ -369,11 +432,13 @@ def main() -> None:
     section_4_physical_coords(er_brick)
     section_5_volumes(er_brick)
     section_6_integrate_canonical(er_brick)
-    section_7_beam_section_force(ds, beam_ids)
+    er_beam = section_7_beam_section_force(ds, beam_ids)
     er_fiber = section_8_fiber_stress(ds, beam_ids)
     section_9_at_ip_fiber(er_fiber)
     section_10_fiber_integrate_raises(er_fiber)
-    section_11_pickle(er_brick)
+    section_11_beam_diagram(er_beam)
+    section_12_brick_scatter(er_brick)
+    section_13_pickle(er_brick)
 
     print()
     print("solid_mixed_example complete.")


### PR DESCRIPTION
## Summary

- **`examples/solid_mixed_example.py`** — wire the two new plot sections into `main()`:
  - `section_11_beam_diagram(er_beam)`: demonstrates `er.plot.diagram()` for a `bending_moment_z` curve and an `axial_force` curve with natural-xi x-axis
  - `section_12_brick_scatter(er_brick)`: demonstrates `er.plot.scatter()` coloring Gauss-point `stress_11` values in the x-z plane
  - Fixed `section_13_pickle` header label (was still saying "11.")
- **`docs/MPCODataSet.md`** — replaced the thin spatial-queries code block with full explanatory prose:
  - What a "Z-level" is and why the concept matters for building/bridge models
  - When to use each of the three methods (`get_elements_at_z_levels`, `get_elements_in_selection_at_z_levels`, `get_element_results_by_selection_and_z`)
  - Return semantics and an iteration pattern for the dict returned by `get_element_results_by_selection_and_z`

## Test plan

- [ ] Run `python examples/solid_mixed_example.py` against the `solid_partition_example` fixture — sections 11 and 12 should print shape/range info without errors and `plt.close("all")` should clean up figures
- [ ] Review spatial-query prose in rendered docs for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)