### PR TITLE
Resolve test fixtures from main checkout when run inside a worktree

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,47 @@ GOLDEN_MPCO_NAME = "golden.mpco"
 # Real-world examples checked in under stko_results_examples/. These are
 # the canonical integration-test inputs; see memory/project_examples_folder.md.
 REPO_ROOT = Path(__file__).resolve().parents[1]
-EXAMPLES_DIR = REPO_ROOT / "stko_results_examples"
+
+
+def _resolve_examples_dir(repo_root: Path) -> Path:
+    """Return the ``stko_results_examples`` dir to read fixtures from.
+
+    Worktrees spawned under ``<main>/.claude/worktrees/<name>/`` rarely
+    carry the ~2 GB of example fixtures — only ``elasticFrame`` is small
+    enough to be checked in. To keep tests in worktrees from silently
+    skipping coverage, we fall back to the main checkout's copy when
+    the worktree-local one is missing the heavier fixtures.
+
+    Resolution order:
+
+    1. ``<repo_root>/stko_results_examples`` if it has the heavier
+       fixtures (``Test_NLShell`` or ``solid_partition_example``).
+    2. The main checkout derived by stripping ``.claude/worktrees/<name>``
+       from ``repo_root``, if that path has the examples.
+    3. Whatever ``<repo_root>/stko_results_examples`` is — individual
+       fixtures will skip per the existing ``.exists()`` checks.
+    """
+    local = repo_root / "stko_results_examples"
+    has_heavy = (local / "Test_NLShell").exists() or (
+        local / "solid_partition_example"
+    ).exists()
+    if has_heavy:
+        return local
+
+    parts = repo_root.parts
+    try:
+        idx = parts.index(".claude")
+    except ValueError:
+        return local
+    if idx + 2 < len(parts) and parts[idx + 1] == "worktrees":
+        main_root = Path(*parts[:idx])
+        candidate = main_root / "stko_results_examples"
+        if candidate.exists():
+            return candidate
+    return local
+
+
+EXAMPLES_DIR = _resolve_examples_dir(REPO_ROOT)
 ELASTIC_FRAME_DIR = EXAMPLES_DIR / "elasticFrame" / "results"
 QUAD_FRAME_DIR = EXAMPLES_DIR / "elasticFrame" / "QuadFrame_results"
 SOLID_PARTITION_DIR = EXAMPLES_DIR / "solid_partition_example"


### PR DESCRIPTION
## Summary

Worktrees spawned under `<main>/.claude/worktrees/<name>/` only carry the small `elasticFrame` example, not the ~2 GB `Test_NLShell` and `solid_partition_example` fixtures that live in the main checkout. As a result, ~32 fixture-gated integration tests silently skipped on every worktree-based PR run, masking real coverage.

`tests/conftest.py` now resolves `EXAMPLES_DIR` via a small helper that:

1. Uses `<repo_root>/stko_results_examples` if it has the heavier fixtures.
2. Otherwise, if `repo_root` lives under `.claude/worktrees/<name>/`, derives the main checkout path and uses its examples directory.
3. Otherwise, leaves the path as-is so the existing per-fixture `.exists()` skip logic still applies.

No fixture files are copied or symlinked — the resolver just points the same code at the existing main-checkout copy when needed. Behaviour outside worktrees is unchanged (the heavy-fixture check passes, so the local path is used).

## Test plan

- [x] Inside a `.claude/worktrees/...` worktree carrying only `elasticFrame`: `pytest -q` went from **570 passed, 32 skipped** to **602 passed, 0 skipped**.
- [x] `python -c "from tests.conftest import EXAMPLES_DIR; print(EXAMPLES_DIR)"` resolves to the main checkout's `stko_results_examples/` from inside a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)