### PR TITLE
Phase 4a: __slots__ on NodalResults + _ResultView

### DIFF
--- a/bench/test_pickle_bench.py
+++ b/bench/test_pickle_bench.py
@@ -89,6 +89,10 @@ def test_bench_setstate_with_unknown_keys(benchmark, warm_dataset):
         return target
 
     loaded = benchmark(_setstate)
-    assert "drift_profile_cache" not in loaded.__dict__
-    assert "residual_cache" not in loaded.__dict__
-    assert "legacy_flag" not in loaded.__dict__
+    # NodalResults is slotted (Phase 4a); leaked unknown keys would
+    # AttributeError on setattr. Verify both that the names aren't bound
+    # and that no rogue __dict__ snuck in.
+    assert not hasattr(loaded, "drift_profile_cache")
+    assert not hasattr(loaded, "residual_cache")
+    assert not hasattr(loaded, "legacy_flag")
+    assert not hasattr(loaded, "__dict__")

--- a/src/STKO_to_python/results/nodal_results_dataclass.py
+++ b/src/STKO_to_python/results/nodal_results_dataclass.py
@@ -33,6 +33,8 @@ class _ResultView:
         results.ACCELERATION[:, [14, 25]]   -> all components, nodes 14 & 25
     """
 
+    __slots__ = ("_parent", "_result_name")
+
     def __init__(self, parent: "NodalResults", result_name: str):
         self._parent = parent
         self._result_name = result_name
@@ -77,7 +79,16 @@ class NodalResults:
     Expected df shape:
       - index: (node_id, step) OR (stage, node_id, step)
       - columns: MultiIndex (result, component) OR single-level
+
+    Memory layout
+    -------------
+    Instance attributes are declared in ``__slots__``. There is no
+    ``__dict__`` per instance; setting an undeclared attribute raises
+    ``AttributeError``. The class-level ``_aggregation_engine`` and
+    ``_PICKLE_FIELDS`` are class attributes and are unaffected.
     """
+
+    __slots__ = ("df", "time", "name", "info", "plot_settings", "_views")
 
     # Shared stateless aggregator — engineering methods (drift, envelope,
     # rocking, ...) forward to this instance. Class-level rather than
@@ -152,7 +163,15 @@ class NodalResults:
     )
 
     def __getstate__(self) -> dict[str, Any]:
-        state = self.__dict__.copy()
+        # Slotted classes have no ``self.__dict__``; build the pickle
+        # payload explicitly from ``_PICKLE_FIELDS``. Missing slots
+        # (e.g. an instance that was never fully initialized) round-trip
+        # as ``None``; ``__setstate__`` ignores ``None`` values for
+        # required fields the same way it ignores missing keys.
+        state: dict[str, Any] = {f: getattr(self, f, None) for f in self._PICKLE_FIELDS}
+        # ``_views`` is transient — rebuilt by ``__setstate__`` against
+        # the restored ``df``. Encoded as None so old readers still see a
+        # familiar shape.
         state["_views"] = None
         return state
 
@@ -160,7 +179,7 @@ class NodalResults:
         """
         Restore from a pickle dict. Tolerant of:
           - extra keys from older layouts (silently dropped with a DEBUG log)
-          - missing keys (the corresponding attribute stays unset; callers
+          - missing keys (the corresponding slot stays unset; callers
             see an AttributeError at access time rather than a cryptic
             unpickling failure)
           - the absence of _aggregation_engine (it is a class attribute
@@ -172,7 +191,9 @@ class NodalResults:
 
         for key, value in state.items():
             if key in known:
-                self.__dict__[key] = value
+                # ``setattr`` routes through the slot descriptor;
+                # ``self.__dict__[...]`` would AttributeError under slots.
+                setattr(self, key, value)
             elif key in accepted_transient:
                 continue
             else:
@@ -183,7 +204,10 @@ class NodalResults:
 
         # _views is never persisted — always rebuild against the loaded df.
         self._views = {}
-        if "df" in self.__dict__:
+        # Pre-slots tolerance: when ``df`` is missing we leave the views
+        # empty rather than synthesizing them from a half-loaded state.
+        df = getattr(self, "df", None)
+        if df is not None:
             self._build_views()
 
     def save_pickle(
@@ -810,13 +834,28 @@ class NodalResults:
     # ------------------------------------------------------------------ #
 
     def __getattr__(self, item: str) -> Any:
-        if "_views" in self.__dict__ and item in self._views:
-            return self._views[item]
+        # ``__getattr__`` only fires after normal lookup (slot descriptor)
+        # has missed. Access ``_views`` through ``object.__getattribute__``
+        # to bypass this method and avoid infinite recursion when the
+        # ``_views`` slot is itself unset (e.g. during early ``__new__``
+        # before ``__init__`` ran).
+        try:
+            views = object.__getattribute__(self, "_views")
+        except AttributeError:
+            raise AttributeError(
+                f"{type(self).__name__!r} object has no attribute {item!r}"
+            ) from None
+        if item in views:
+            return views[item]
         raise AttributeError(f"{type(self).__name__!r} object has no attribute {item!r}")
 
     def __dir__(self):
         base = set(super().__dir__())
-        base.update(self._views.keys())
+        try:
+            views = object.__getattribute__(self, "_views")
+            base.update(views.keys())
+        except AttributeError:
+            pass
         return sorted(base)
 
     # ------------------------------------------------------------------ #

--- a/tests/unit/results/test_nodal_results_pickle.py
+++ b/tests/unit/results/test_nodal_results_pickle.py
@@ -92,9 +92,15 @@ def test_setstate_drops_unknown_keys_with_debug_log(caplog):
 
     # Known fields land on the instance.
     pd.testing.assert_frame_equal(target.df, nr.df)
-    # Unknown fields did not leak in.
-    assert "drift_profile_cache" not in target.__dict__
-    assert "residual_cache" not in target.__dict__
+    # Unknown fields did not leak in. ``NodalResults`` is slotted, so a
+    # leaked key would have raised AttributeError on setattr; verify both
+    # that the names aren't bound and that the instance has no __dict__.
+    assert not hasattr(target, "drift_profile_cache")
+    assert not hasattr(target, "residual_cache")
+    assert not hasattr(target, "__dict__"), (
+        "NodalResults must remain slotted; an unexpected __dict__ would "
+        "let unknown pickle keys leak onto the instance."
+    )
     # DEBUG log mentions the dropped keys by name.
     messages = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
     joined = "\n".join(messages)


### PR DESCRIPTION
## Summary
Closes the last structural gap of Phase 4 in the architecture proposal. Engineering aggregations were already forwarders to `AggregationEngine` and the tolerant `__setstate__` was already in place; this PR adds the slot discipline the proposal mandates and updates the surrounding code to be `__dict__`-free.

## Changes
- `NodalResults.__slots__` declares the six instance attributes (`df`, `time`, `name`, `info`, `plot_settings`, `_views`). Class-level `_aggregation_engine` and `_PICKLE_FIELDS` stay as class attributes — slots only constrain instance state.
- `_ResultView` (the dynamic-attribute proxy) gets matching slots.
- `__getstate__` builds the pickle payload from `_PICKLE_FIELDS` via `getattr` instead of copying `self.__dict__`.
- `__setstate__` routes through `setattr` (which goes through the slot descriptor) instead of `self.__dict__[key] = value`.
- `__getattr__` and `__dir__` access `_views` through `object.__getattribute__` to bypass the recursion that would otherwise occur when the slot is unset (e.g., between `__new__` and `__init__`).

## Behavior
The only publicly observable change is **discipline**: attempts to set undeclared attributes on a `NodalResults` instance now raise `AttributeError` instead of silently growing the instance dict. Nothing in the library or test suite was setting such attributes.

Pickle compatibility is preserved end-to-end:
- Old pickles with extra keys (e.g. `drift_profile_cache` from a pre-AggregationEngine layout) load cleanly; unknown keys are filtered before any `setattr` call and logged at DEBUG.
- Old pickles missing keys still load — the slot stays unset, and access raises `AttributeError` exactly as documented.

## Tests
- Pickle-tolerance test now asserts the slotted invariant: no rogue `__dict__` after a load with unknown keys; `hasattr` returns False for the dropped names.
- The matching bench (`test_bench_setstate_with_unknown_keys`) was updated to the same shape so the regression-protection benches still run green.
- Full suite: **616 unit/integration + 10 benches = 626 passed.**

## Test plan
- [ ] CI green (test + bench workflows)
- [ ] No `__dict__` regression on `NodalResults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)