### PR TITLE
Bump to v1.1.0 and document versioning policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,16 @@
 This is a helper class to parse results obtained from opensees using MPCO recorders.
 
 The class works with STKO outputs
+
+## Versioning policy
+
+We follow semver and tag releases on `main`:
+
+- **MAJOR** (`vX.0.0`) — breaking changes to the public API.
+- **MINOR** (`v1.X.0`) — new backward-compatible features (new methods, new result types, new plot helpers).
+- **PATCH** (`v1.x.Y`) — bug fixes, docs, tests, internal refactors with no API change.
+
+When merging a PR (or a batch of related PRs) that warrants a release:
+1. Bump `version` in `pyproject.toml`.
+2. After the PR merges, tag the merge commit on `main` (`git tag vX.Y.Z <sha> && git push origin vX.Y.Z`).
+3. Tags are lightweight unless a real GitHub release with artifacts is being cut.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "STKO_to_python"
-version = "1.0.0"
+version = "1.1.0"
 description = "STKO tools for Python"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` from 1.0.0 → 1.1.0 to reflect the 21 backward-compatible PRs (#22–#42) merged since the v1.0.0 release.
- Adds a short semver policy to `CLAUDE.md` so future bumps and tags are done consistently (MINOR for features, PATCH for fixes/docs/tests, MAJOR for breaking changes; tag the merge commit on `main` after each release-worthy merge).

## What's in v1.1.0 vs v1.0.0
Feature work:
- MPCO META parser (#22), Gauss-point catalog (#23/#24), integration helpers (#28), physical coordinates + Jacobians (#25), layered shells (#30), ElementResults extras + plot namespace (#32), deformed-shape (#37), mesh wireframe (#38), multi-stage fetch (#42).

Docs / examples / tests:
- Elements user guide (#27), nav and index updates (#29/#31), API stub fills (#34/#35), spatial-query polish (#36), fixture-specific demos (#33), worktree-aware fixture resolver (#40), cookbook tutorials (#41), scatter docstring (#39), repo hygiene (#26).

## Follow-up after merge
- Tag the merge commit: `git tag v1.1.0 <sha> && git push origin v1.1.0`.

## Test plan
- [ ] CI passes (no code changes, version string + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)