### PR TITLE
Add test CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+# Runs the unit + integration test suite under tests/ on every PR and on
+# every push to main. Matrix-tests across the supported Python versions
+# (3.11 / 3.12 / 3.13) declared in pyproject.toml.
+#
+# Plotting tests rely on matplotlib; MPLBACKEND=Agg keeps the headless
+# runner from trying to open an interactive display.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with test extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run pytest
+        run: pytest tests/ -q


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` running the unit + integration test suite (`tests/`) on every PR and push to `main`
- Matrix-tests Python 3.11 / 3.12 / 3.13 (the versions declared in `pyproject.toml` classifiers)
- Sets `MPLBACKEND=Agg` so plotting tests work on the headless runner

## Why
Previously only `docs.yml` (mkdocs build) and `release.yml` (tag-driven artifacts) ran on PRs. The 615-test suite never executed in CI, so a regression could merge silently. This PR closes that gap.

## Local verification
\`\`\`
$ pytest tests/ -q
... 615 passed in 59.62s
\`\`\`

## Test plan
- [ ] Test workflow runs green on this PR across all three Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)