### PR TITLE
Emit DeprecationWarning on legacy Group-A compat shim paths

### DIFF
--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -11,7 +11,13 @@ from .model.model_info import ModelInfo
 from .model.cdata import CData
 
 from .plotting.plot import Plot
-from .plotting.plot_dataclasses import ModelPlotSettings
+from .plotting.plot_settings import PlotSettings
+
+# Back-compat alias preserved on the top-level package surface (quiet);
+# the deep path
+# ``STKO_to_python.plotting.plot_dataclasses.ModelPlotSettings`` emits a
+# ``DeprecationWarning``.
+ModelPlotSettings = PlotSettings
 
 from .dataprocess import Aggregator, StrOp
 

--- a/src/STKO_to_python/core/__init__.py
+++ b/src/STKO_to_python/core/__init__.py
@@ -1,6 +1,10 @@
 from .dataset import MPCODataSet
-from .dataclasses import MetaData
 from .metadata import ModelMetadata
+
+# Back-compat alias preserved on the package surface (quiet); the deep
+# path ``STKO_to_python.core.dataclasses.MetaData`` emits a
+# ``DeprecationWarning`` via PEP 562 ``__getattr__``.
+MetaData = ModelMetadata
 
 __all__ = [
     "MPCODataSet",

--- a/src/STKO_to_python/core/dataclasses.py
+++ b/src/STKO_to_python/core/dataclasses.py
@@ -1,20 +1,42 @@
-"""Back-compat shim — re-exports ``ModelMetadata`` as ``MetaData``.
+"""Back-compat shim — emits ``DeprecationWarning`` when ``MetaData`` is accessed.
 
-The canonical class now lives in :mod:`STKO_to_python.core.metadata`.
-``MetaData`` is an alias so existing callers continue to work
-unchanged. Both names resolve to the *same* class object:
+The canonical class lives at :mod:`STKO_to_python.core.metadata` as
+``ModelMetadata``. ``MetaData`` is preserved as a back-compat name on
+this module and (without warning) on the top-level package, so
 
-    >>> from STKO_to_python.core.dataclasses import MetaData
+    >>> from STKO_to_python import MetaData            # quiet
+    >>> from STKO_to_python.core.dataclasses import MetaData   # DeprecationWarning
+
+both keep working. New code should prefer
+
     >>> from STKO_to_python.core.metadata import ModelMetadata
-    >>> MetaData is ModelMetadata
-    True
+    >>> # or, equivalently, the top-level export:
+    >>> from STKO_to_python import ModelMetadata
 
-A future phase may emit a ``DeprecationWarning`` on import; for now the
-shim is silent so the strict-warning filter under
-``pyproject.toml[tool.pytest]`` stays happy.
+The lookup is implemented via the PEP 562 module ``__getattr__`` so the
+warning only fires when ``MetaData`` is actually imported from this
+specific deep path — plain ``import STKO_to_python.core.dataclasses``
+remains silent.
 """
 from __future__ import annotations
 
-from .metadata import ModelMetadata as MetaData
+import warnings
+from typing import Any
+
+from .metadata import ModelMetadata
+
+
+def __getattr__(name: str) -> Any:
+    if name == "MetaData":
+        warnings.warn(
+            "`STKO_to_python.core.dataclasses.MetaData` is deprecated; "
+            "import `ModelMetadata` from `STKO_to_python.core.metadata` "
+            "instead (or use the top-level `STKO_to_python.ModelMetadata`).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ModelMetadata
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["MetaData"]

--- a/src/STKO_to_python/core/dataset.py
+++ b/src/STKO_to_python/core/dataset.py
@@ -13,8 +13,8 @@ from ..io.partition_pool import Hdf5PartitionPool
 from ..io.format_policy import MpcoFormatPolicy
 from ..selection import SelectionSetResolver
 from ..query import ElementResultsQueryEngine, NodalResultsQueryEngine
-from .dataclasses import MetaData
-from ..plotting.plot_dataclasses import ModelPlotSettings
+from .metadata import ModelMetadata
+from ..plotting.plot_settings import PlotSettings
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +149,7 @@ class MPCODataSet:
         name=None, # The model name, if None it will be extracted from the folder name
         file_extension='*.mpco',
         verbose=False,
-        plot_settings: Optional[ModelPlotSettings] = None,
+        plot_settings: Optional[PlotSettings] = None,
         pool_size: Optional[int] = None,
     ):
 
@@ -175,7 +175,7 @@ class MPCODataSet:
         self._pool: Optional[Hdf5PartitionPool] = None
 
         # Initialize the metadata
-        self.metadata = MetaData()
+        self.metadata = ModelMetadata()
         
         # Instanciate the composite classes
         self.nodes=Nodes(self)
@@ -184,7 +184,7 @@ class MPCODataSet:
         self.cdata=CData(self)
         self.plot=Plot(self)
         self.info=Info(self)
-        self.plot_settings = plot_settings or ModelPlotSettings()
+        self.plot_settings = plot_settings or PlotSettings()
         
         # Create the object attributes
         self._create_object_attributes()

--- a/src/STKO_to_python/plotting/__init__.py
+++ b/src/STKO_to_python/plotting/__init__.py
@@ -1,6 +1,10 @@
 from .plot import Plot
-from .plot_dataclasses import ModelPlotSettings
 from .plot_settings import PlotSettings
+
+# Back-compat alias preserved on the package surface (quiet); the deep
+# path ``STKO_to_python.plotting.plot_dataclasses.ModelPlotSettings``
+# emits a ``DeprecationWarning`` via PEP 562 ``__getattr__``.
+ModelPlotSettings = PlotSettings
 
 __all__=[
     'Plot',

--- a/src/STKO_to_python/plotting/plot_dataclasses.py
+++ b/src/STKO_to_python/plotting/plot_dataclasses.py
@@ -1,16 +1,46 @@
-"""Back-compat shim — re-exports ``PlotSettings`` as ``ModelPlotSettings``.
+"""Back-compat shim — emits ``DeprecationWarning`` when ``ModelPlotSettings``
+is accessed.
 
-The canonical class now lives in :mod:`STKO_to_python.plotting.plot_settings`.
-``ModelPlotSettings`` is an alias; both names resolve to the **same
-class object**:
+The canonical class lives at :mod:`STKO_to_python.plotting.plot_settings`
+as ``PlotSettings``. ``ModelPlotSettings`` is preserved as a back-compat
+name on this module and (without warning) on the top-level
+``STKO_to_python.plotting`` package, so
 
+    >>> from STKO_to_python.plotting import ModelPlotSettings   # quiet
     >>> from STKO_to_python.plotting.plot_dataclasses import ModelPlotSettings
+    ...                                                         # DeprecationWarning
+
+both keep working. New code should prefer
+
     >>> from STKO_to_python.plotting.plot_settings import PlotSettings
-    >>> ModelPlotSettings is PlotSettings
-    True
+    >>> # or, equivalently:
+    >>> from STKO_to_python.plotting import PlotSettings
+
+The lookup is implemented via the PEP 562 module ``__getattr__`` so the
+warning only fires when ``ModelPlotSettings`` is actually imported from
+this specific deep path — plain ``import
+STKO_to_python.plotting.plot_dataclasses`` remains silent.
 """
 from __future__ import annotations
 
-from .plot_settings import PlotSettings as ModelPlotSettings
+import warnings
+from typing import Any
+
+from .plot_settings import PlotSettings
+
+
+def __getattr__(name: str) -> Any:
+    if name == "ModelPlotSettings":
+        warnings.warn(
+            "`STKO_to_python.plotting.plot_dataclasses.ModelPlotSettings` "
+            "is deprecated; import `PlotSettings` from "
+            "`STKO_to_python.plotting.plot_settings` instead (or use the "
+            "top-level `STKO_to_python.ModelPlotSettings`).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return PlotSettings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["ModelPlotSettings"]

--- a/tests/unit/test_model_metadata.py
+++ b/tests/unit/test_model_metadata.py
@@ -8,18 +8,26 @@ from datetime import datetime
 import pytest
 
 from STKO_to_python.core.metadata import ModelMetadata
-from STKO_to_python.core.dataclasses import MetaData
 
 
 # ---------------------------------------------------------------------- #
 # Alias identity
 # ---------------------------------------------------------------------- #
-def test_metadata_alias_is_model_metadata():
+def test_metadata_alias_is_model_metadata_and_emits_deprecation():
+    """Importing ``MetaData`` from the deprecated deep path must emit a
+    ``DeprecationWarning`` and resolve to ``ModelMetadata``."""
+    with pytest.warns(DeprecationWarning, match="MetaData.*deprecated"):
+        from STKO_to_python.core.dataclasses import MetaData
     assert MetaData is ModelMetadata
 
 
-def test_top_level_core_exports_both_names():
-    from STKO_to_python.core import MetaData as M, ModelMetadata as MM
+def test_top_level_core_exports_both_names_quietly():
+    """The package-surface alias (``STKO_to_python.core.MetaData``) is
+    quiet — only the deep ``core.dataclasses`` path emits the warning."""
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        from STKO_to_python.core import MetaData as M, ModelMetadata as MM
     assert M is MM
 
 

--- a/tests/unit/test_plot_settings.py
+++ b/tests/unit/test_plot_settings.py
@@ -7,18 +7,26 @@ import pickle
 import pytest
 
 from STKO_to_python.plotting.plot_settings import PlotSettings
-from STKO_to_python.plotting.plot_dataclasses import ModelPlotSettings
 
 
 # ---------------------------------------------------------------------- #
 # Alias identity
 # ---------------------------------------------------------------------- #
-def test_alias_is_plot_settings():
+def test_alias_is_plot_settings_and_emits_deprecation():
+    """Importing ``ModelPlotSettings`` from the deprecated deep path must
+    emit a ``DeprecationWarning`` and resolve to ``PlotSettings``."""
+    with pytest.warns(DeprecationWarning, match="ModelPlotSettings.*deprecated"):
+        from STKO_to_python.plotting.plot_dataclasses import ModelPlotSettings
     assert ModelPlotSettings is PlotSettings
 
 
-def test_top_level_plotting_exports_both_names():
-    from STKO_to_python.plotting import ModelPlotSettings as M, PlotSettings as P
+def test_top_level_plotting_exports_both_names_quietly():
+    """The package-surface alias is quiet — only the deep
+    ``plotting.plot_dataclasses`` path emits the warning."""
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        from STKO_to_python.plotting import ModelPlotSettings as M, PlotSettings as P
     assert M is P
 
 

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -43,10 +43,11 @@ PUBLIC_SYMBOLS = [
     ("STKO_to_python.model.model_info", "ModelInfo"),
     ("STKO_to_python.model.cdata", "CData"),
     ("STKO_to_python.plotting.plot", "Plot"),
-    ("STKO_to_python.plotting.plot_dataclasses", "ModelPlotSettings"),
     ("STKO_to_python.utilities.attribute_dictionary_class", "AttrDict"),
     ("STKO_to_python.results.nodal_results_dataclass", "NodalResults"),
     ("STKO_to_python.results.nodal_results_plotting", "NodalResultsPlotter"),
+    # NOTE: deprecated deep paths (e.g. STKO_to_python.plotting.plot_dataclasses)
+    # are exercised below with explicit DeprecationWarning expectations.
 ]
 
 
@@ -73,6 +74,43 @@ def test_package_all_contract() -> None:
     declared = set(pkg.__all__)
     missing = required - declared
     assert not missing, f"Public __all__ is missing symbols: {missing}"
+
+
+DEPRECATED_DEEP_IMPORTS = [
+    # (module_path, attr, canonical_module, canonical_attr)
+    (
+        "STKO_to_python.core.dataclasses",
+        "MetaData",
+        "STKO_to_python.core.metadata",
+        "ModelMetadata",
+    ),
+    (
+        "STKO_to_python.plotting.plot_dataclasses",
+        "ModelPlotSettings",
+        "STKO_to_python.plotting.plot_settings",
+        "PlotSettings",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("module_path", "attr", "canonical_module", "canonical_attr"),
+    DEPRECATED_DEEP_IMPORTS,
+)
+def test_deprecated_deep_path_still_resolves(
+    module_path: str,
+    attr: str,
+    canonical_module: str,
+    canonical_attr: str,
+) -> None:
+    """Deprecated deep paths must keep resolving (hard-compat) but emit
+    a ``DeprecationWarning`` and resolve to the same object as the
+    canonical path."""
+    module = importlib.import_module(module_path)
+    with pytest.warns(DeprecationWarning, match=attr):
+        legacy = getattr(module, attr)
+    canonical = getattr(importlib.import_module(canonical_module), canonical_attr)
+    assert legacy is canonical
 
 
 def test_pickle_module_qualname_pins() -> None:


### PR DESCRIPTION
## Summary
- Adds PEP 562 `__getattr__`-based `DeprecationWarning` emission on the two pure compat shim files: `core/dataclasses.py` (`MetaData`) and `plotting/plot_dataclasses.py` (`ModelPlotSettings`)
- Updates internal library imports to use the canonical names (`ModelMetadata`, `PlotSettings`) so the library never trips its own warning
- Wraps the tests that exercise the legacy paths in `pytest.warns(DeprecationWarning)` so they still pass under the strict-warning filter
- Top-level package surface stays warning-free; only deep imports from the shim modules warn

## Behavior
| Import | After this PR |
|---|---|
| `from STKO_to_python import ModelPlotSettings` | quiet (top-level alias of `PlotSettings`) |
| `from STKO_to_python.plotting import ModelPlotSettings` | quiet (subpackage alias of `PlotSettings`) |
| `from STKO_to_python.plotting.plot_dataclasses import ModelPlotSettings` | **DeprecationWarning** |
| `from STKO_to_python.core import MetaData` | quiet (subpackage alias of `ModelMetadata`) |
| `from STKO_to_python.core.dataclasses import MetaData` | **DeprecationWarning** |

Same identity in every case — the legacy names resolve to the canonical class object.

## Why PEP 562, not eager `warnings.warn()`
A plain `import STKO_to_python.core.dataclasses` shouldn't fire the warning — only an explicit deep-path attribute access should. PEP 562's module-level `__getattr__` gives us exactly that behavior.

## Local verification
\`\`\`
$ pytest tests/ -q
... 616 passed in 30.02s
\`\`\`

## Scope
Only Group A (pure shim files). Group B aliases — `Nodes`, `Elements`, `ModelInfo`, `CData` — sit at the bottom of their canonical-class files. Deprecating those cleanly requires the file rename the proposal originally called for (`nodes/nodes.py` → `nodes/node_manager.py`, etc.), which is its own PR.

## Test plan
- [ ] CI passes
- [ ] No warnings on `import STKO_to_python` or any documented top-level import

🤖 Generated with [Claude Code](https://claude.com/claude-code)