### PR TITLE
Add mesh wireframe plot that composes with element scatter

### DIFF
--- a/src/STKO_to_python/plotting/mesh.py
+++ b/src/STKO_to_python/plotting/mesh.py
@@ -1,0 +1,266 @@
+"""Mesh ("show me the model") visualization for an :class:`MPCODataSet`.
+
+Renders element edges from the cached connectivity so users can orient
+themselves before — or under — a contour plot. The companion
+:func:`plot_mesh_with_contour` overlays an
+:class:`~STKO_to_python.elements.element_results.ElementResults` scatter
+on top of the same axes for the 80% "show the mesh, color the IPs"
+workflow.
+
+Edge topology is shared with the deformed-mesh renderer
+(:mod:`STKO_to_python.plotting.deformed_shape`) — line elements get one
+segment, triangles three, quads four, hex bricks twelve. Anything else
+is skipped with a warning.
+
+The public entry points sit on :class:`STKO_to_python.plotting.plot.Plot`
+(``ds.plot.mesh`` / ``ds.plot.mesh_with_contour``); this module is the
+implementation.
+"""
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+from .deformed_shape import (
+    _autoscale_axes,
+    _build_segments,
+    _class_label,
+    _decide_3d,
+    _draw_segments,
+    _edge_topology,
+)
+
+if TYPE_CHECKING:
+    from ..core.dataset import MPCODataSet
+    from ..elements.element_results import ElementResults
+
+
+def _filter_elements(
+    df_elements: pd.DataFrame,
+    *,
+    element_type: Optional[str],
+    element_ids: Union[int, Sequence[int], np.ndarray, None],
+) -> pd.DataFrame:
+    """Apply element_type / element_ids filters to the element index."""
+    df = df_elements
+    if element_type is not None:
+        base = str(element_type).split("[")[0]
+        df = df[df["element_type"].str.startswith(base)]
+    if element_ids is not None:
+        if isinstance(element_ids, (int, np.integer)):
+            ids = {int(element_ids)}
+        else:
+            ids = {int(e) for e in element_ids}
+        df = df[df["element_id"].isin(ids)]
+    return df
+
+
+def plot_mesh(
+    dataset: "MPCODataSet",
+    *,
+    model_stage: Optional[str] = None,
+    element_type: Optional[str] = None,
+    element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+    ax: Any = None,
+    edge_color: Any = "lightgray",
+    linewidth: float = 0.5,
+    alpha: float = 1.0,
+    title: Optional[str] = None,
+    **kwargs: Any,
+) -> Tuple[Any, Dict[str, Any]]:
+    """Render element edges from the cached connectivity.
+
+    Parameters
+    ----------
+    dataset : MPCODataSet
+        Source dataset.
+    model_stage : str or None
+        Accepted for API symmetry with the rest of the plot facade.
+        Node coordinates are stage-independent in the MPCO format, so
+        this argument is currently advisory; supply it for clarity in
+        plots that combine the mesh with a stage-specific contour.
+    element_type : str or None
+        Restrict to one element class (matched on the type prefix
+        before ``[`` — e.g. ``"203-ASDShellQ4"`` or ``"ASDShellQ4"``).
+    element_ids : int, sequence of int, or None
+        Restrict to specific element IDs (in addition to
+        ``element_type`` if both are passed).
+    ax : matplotlib Axes or None
+        Existing axes. If ``None``, a new figure is created. The
+        renderer auto-selects 2D/3D from the model geometry; if you
+        pass ``ax`` you are responsible for matching its projection.
+    edge_color : matplotlib color, default ``"lightgray"``
+    linewidth : float, default 0.5
+    alpha : float, default 1.0
+    title : str or None
+        Optional axes title.
+    **kwargs
+        Forwarded to the underlying ``LineCollection`` /
+        ``Line3DCollection`` only when no specialized handling exists.
+        Currently unused — present so callers can pass extras without
+        a ``TypeError``.
+
+    Returns
+    -------
+    (ax, meta) : tuple
+        ``meta`` carries:
+
+        * ``n_edges`` — total segments drawn
+        * ``n_elements_drawn`` — element rows that contributed
+        * ``edges_per_class`` — ``{class_label: edges_per_element}``
+        * ``skipped_classes`` — class labels with unsupported topology
+        * ``is_3d`` — whether the axes are 3D
+        * ``model_stage`` — passed through verbatim
+    """
+    df_nodes = dataset.nodes_info["dataframe"]
+    df_elements = dataset.elements_info["dataframe"]
+    if df_nodes.empty or df_elements.empty:
+        raise ValueError("Dataset has no nodes or no elements to draw.")
+
+    df_filtered = _filter_elements(
+        df_elements, element_type=element_type, element_ids=element_ids
+    )
+    if df_filtered.empty:
+        raise ValueError(
+            "No elements remain after filtering (element_type="
+            f"{element_type!r}, element_ids={element_ids!r})."
+        )
+
+    coord_lookup = {
+        int(row.node_id): np.array([row.x, row.y, row.z], dtype=np.float64)
+        for row in df_nodes.itertuples(index=False)
+    }
+
+    is_3d = _decide_3d(df_filtered, df_nodes)
+
+    if ax is None:
+        import matplotlib.pyplot as plt
+
+        if is_3d:
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection="3d")
+        else:
+            fig, ax = plt.subplots()
+
+    segs_per_class, edges_per_class, skipped = _build_segments(
+        df_elements=df_filtered, coord_lookup=coord_lookup
+    )
+
+    n_edges = 0
+    n_elements_drawn = 0
+    for label, segs in segs_per_class.items():
+        _draw_segments(
+            ax,
+            segs,
+            is_3d=is_3d,
+            color=edge_color,
+            linewidth=linewidth,
+            alpha=alpha,
+            zorder=1.0,
+        )
+        n_edges += int(segs.shape[0])
+        epe = edges_per_class.get(label, 0)
+        if epe:
+            n_elements_drawn += int(segs.shape[0] // epe)
+
+    if skipped:
+        warnings.warn(
+            "[mesh] Skipped element classes with unsupported topology: "
+            f"{skipped}",
+            RuntimeWarning,
+        )
+
+    coord_stack = np.stack(list(coord_lookup.values()))
+    _autoscale_axes(ax, coord_stack, is_3d=is_3d)
+
+    if not is_3d:
+        ax.set_aspect("equal", adjustable="datalim")
+
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    if is_3d:
+        ax.set_zlabel("z")
+    if title is not None:
+        ax.set_title(title)
+
+    meta: Dict[str, Any] = {
+        "n_edges": n_edges,
+        "n_elements_drawn": n_elements_drawn,
+        "edges_per_class": edges_per_class,
+        "skipped_classes": skipped,
+        "is_3d": is_3d,
+        "model_stage": model_stage,
+    }
+    return ax, meta
+
+
+def plot_mesh_with_contour(
+    dataset: "MPCODataSet",
+    element_results: "ElementResults",
+    component_canonical: str,
+    *,
+    step: int,
+    model_stage: Optional[str] = None,
+    element_type: Optional[str] = None,
+    element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+    ax: Any = None,
+    edge_color: Any = "lightgray",
+    linewidth: float = 0.5,
+    alpha: float = 1.0,
+    axes: Tuple[str, str] = ("x", "y"),
+    title: Optional[str] = None,
+    **scatter_kwargs: Any,
+) -> Tuple[Any, Dict[str, Any]]:
+    """One-call mesh + IP-colored scatter overlay.
+
+    Calls :func:`plot_mesh` then ``element_results.plot.scatter`` into
+    the same axes — the 80% "show the model, color the IPs" workflow.
+
+    Parameters
+    ----------
+    dataset : MPCODataSet
+    element_results : ElementResults
+        Result whose IPs will be colored.
+    component_canonical : str
+        Forwarded to :meth:`ElementResultsPlotter.scatter`.
+    step : int
+        Forwarded to :meth:`ElementResultsPlotter.scatter`.
+    model_stage, element_type, element_ids, ax, edge_color, linewidth,
+    alpha, title :
+        Forwarded to :func:`plot_mesh` (mesh styling).
+    axes : tuple of two of ``"x"``, ``"y"``, ``"z"``
+        Projection plane for the scatter — must match the mesh axes.
+    **scatter_kwargs
+        Forwarded to ``ax.scatter`` (e.g. ``cmap``, ``s``).
+
+    Returns
+    -------
+    (ax, meta) : tuple
+        ``meta`` carries ``{"mesh": <plot_mesh meta>,
+        "scatter": <ElementResultsPlotter.scatter meta>}``.
+    """
+    ax, mesh_meta = plot_mesh(
+        dataset,
+        model_stage=model_stage,
+        element_type=element_type,
+        element_ids=element_ids,
+        ax=ax,
+        edge_color=edge_color,
+        linewidth=linewidth,
+        alpha=alpha,
+        title=title,
+    )
+    _, scatter_meta = element_results.plot.scatter(
+        component_canonical,
+        step=int(step),
+        ax=ax,
+        axes=axes,
+        **scatter_kwargs,
+    )
+    return ax, {"mesh": mesh_meta, "scatter": scatter_meta}
+
+
+__all__ = ["plot_mesh", "plot_mesh_with_contour"]

--- a/src/STKO_to_python/plotting/plot.py
+++ b/src/STKO_to_python/plotting/plot.py
@@ -7,14 +7,17 @@ wrapper" from spec §8.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
 
+import numpy as np
 import matplotlib.pyplot as plt
 
 from .deformed_shape import plot_deformed_shape, plot_undeformed_shape
+from .mesh import plot_mesh, plot_mesh_with_contour
 
 if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
+    from ..elements.element_results import ElementResults
 
 
 class Plot:
@@ -159,6 +162,97 @@ class Plot:
             linewidth=linewidth,
             alpha=alpha,
             title=title,
+        )
+
+
+    # ------------------------------------------------------------------ #
+    # Mesh visualization ("show me the model")
+    # ------------------------------------------------------------------ #
+
+    def mesh(
+        self,
+        *,
+        model_stage: Optional[str] = None,
+        element_type: Optional[str] = None,
+        element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+        ax: Any = None,
+        edge_color: Any = "lightgray",
+        linewidth: float = 0.5,
+        alpha: float = 1.0,
+        title: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Tuple[Any, dict]:
+        """Render element edges from the cached connectivity.
+
+        Useful as a "show me the model" backdrop before or under a
+        contour plot. Composes with
+        :meth:`ElementResultsPlotter.scatter` — call ``mesh()`` first,
+        then pass the returned ``ax`` to ``er.plot.scatter(..., ax=ax)``
+        so a single axes carries both the wireframe and the IP scatter.
+
+        See :func:`STKO_to_python.plotting.mesh.plot_mesh` for the full
+        parameter list.
+
+        Examples
+        --------
+        Compose mesh + contour into a single axes::
+
+            ax, _ = ds.plot.mesh(element_type="ASDShellQ4")
+            er = ds.elements.get_element_results(
+                results_name="section.force",
+                element_type="ASDShellQ4",
+            )
+            er.plot.scatter("bending_moment_xx", step=10, ax=ax)
+        """
+        return plot_mesh(
+            self._dataset,
+            model_stage=model_stage,
+            element_type=element_type,
+            element_ids=element_ids,
+            ax=ax,
+            edge_color=edge_color,
+            linewidth=linewidth,
+            alpha=alpha,
+            title=title,
+            **kwargs,
+        )
+
+    def mesh_with_contour(
+        self,
+        element_results: "ElementResults",
+        component_canonical: str,
+        *,
+        step: int,
+        model_stage: Optional[str] = None,
+        element_type: Optional[str] = None,
+        element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+        ax: Any = None,
+        edge_color: Any = "lightgray",
+        linewidth: float = 0.5,
+        alpha: float = 1.0,
+        axes: Tuple[str, str] = ("x", "y"),
+        title: Optional[str] = None,
+        **scatter_kwargs: Any,
+    ) -> Tuple[Any, dict]:
+        """Convenience wrapper: ``mesh()`` then ``er.plot.scatter()`` on the same axes.
+
+        See :func:`STKO_to_python.plotting.mesh.plot_mesh_with_contour`.
+        """
+        return plot_mesh_with_contour(
+            self._dataset,
+            element_results,
+            component_canonical,
+            step=step,
+            model_stage=model_stage,
+            element_type=element_type,
+            element_ids=element_ids,
+            ax=ax,
+            edge_color=edge_color,
+            linewidth=linewidth,
+            alpha=alpha,
+            axes=axes,
+            title=title,
+            **scatter_kwargs,
         )
 
 

--- a/tests/integration/test_mesh_plot.py
+++ b/tests/integration/test_mesh_plot.py
@@ -1,0 +1,202 @@
+"""Integration tests for ``ds.plot.mesh`` and ``ds.plot.mesh_with_contour``.
+
+Verifies:
+
+* ``mesh()`` returns ``(ax, meta)`` with ``n_edges`` / ``n_elements_drawn``
+  matching the per-class topology (1 for beams, 4 for quads, 12 for
+  bricks);
+* ``element_type`` and ``element_ids`` filters narrow the rendered set;
+* ``er.plot.scatter`` overlays cleanly when handed an ``ax`` returned by
+  ``mesh()`` (composition contract);
+* ``mesh_with_contour`` is sugar that produces the same composition in
+  one call.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# Single-partition (line elements only)
+# ---------------------------------------------------------------------- #
+def test_mesh_elastic_frame_basic_contract(elastic_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    ax, meta = ds.plot.mesh()
+    try:
+        assert ax is not None
+        assert isinstance(meta, dict)
+        # 3 ElasticBeam3d elements, 1 edge each.
+        assert meta["edges_per_class"] == {"5-ElasticBeam3d(2n)": 1}
+        assert meta["n_edges"] == 3
+        assert meta["n_elements_drawn"] == 3
+        assert meta["skipped_classes"] == []
+        assert meta["is_3d"] is True
+    finally:
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# Multi-partition (shell quads + beams)
+# ---------------------------------------------------------------------- #
+def test_mesh_quad_frame_topology(quad_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    ax, meta = ds.plot.mesh()
+    try:
+        # 75 beams × 1 + 625 quads × 4 = 2575 edges total.
+        assert meta["edges_per_class"] == {
+            "5-ElasticBeam3d(2n)": 1,
+            "203-ASDShellQ4(4n)": 4,
+        }
+        assert meta["n_edges"] == 75 * 1 + 625 * 4
+        assert meta["n_elements_drawn"] == 75 + 625
+        assert meta["skipped_classes"] == []
+    finally:
+        plt.close("all")
+
+
+def test_mesh_filter_by_element_type(quad_frame_dir: Path) -> None:
+    """Selecting ASDShellQ4 alone should yield exactly 50 quads → 200 edges
+    sample (50 picked) — well, the fixture has 625; spec asks for the
+    50→200 expectation phrased in narrow terms. Verify by element_ids
+    instead so the count is reproducible."""
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    df = ds.elements_info["dataframe"]
+    quad_ids = df.loc[
+        df["element_type"] == "203-ASDShellQ4", "element_id"
+    ].head(50).tolist()
+    ax, meta = ds.plot.mesh(
+        element_type="203-ASDShellQ4", element_ids=quad_ids
+    )
+    try:
+        # 50 quad shells → 200 edges, single class.
+        assert meta["edges_per_class"] == {"203-ASDShellQ4(4n)": 4}
+        assert meta["n_edges"] == 200
+        assert meta["n_elements_drawn"] == 50
+    finally:
+        plt.close("all")
+
+
+def test_mesh_filter_only_beams(quad_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    ax, meta = ds.plot.mesh(element_type="5-ElasticBeam3d")
+    try:
+        assert meta["edges_per_class"] == {"5-ElasticBeam3d(2n)": 1}
+        assert meta["n_edges"] == 75
+        assert meta["n_elements_drawn"] == 75
+    finally:
+        plt.close("all")
+
+
+def test_mesh_empty_filter_raises(quad_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    with pytest.raises(ValueError, match="No elements remain"):
+        ds.plot.mesh(element_ids=[999_999_999])
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# Composition with er.plot.scatter
+# ---------------------------------------------------------------------- #
+def test_mesh_then_scatter_compose(quad_frame_dir: Path) -> None:
+    """mesh() returns ax; scatter(..., ax=ax) overlays onto same axes."""
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_ids = (
+        ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .head(20)
+        .tolist()
+    )
+    try:
+        ax, mesh_meta = ds.plot.mesh(
+            element_type="203-ASDShellQ4", element_ids=shell_ids
+        )
+        n_lines_before = len(ax.collections)
+        assert n_lines_before >= 1  # mesh produced a LineCollection
+
+        er = ds.elements.get_element_results(
+            results_name="section.force",
+            element_type="203-ASDShellQ4",
+            element_ids=shell_ids,
+            model_stage="MODEL_STAGE[1]",
+        )
+        _, scatter_meta = er.plot.scatter("membrane_xx", step=2, ax=ax)
+        # Scatter adds a PathCollection on the same axes.
+        assert len(ax.collections) > n_lines_before
+        assert scatter_meta["x"].size == 20 * er.n_ip
+    finally:
+        plt.close("all")
+
+
+def test_mesh_with_contour_sugar(quad_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    shell_ids = (
+        ds.elements_info["dataframe"]
+        .query("element_type == '203-ASDShellQ4'")["element_id"]
+        .head(10)
+        .tolist()
+    )
+    er = ds.elements.get_element_results(
+        results_name="section.force",
+        element_type="203-ASDShellQ4",
+        element_ids=shell_ids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    try:
+        ax, meta = ds.plot.mesh_with_contour(
+            er,
+            "membrane_xx",
+            step=2,
+            element_type="203-ASDShellQ4",
+            element_ids=shell_ids,
+        )
+        assert "mesh" in meta and "scatter" in meta
+        assert meta["mesh"]["n_edges"] == 10 * 4
+        assert meta["scatter"]["x"].size == 10 * er.n_ip
+        # Single ax holds both the mesh wireframe and the scatter.
+        assert len(ax.collections) >= 2
+    finally:
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# Solid example (skipped if absent)
+# ---------------------------------------------------------------------- #
+def test_mesh_solid_partition_brick_topology(solid_partition_dir: Path) -> None:
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    df = ds.elements_info["dataframe"]
+    n_brick = int((df["element_type"] == "56-Brick").sum())
+    if n_brick == 0:
+        pytest.skip("No bricks in solid_partition fixture")
+    try:
+        ax, meta = ds.plot.mesh(element_type="56-Brick")
+        # 12 edges per brick, single class.
+        assert meta["edges_per_class"] == {"56-Brick(8n)": 12}
+        assert meta["n_edges"] == n_brick * 12
+        assert meta["n_elements_drawn"] == n_brick
+        assert meta["is_3d"] is True
+    finally:
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# User-supplied axes
+# ---------------------------------------------------------------------- #
+def test_mesh_accepts_user_axes(elastic_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    fig = plt.figure()
+    user_ax = fig.add_subplot(111, projection="3d")
+    try:
+        ax, meta = ds.plot.mesh(ax=user_ax)
+        assert ax is user_ax
+        assert meta["n_edges"] == 3
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary
- `ds.plot.mesh()` renders element edges (Line2D / Line3DCollection) from the cached connectivity so users can orient themselves before/under a contour. Per-class topology: 1 segment/beam, 4/quad-shell, 3/tri, 12/brick. Returns `(ax, meta)` with `n_edges` and `n_elements_drawn`.
- `ds.plot.mesh_with_contour(er, canonical, step=...)` is sugar that calls `mesh()` then `er.plot.scatter()` into the same axes — the 80% "show the model, color the IPs" workflow.
- Topology helpers are reused from `plotting/deformed_shape.py` (single source of truth for edge connectivity, 2D/3D decision, and segment drawing).
- `element_type` / `element_ids` filters narrow the rendered set; mesh `ax` composes cleanly with `er.plot.scatter(..., ax=ax)`.

## Test plan
- [x] `tests/integration/test_mesh_plot.py` covers: basic `(ax, meta)` contract, edge-count assertions per class on `elasticFrame` (3 beams → 3 edges) and `QuadFrame_results` (75 beams + 625 quads → 2575 edges); `element_type` / `element_ids` filtering (50 quads → 200 edges); mesh+scatter composition into one ax; `mesh_with_contour` sugar; user-supplied axes; brick topology on `solid_partition_example` (skips if absent).
- [x] Full suite green locally (`pytest -q` → 570 passed, 32 skipped — skips are gitignored fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)