### PR TITLE
Add benchmark CI workflow (Phase 5.1)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,51 @@
+name: Bench
+
+# Runs the pytest-benchmark suite under bench/ on every PR and on every
+# push to main. Uploads benchmark.json as an artifact so it can be
+# compared across runs. Regression detection lands in a follow-up:
+# this workflow currently surfaces numbers but does not fail the build
+# on regression.
+#
+# The bench tree is gated on small fixtures committed under
+# stko_results_examples/elasticFrame/ (~330 KB). Benches that require
+# the larger Test_NLShell fixture (gitignored) skip cleanly.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package with bench extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[bench]"
+
+      - name: Run benchmarks
+        run: |
+          pytest bench/ -q \
+            --benchmark-only \
+            --benchmark-json=benchmark.json
+
+      - name: Upload benchmark.json
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ github.run_id }}
+          path: benchmark.json
+          if-no-files-found: warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pytest>=7.4",
 ]
 # Installed with: pip install -e ".[bench]"
-# Enables pytest-benchmark suites under tests/bench/. Opt-in so regular
+# Enables pytest-benchmark suites under bench/. Opt-in so regular
 # test runs don't pay the bench collection overhead. Introduced in
 # Phase 5.1.a.
 bench = [


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bench.yml` running the `pytest-benchmark` suite under `bench/` on every PR and on every push to `main`
- Uploads `benchmark.json` as a build artifact for later regression analysis
- Fixes stale `tests/bench/` reference in `pyproject.toml` bench-extras comment (the suite lives at `bench/`)

## Why this shape
The proposal (Phase 5.1) calls for a 25 % regression gate. That requires a stored baseline; this PR establishes the pipeline first and leaves gating to a follow-up once a few green main runs have populated artifacts. The bench tree gates itself on the small committed elasticFrame fixtures (~330 KB), so CI runs end-to-end without needing the gitignored Test_NLShell data.

## Local verification
\`\`\`
$ pytest bench/ -q --benchmark-only
... 10 passed in 9.16s
\`\`\`

## Test plan
- [ ] Bench workflow runs green on this PR
- [ ] `benchmark-<run_id>` artifact appears on the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)