### PR TITLE
Relocate Gauss/shape modules from utilities/ to format/

### DIFF
--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -380,7 +380,7 @@ class ElementResults:
         """
         if self.gp_natural is None or self.element_node_coords is None:
             return None
-        from ..utilities.shape_functions import (
+        from ..format.shape_functions import (
             compute_physical_coords,
             get_shape_functions,
         )
@@ -422,7 +422,7 @@ class ElementResults:
         """
         if self.gp_natural is None or self.element_node_coords is None:
             return None
-        from ..utilities.shape_functions import (
+        from ..format.shape_functions import (
             compute_jacobian_dets,
             get_shape_functions,
         )

--- a/src/STKO_to_python/elements/elements.py
+++ b/src/STKO_to_python/elements/elements.py
@@ -1089,7 +1089,7 @@ class ElementManager:
                                     # Look up catalog by the connectivity
                                     # bracket's base class (strip the
                                     # ``[rule:cust]`` suffix).
-                                    from ..utilities.gauss_points import (
+                                    from ..format.gauss_points import (
                                         get_ip_layout,
                                     )
 

--- a/src/STKO_to_python/format/__init__.py
+++ b/src/STKO_to_python/format/__init__.py
@@ -1,0 +1,57 @@
+"""MPCO format quirks — Gauss-point catalog, shape functions, and other
+per-element-class conventions live here.
+
+This package is the single home for "how does an MPCO file say
+something?" knowledge: integration-point natural coordinates, shape
+functions, Jacobian-determinant kinds, and (in :mod:`STKO_to_python.io.format_policy`)
+the format policy that decides shell-vs-beam keywords and similar
+class-tag-driven branching. Code that needs to interpret raw MPCO
+data goes through this package; nothing else.
+
+The legacy import paths
+``STKO_to_python.utilities.gauss_points`` and
+``STKO_to_python.utilities.shape_functions`` continue to work as
+``DeprecationWarning``-emitting shims; new code should import from
+this package directly.
+"""
+from __future__ import annotations
+
+from .gauss_points import (
+    ELEMENT_IP_CATALOG,
+    gauss_legendre_1d,
+    gauss_tetrahedron,
+    gauss_triangle,
+    get_ip_layout,
+    tensor_product_2d,
+    tensor_product_3d,
+)
+from .shape_functions import (
+    SHAPE_FUNCTIONS,
+    compute_jacobian_dets,
+    compute_physical_coords,
+    get_shape_functions,
+    tet4_N,
+    tet4_dN,
+    tri3_N,
+    tri3_dN,
+)
+
+__all__ = [
+    # gauss_points
+    "ELEMENT_IP_CATALOG",
+    "gauss_legendre_1d",
+    "gauss_tetrahedron",
+    "gauss_triangle",
+    "get_ip_layout",
+    "tensor_product_2d",
+    "tensor_product_3d",
+    # shape_functions
+    "SHAPE_FUNCTIONS",
+    "compute_jacobian_dets",
+    "compute_physical_coords",
+    "get_shape_functions",
+    "tet4_N",
+    "tet4_dN",
+    "tri3_N",
+    "tri3_dN",
+]

--- a/src/STKO_to_python/format/gauss_points.py
+++ b/src/STKO_to_python/format/gauss_points.py
@@ -1,0 +1,303 @@
+"""Standard Gauss-point coordinates for fixed-class elements.
+
+For force/disp-based beam-columns the integration-point coordinates
+live on the connectivity dataset's ``@GP_X`` attribute (custom rule —
+see docs/mpco_format_conventions.md §1, §4). For continuum solids,
+shells, and plane elements, the coordinates are *fixed by the
+element class and integration-point count* and are **not** written to
+disk. This module is the catalog the read path consults to fill in
+``ElementResults.gp_natural`` for those classes.
+
+Values are in **natural coordinates** (parent-element parametric
+space): ξ ∈ [-1, +1] for line elements, (ξ, η) ∈ [-1, +1]² for 2-D
+shells / plane elements, (ξ, η, ζ) ∈ [-1, +1]³ for 3-D solids.
+
+Ordering convention
+-------------------
+Tensor-product integration schemes enumerate points with **ξ varying
+fastest, then η, then ζ** — a left-to-right, bottom-to-top, front-to-
+back walk. This is the standard convention used by most FEM textbooks
+and by OpenSees's natural-coordinate quadrature loops. If a particular
+element class turns out to enumerate differently, override its catalog
+entry rather than changing the global helpers.
+
+The catalog is intentionally small in v1 — entries are added per
+element class as fixtures or user reports appear. Lookup falls back
+to ``None`` for unknown (class, n_ip) pairs; the read path then leaves
+``gp_natural`` unset rather than guessing.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+__all__ = [
+    "gauss_legendre_1d",
+    "tensor_product_2d",
+    "tensor_product_3d",
+    "gauss_triangle",
+    "gauss_tetrahedron",
+    "ELEMENT_IP_CATALOG",
+    "get_ip_layout",
+]
+
+
+# --------------------------------------------------------------------- #
+# Gauss-Legendre primitives                                             #
+# --------------------------------------------------------------------- #
+
+
+@lru_cache(maxsize=16)
+def gauss_legendre_1d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Return the 1-D Gauss-Legendre points and weights for ``n``-point
+    quadrature.
+
+    Backed by :func:`numpy.polynomial.legendre.leggauss`. Cached so a
+    repeat lookup is free.
+
+    Returns
+    -------
+    points, weights : np.ndarray of shape (n,)
+        Sorted ascending in ξ ∈ (-1, +1).
+    """
+    if n < 1:
+        raise ValueError(f"n must be ≥ 1, got {n!r}")
+    pts, wts = np.polynomial.legendre.leggauss(int(n))
+    return pts.astype(np.float64), wts.astype(np.float64)
+
+
+def tensor_product_2d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the 2-D tensor-product Gauss-Legendre rule with ``n`` points
+    per direction.
+
+    Ordering: ξ varies fastest, then η.
+
+    Returns
+    -------
+    coords : np.ndarray of shape (n*n, 2)
+        Each row is (ξ_i, η_i).
+    weights : np.ndarray of shape (n*n,)
+        Product weights.
+    """
+    pts, wts = gauss_legendre_1d(n)
+    # ξ-fastest: outer loop over η.
+    xi_grid, eta_grid = np.meshgrid(pts, pts, indexing="xy")
+    wxi, weta = np.meshgrid(wts, wts, indexing="xy")
+    coords = np.stack([xi_grid.ravel(), eta_grid.ravel()], axis=1)
+    weights = (wxi * weta).ravel()
+    return coords.astype(np.float64), weights.astype(np.float64)
+
+
+def tensor_product_3d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the 3-D tensor-product Gauss-Legendre rule with ``n`` points
+    per direction.
+
+    Ordering: ξ varies fastest, then η, then ζ.
+
+    Returns
+    -------
+    coords : np.ndarray of shape (n^3, 3)
+        Each row is (ξ_i, η_i, ζ_i).
+    weights : np.ndarray of shape (n^3,)
+        Product weights.
+    """
+    pts, wts = gauss_legendre_1d(n)
+    # ξ-fastest, then η, then ζ.
+    xi_grid, eta_grid, zeta_grid = np.meshgrid(pts, pts, pts, indexing="ij")
+    # 'ij' indexing makes the FIRST axis vary slowest. We want xi-fastest
+    # which means xi should be the LAST varying axis when raveled. Re-
+    # arrange axes accordingly.
+    coords = np.stack(
+        [
+            xi_grid.transpose(2, 1, 0).ravel(),
+            eta_grid.transpose(2, 1, 0).ravel(),
+            zeta_grid.transpose(2, 1, 0).ravel(),
+        ],
+        axis=1,
+    )
+    wxi, weta, wzeta = np.meshgrid(wts, wts, wts, indexing="ij")
+    weights = (wxi * weta * wzeta).transpose(2, 1, 0).ravel()
+    return coords.astype(np.float64), weights.astype(np.float64)
+
+
+# --------------------------------------------------------------------- #
+# Triangle / tetrahedron quadrature                                     #
+# --------------------------------------------------------------------- #
+#
+# Triangles and tets use barycentric-style natural coords on the
+# **unit** triangle / tetrahedron (vertices at the origin and on the
+# axes). This is a different parent domain than tensor-product
+# rules — the parent measure is 1/2 (triangle) or 1/6 (tet), not 4 / 8
+# — and the corresponding shape functions in
+# :mod:`STKO_to_python.utilities.shape_functions` use the same domain.
+
+# Standard 1-, 3-, 7-point rules on the unit triangle.
+_TRI_RULES: Dict[int, Tuple[np.ndarray, np.ndarray]] = {
+    1: (
+        np.array([[1.0 / 3.0, 1.0 / 3.0]]),
+        np.array([0.5]),
+    ),
+    3: (
+        np.array(
+            [
+                [1.0 / 6.0, 1.0 / 6.0],
+                [2.0 / 3.0, 1.0 / 6.0],
+                [1.0 / 6.0, 2.0 / 3.0],
+            ]
+        ),
+        np.array([1.0 / 6.0] * 3),
+    ),
+}
+
+# Standard 1- and 4-point rules on the unit tetrahedron.
+_TET_A = (5.0 + 3.0 * np.sqrt(5.0)) / 20.0
+_TET_B = (5.0 - np.sqrt(5.0)) / 20.0
+_TET_RULES: Dict[int, Tuple[np.ndarray, np.ndarray]] = {
+    1: (
+        np.array([[0.25, 0.25, 0.25]]),
+        np.array([1.0 / 6.0]),
+    ),
+    4: (
+        np.array(
+            [
+                [_TET_A, _TET_B, _TET_B],
+                [_TET_B, _TET_A, _TET_B],
+                [_TET_B, _TET_B, _TET_A],
+                [_TET_B, _TET_B, _TET_B],
+            ]
+        ),
+        np.array([1.0 / 24.0] * 4),
+    ),
+}
+
+
+def gauss_triangle(n_ip: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Standard Gauss rule on the unit reference triangle.
+
+    Parent domain: vertices at (0,0), (1,0), (0,1); area 1/2.
+    Sum of weights equals the parent area.
+
+    Parameters
+    ----------
+    n_ip : int
+        ``1`` (degree-1, centroid) or ``3`` (degree-2, edge midpoints
+        of the medial triangle). Other rules can be added if needed.
+
+    Returns
+    -------
+    (coords, weights) : (ndarray (n_ip, 2), ndarray (n_ip,))
+
+    Raises
+    ------
+    ValueError if ``n_ip`` is not in the supported set.
+    """
+    if n_ip not in _TRI_RULES:
+        raise ValueError(
+            f"Unsupported n_ip={n_ip!r} for triangle rule. "
+            f"Available: {sorted(_TRI_RULES)}"
+        )
+    coords, weights = _TRI_RULES[n_ip]
+    return coords.copy(), weights.copy()
+
+
+def gauss_tetrahedron(n_ip: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Standard Gauss rule on the unit reference tetrahedron.
+
+    Parent domain: vertices at the origin and the three unit axis
+    points; volume 1/6. Sum of weights equals the parent volume.
+
+    Parameters
+    ----------
+    n_ip : int
+        ``1`` (degree-1, centroid) or ``4`` (degree-2). Other rules
+        (e.g. 5-point degree-3) can be added if needed.
+
+    Returns
+    -------
+    (coords, weights) : (ndarray (n_ip, 3), ndarray (n_ip,))
+    """
+    if n_ip not in _TET_RULES:
+        raise ValueError(
+            f"Unsupported n_ip={n_ip!r} for tetrahedron rule. "
+            f"Available: {sorted(_TET_RULES)}"
+        )
+    coords, weights = _TET_RULES[n_ip]
+    return coords.copy(), weights.copy()
+
+
+# --------------------------------------------------------------------- #
+# Element catalog                                                       #
+# --------------------------------------------------------------------- #
+#
+# Keys are the *base* element name carried in MPCO connectivity datasets
+# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
+# Inner keys are the integration-point count expected for the bucket.
+# Values are ``(coords, weights)`` tuples.
+#
+# Add new entries as fixtures or user models surface them. Unknown
+# (class, n_ip) pairs return ``None`` from :func:`get_ip_layout` and
+# the read path leaves ``gp_natural`` empty.
+
+ELEMENT_IP_CATALOG: Dict[str, Dict[int, Tuple[np.ndarray, np.ndarray]]] = {
+    # --- Shells (in-plane 2-D Gauss-Legendre) ---
+    "203-ASDShellQ4": {
+        4: tensor_product_2d(2),  # standard 2×2 quadrature
+    },
+    # --- Triangular shells (3-pt Gauss on the unit triangle) ---
+    "204-ASDShellT3": {
+        3: gauss_triangle(3),     # validated against Test_NLShell fixture
+    },
+    # --- 3-D continuum solids ---
+    "56-Brick": {
+        8: tensor_product_3d(2),   # standard 2×2×2
+        27: tensor_product_3d(3),  # full 3×3×3
+    },
+    # --- Plane elements (2-D quads) ---
+    # Common 4-node quad classes — names need verification against
+    # actual fixtures before relying on these in production.
+    "FourNodeQuad": {
+        4: tensor_product_2d(2),
+        9: tensor_product_2d(3),
+    },
+}
+
+
+def get_ip_layout(
+    element_class_base: str, n_ip: int
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Look up natural coords + weights for a ``(class, n_ip)`` pair.
+
+    Parameters
+    ----------
+    element_class_base : str
+        Base class name as it appears in the MPCO connectivity bracket
+        — e.g. ``"56-Brick"`` (not ``"56-Brick[401:0]"``).
+    n_ip : int
+        Number of integration points actually present in the bucket
+        (from META/GAUSS_IDS).
+
+    Returns
+    -------
+    (coords, weights) or None
+        ``coords`` shape ``(n_ip, dim)``; ``weights`` shape ``(n_ip,)``.
+        ``None`` if the class or the requested IP count is not in the
+        catalog — the read path then leaves ``gp_natural`` unset and
+        the user keeps named columns but no spatial coordinates.
+    """
+    entry = ELEMENT_IP_CATALOG.get(element_class_base)
+    if entry is None:
+        return None
+    layout = entry.get(int(n_ip))
+    if layout is None:
+        return None
+    coords, weights = layout
+    if coords.shape[0] != int(n_ip):
+        # Defensive: catch a miscataloged entry early.
+        raise RuntimeError(
+            f"Catalog inconsistency for {element_class_base!r} n_ip={n_ip}: "
+            f"got {coords.shape[0]} coords."
+        )
+    return coords, weights

--- a/src/STKO_to_python/format/shape_functions.py
+++ b/src/STKO_to_python/format/shape_functions.py
@@ -1,0 +1,352 @@
+"""Shape functions and derivatives for fixed-class elements.
+
+Maps natural coordinates (ξ, η, ζ) from
+:mod:`STKO_to_python.utilities.gauss_points` to physical (x, y, z) on
+the actual element via standard FE shape functions, and provides the
+Jacobian determinants needed for physical-volume / physical-area
+integration.
+
+For each supported element class the catalog returns:
+
+* ``N(nat_coords)`` → ``(n_ip, n_nodes)`` shape-function values
+* ``dN_dnat(nat_coords)`` → ``(n_ip, n_nodes, parent_dim)`` derivatives
+  in the parametric directions
+* ``geom_kind`` ∈ ``{"line", "shell", "solid"}`` — determines how the
+  Jacobian determinant is computed:
+
+  - **solid** (parent_dim=3, physical_dim=3): square Jacobian, det.
+  - **shell** (parent_dim=2, physical_dim=3): rectangular Jacobian; the
+    surface measure is ``||∂x/∂ξ × ∂x/∂η||``.
+  - **line** (parent_dim=1, physical_dim=3): single-row Jacobian; the
+    line measure is the norm of ``∂x/∂ξ``.
+
+Node-ordering convention follows OpenSees's standard for each class:
+ASDShellQ4 corners CCW (1:(-1,-1) → 2:(+1,-1) → 3:(+1,+1) → 4:(-1,+1));
+Brick bottom-face CCW then top-face CCW (1..4 at ζ=-1, 5..8 at ζ=+1).
+Override these per-class if a particular model uses a different node
+order.
+"""
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional, Tuple
+
+import numpy as np
+
+
+__all__ = [
+    "SHAPE_FUNCTIONS",
+    "get_shape_functions",
+    "compute_physical_coords",
+    "compute_jacobian_dets",
+    # Reusable shape-function primitives — exported so users can
+    # register them under their own element-class keys when those
+    # surface in fixtures (e.g. ``SHAPE_FUNCTIONS["204-ASDShellT3"] =
+    # (tri3_N, tri3_dN, "shell")``).
+    "tri3_N",
+    "tri3_dN",
+    "tet4_N",
+    "tet4_dN",
+]
+
+
+ShapeFn = Callable[[np.ndarray], np.ndarray]
+GeomKind = str  # "line" | "shell" | "solid"
+
+
+# --------------------------------------------------------------------- #
+# ASDShellQ4 — 4-node bilinear quad in 3-D space (shell)                #
+# --------------------------------------------------------------------- #
+#
+# Node ordering (natural):
+#   1: (-1, -1)
+#   2: (+1, -1)
+#   3: (+1, +1)
+#   4: (-1, +1)
+
+
+def _asd_shell_q4_N(nat: np.ndarray) -> np.ndarray:
+    """N_i(ξ, η) for i=1..4 at each row of ``nat`` shape (n_ip, 2)."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    return 0.25 * np.stack(
+        [
+            (1 - xi) * (1 - eta),
+            (1 + xi) * (1 - eta),
+            (1 + xi) * (1 + eta),
+            (1 - xi) * (1 + eta),
+        ],
+        axis=1,
+    )
+
+
+def _asd_shell_q4_dN(nat: np.ndarray) -> np.ndarray:
+    """∂N_i/∂(ξ, η) — shape (n_ip, 4, 2)."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 4, 2), dtype=np.float64)
+    # ∂N/∂ξ
+    out[:, 0, 0] = -0.25 * (1 - eta)
+    out[:, 1, 0] = +0.25 * (1 - eta)
+    out[:, 2, 0] = +0.25 * (1 + eta)
+    out[:, 3, 0] = -0.25 * (1 + eta)
+    # ∂N/∂η
+    out[:, 0, 1] = -0.25 * (1 - xi)
+    out[:, 1, 1] = -0.25 * (1 + xi)
+    out[:, 2, 1] = +0.25 * (1 + xi)
+    out[:, 3, 1] = +0.25 * (1 - xi)
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Brick — 8-node trilinear hex (solid)                                  #
+# --------------------------------------------------------------------- #
+#
+# Node ordering (natural):
+#   1: (-1, -1, -1)        5: (-1, -1, +1)
+#   2: (+1, -1, -1)        6: (+1, -1, +1)
+#   3: (+1, +1, -1)        7: (+1, +1, +1)
+#   4: (-1, +1, -1)        8: (-1, +1, +1)
+
+
+_BRICK_NODE_SIGNS = np.array(
+    [
+        [-1, -1, -1],
+        [+1, -1, -1],
+        [+1, +1, -1],
+        [-1, +1, -1],
+        [-1, -1, +1],
+        [+1, -1, +1],
+        [+1, +1, +1],
+        [-1, +1, +1],
+    ],
+    dtype=np.float64,
+)
+
+
+def _brick_N(nat: np.ndarray) -> np.ndarray:
+    """N_i(ξ, η, ζ) for i=1..8 — shape (n_ip, 8)."""
+    # nat: (n_ip, 3); _BRICK_NODE_SIGNS: (8, 3)
+    # Broadcast: (n_ip, 1, 3) * (1, 8, 3) → (n_ip, 8, 3)
+    factors = 1.0 + _BRICK_NODE_SIGNS[None, :, :] * nat[:, None, :]
+    return 0.125 * np.prod(factors, axis=2)
+
+
+def _brick_dN(nat: np.ndarray) -> np.ndarray:
+    """∂N_i/∂(ξ, η, ζ) — shape (n_ip, 8, 3)."""
+    # ∂N_i/∂x_k = (sign_ik / 8) * ∏_{j != k} (1 + sign_ij * x_j)
+    factors = 1.0 + _BRICK_NODE_SIGNS[None, :, :] * nat[:, None, :]
+    # full_prod: (n_ip, 8) — product over the 3 axes
+    full_prod = np.prod(factors, axis=2)
+    # ∂/∂x_k pulls out factor (1 + sign_ik * x_k); divide it out.
+    # Avoid division by zero when (1 + sign_ik * x_k) == 0 (only at the
+    # opposite face) by recomputing those rows manually.
+    out = np.empty((nat.shape[0], 8, 3), dtype=np.float64)
+    for k in range(3):
+        # Other two axes' factors product
+        other = np.delete(factors, k, axis=2).prod(axis=2)  # (n_ip, 8)
+        out[:, :, k] = 0.125 * _BRICK_NODE_SIGNS[None, :, k] * other
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Linear line element — 2-node (line)                                   #
+# --------------------------------------------------------------------- #
+#
+# Node ordering (natural):
+#   1: (-1)
+#   2: (+1)
+
+
+def _line2_N(nat: np.ndarray) -> np.ndarray:
+    """N_i(ξ) for i=1..2 — shape (n_ip, 2)."""
+    xi = nat[:, 0]
+    return 0.5 * np.stack([1 - xi, 1 + xi], axis=1)
+
+
+def _line2_dN(nat: np.ndarray) -> np.ndarray:
+    """∂N_i/∂ξ — shape (n_ip, 2, 1)."""
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 2, 1), dtype=np.float64)
+    out[:, 0, 0] = -0.5
+    out[:, 1, 0] = +0.5
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Tri3 — 3-node linear triangle (shell or plane)                        #
+# --------------------------------------------------------------------- #
+#
+# Parent domain: unit triangle with vertices at (0,0), (1,0), (0,1).
+# Pair with ``gauss_triangle()`` from :mod:`gauss_points`.
+#
+# Node ordering (natural):
+#   1: (0, 0)
+#   2: (1, 0)
+#   3: (0, 1)
+
+
+def tri3_N(nat: np.ndarray) -> np.ndarray:
+    """Linear-triangle shape functions — shape ``(n_ip, 3)``."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    return np.stack([1.0 - xi - eta, xi, eta], axis=1)
+
+
+def tri3_dN(nat: np.ndarray) -> np.ndarray:
+    """Linear-triangle derivatives — shape ``(n_ip, 3, 2)``.
+
+    Derivatives are constant on the parent triangle; the per-IP
+    repetition just makes the array shape consistent with the rest of
+    the catalog.
+    """
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 3, 2), dtype=np.float64)
+    out[:, 0, 0] = -1.0; out[:, 0, 1] = -1.0  # ∂N1/∂(ξ, η)
+    out[:, 1, 0] = +1.0; out[:, 1, 1] = +0.0  # ∂N2/∂(ξ, η)
+    out[:, 2, 0] = +0.0; out[:, 2, 1] = +1.0  # ∂N3/∂(ξ, η)
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Tet4 — 4-node linear tetrahedron (solid)                              #
+# --------------------------------------------------------------------- #
+#
+# Parent domain: unit tetrahedron with vertices at the origin and the
+# three unit-axis points. Pair with ``gauss_tetrahedron()`` from
+# :mod:`gauss_points`.
+#
+# Node ordering (natural):
+#   1: (0, 0, 0)
+#   2: (1, 0, 0)
+#   3: (0, 1, 0)
+#   4: (0, 0, 1)
+
+
+def tet4_N(nat: np.ndarray) -> np.ndarray:
+    """Linear-tet shape functions — shape ``(n_ip, 4)``."""
+    xi = nat[:, 0]
+    eta = nat[:, 1]
+    zeta = nat[:, 2]
+    return np.stack(
+        [1.0 - xi - eta - zeta, xi, eta, zeta], axis=1
+    )
+
+
+def tet4_dN(nat: np.ndarray) -> np.ndarray:
+    """Linear-tet derivatives — shape ``(n_ip, 4, 3)`` (constant)."""
+    n_ip = nat.shape[0]
+    out = np.empty((n_ip, 4, 3), dtype=np.float64)
+    out[:, 0, :] = [-1.0, -1.0, -1.0]
+    out[:, 1, :] = [+1.0,  0.0,  0.0]
+    out[:, 2, :] = [ 0.0, +1.0,  0.0]
+    out[:, 3, :] = [ 0.0,  0.0, +1.0]
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Catalog                                                               #
+# --------------------------------------------------------------------- #
+#
+# Keys are the *base* element name carried in MPCO connectivity datasets
+# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
+
+SHAPE_FUNCTIONS: Dict[str, Tuple[ShapeFn, ShapeFn, GeomKind]] = {
+    "203-ASDShellQ4": (_asd_shell_q4_N, _asd_shell_q4_dN, "shell"),
+    "204-ASDShellT3": (tri3_N, tri3_dN, "shell"),
+    "56-Brick":       (_brick_N, _brick_dN, "solid"),
+    # Beam/disp-based-beam line elements use 2-node linear interpolation
+    # for the geometric mapping (the integration scheme is independent;
+    # custom rules carry their own GP_X). Only used here when the user
+    # asks for physical coordinates of beam IPs.
+    "5-ElasticBeam3d":      (_line2_N, _line2_dN, "line"),
+    "64-DispBeamColumn3d":  (_line2_N, _line2_dN, "line"),
+}
+
+
+def get_shape_functions(
+    element_class_base: str,
+) -> Optional[Tuple[ShapeFn, ShapeFn, GeomKind]]:
+    """Look up shape functions for a base element class.
+
+    Returns
+    -------
+    (N, dN_dnat, geom_kind) or None
+        ``None`` if the class is not in the catalog. The caller should
+        leave physical coords / Jacobians unset and surface a clear
+        message rather than guessing.
+    """
+    return SHAPE_FUNCTIONS.get(element_class_base)
+
+
+# --------------------------------------------------------------------- #
+# Vectorized mapping                                                    #
+# --------------------------------------------------------------------- #
+
+
+def compute_physical_coords(
+    natural_coords: np.ndarray,
+    element_node_coords: np.ndarray,
+    N_fn: ShapeFn,
+) -> np.ndarray:
+    """Map natural-coord IP positions to physical (x, y, z).
+
+    Parameters
+    ----------
+    natural_coords : np.ndarray, shape (n_ip, parent_dim)
+        IP positions in the parent domain (output of
+        :mod:`STKO_to_python.utilities.gauss_points`).
+    element_node_coords : np.ndarray, shape (n_elements, n_nodes_per, 3)
+        Physical coordinates of each element's nodes, in node-ordering
+        consistent with the shape function.
+    N_fn : callable
+        Shape-function evaluator returning ``(n_ip, n_nodes_per)``.
+
+    Returns
+    -------
+    np.ndarray, shape (n_elements, n_ip, 3)
+        Physical position of each IP for each element.
+    """
+    N = N_fn(natural_coords)  # (n_ip, n_nodes)
+    # einsum: (i,n) @ (e,n,3) → (e,i,3)
+    return np.einsum("in,enj->eij", N, element_node_coords)
+
+
+def compute_jacobian_dets(
+    natural_coords: np.ndarray,
+    element_node_coords: np.ndarray,
+    dN_fn: ShapeFn,
+    geom_kind: GeomKind,
+) -> np.ndarray:
+    """Jacobian determinants at each IP for each element.
+
+    Returns
+    -------
+    np.ndarray, shape (n_elements, n_ip)
+        - ``"solid"``: ``det(J)`` where ``J`` is the 3x3 ∂x/∂ξ matrix.
+        - ``"shell"``: surface measure ``||∂x/∂ξ × ∂x/∂η||``.
+        - ``"line"``: line measure ``||∂x/∂ξ||``.
+
+    All three are non-negative scalars; multiplying a Gauss-point value
+    by ``weight * |J|`` produces a contribution to the integral over
+    the physical element.
+    """
+    dN = dN_fn(natural_coords)  # (n_ip, n_nodes, parent_dim)
+    # J: ∂x_a/∂ξ_k for a ∈ physical (3), k ∈ parent.
+    # einsum: (i,n,k) @ (e,n,a) → (e,i,k,a)
+    J = np.einsum("ink,ena->eika", dN, element_node_coords)
+    # J shape: (n_elements, n_ip, parent_dim, 3)
+
+    if geom_kind == "solid":
+        # J is (e, i, 3, 3) — square matrix per IP; take det.
+        return np.abs(np.linalg.det(J))
+    if geom_kind == "shell":
+        # J is (e, i, 2, 3); cross product of the two parent rows.
+        cross = np.cross(J[..., 0, :], J[..., 1, :])
+        return np.linalg.norm(cross, axis=-1)
+    if geom_kind == "line":
+        # J is (e, i, 1, 3); norm of the single row.
+        return np.linalg.norm(J[..., 0, :], axis=-1)
+    raise ValueError(
+        f"Unknown geom_kind {geom_kind!r}; expected 'solid', 'shell', or 'line'."
+    )

--- a/src/STKO_to_python/utilities/gauss_points.py
+++ b/src/STKO_to_python/utilities/gauss_points.py
@@ -1,303 +1,40 @@
-"""Standard Gauss-point coordinates for fixed-class elements.
+"""Back-compat shim — emits ``DeprecationWarning`` on attribute access.
 
-For force/disp-based beam-columns the integration-point coordinates
-live on the connectivity dataset's ``@GP_X`` attribute (custom rule —
-see docs/mpco_format_conventions.md §1, §4). For continuum solids,
-shells, and plane elements, the coordinates are *fixed by the
-element class and integration-point count* and are **not** written to
-disk. This module is the catalog the read path consults to fill in
-``ElementResults.gp_natural`` for those classes.
+The Gauss-point catalog and quadrature primitives moved to
+:mod:`STKO_to_python.format.gauss_points` as part of the architecture
+refactor. The legacy import path
 
-Values are in **natural coordinates** (parent-element parametric
-space): ξ ∈ [-1, +1] for line elements, (ξ, η) ∈ [-1, +1]² for 2-D
-shells / plane elements, (ξ, η, ζ) ∈ [-1, +1]³ for 3-D solids.
+    from STKO_to_python.utilities.gauss_points import get_ip_layout
 
-Ordering convention
--------------------
-Tensor-product integration schemes enumerate points with **ξ varying
-fastest, then η, then ζ** — a left-to-right, bottom-to-top, front-to-
-back walk. This is the standard convention used by most FEM textbooks
-and by OpenSees's natural-coordinate quadrature loops. If a particular
-element class turns out to enumerate differently, override its catalog
-entry rather than changing the global helpers.
+continues to work but now emits a ``DeprecationWarning`` per access via
+PEP 562 module-level ``__getattr__``. New code should prefer
 
-The catalog is intentionally small in v1 — entries are added per
-element class as fixtures or user reports appear. Lookup falls back
-to ``None`` for unknown (class, n_ip) pairs; the read path then leaves
-``gp_natural`` unset rather than guessing.
+    from STKO_to_python.format.gauss_points import get_ip_layout
+    # or, equivalently:
+    from STKO_to_python.format import get_ip_layout
 """
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import Dict, Optional, Tuple
+import warnings
+from typing import Any
 
-import numpy as np
-
-
-__all__ = [
-    "gauss_legendre_1d",
-    "tensor_product_2d",
-    "tensor_product_3d",
-    "gauss_triangle",
-    "gauss_tetrahedron",
-    "ELEMENT_IP_CATALOG",
-    "get_ip_layout",
-]
+from ..format import gauss_points as _canonical
 
 
-# --------------------------------------------------------------------- #
-# Gauss-Legendre primitives                                             #
-# --------------------------------------------------------------------- #
+_REEXPORTED_NAMES = frozenset(_canonical.__all__)
 
 
-@lru_cache(maxsize=16)
-def gauss_legendre_1d(n: int) -> Tuple[np.ndarray, np.ndarray]:
-    """Return the 1-D Gauss-Legendre points and weights for ``n``-point
-    quadrature.
-
-    Backed by :func:`numpy.polynomial.legendre.leggauss`. Cached so a
-    repeat lookup is free.
-
-    Returns
-    -------
-    points, weights : np.ndarray of shape (n,)
-        Sorted ascending in ξ ∈ (-1, +1).
-    """
-    if n < 1:
-        raise ValueError(f"n must be ≥ 1, got {n!r}")
-    pts, wts = np.polynomial.legendre.leggauss(int(n))
-    return pts.astype(np.float64), wts.astype(np.float64)
-
-
-def tensor_product_2d(n: int) -> Tuple[np.ndarray, np.ndarray]:
-    """Build the 2-D tensor-product Gauss-Legendre rule with ``n`` points
-    per direction.
-
-    Ordering: ξ varies fastest, then η.
-
-    Returns
-    -------
-    coords : np.ndarray of shape (n*n, 2)
-        Each row is (ξ_i, η_i).
-    weights : np.ndarray of shape (n*n,)
-        Product weights.
-    """
-    pts, wts = gauss_legendre_1d(n)
-    # ξ-fastest: outer loop over η.
-    xi_grid, eta_grid = np.meshgrid(pts, pts, indexing="xy")
-    wxi, weta = np.meshgrid(wts, wts, indexing="xy")
-    coords = np.stack([xi_grid.ravel(), eta_grid.ravel()], axis=1)
-    weights = (wxi * weta).ravel()
-    return coords.astype(np.float64), weights.astype(np.float64)
-
-
-def tensor_product_3d(n: int) -> Tuple[np.ndarray, np.ndarray]:
-    """Build the 3-D tensor-product Gauss-Legendre rule with ``n`` points
-    per direction.
-
-    Ordering: ξ varies fastest, then η, then ζ.
-
-    Returns
-    -------
-    coords : np.ndarray of shape (n^3, 3)
-        Each row is (ξ_i, η_i, ζ_i).
-    weights : np.ndarray of shape (n^3,)
-        Product weights.
-    """
-    pts, wts = gauss_legendre_1d(n)
-    # ξ-fastest, then η, then ζ.
-    xi_grid, eta_grid, zeta_grid = np.meshgrid(pts, pts, pts, indexing="ij")
-    # 'ij' indexing makes the FIRST axis vary slowest. We want xi-fastest
-    # which means xi should be the LAST varying axis when raveled. Re-
-    # arrange axes accordingly.
-    coords = np.stack(
-        [
-            xi_grid.transpose(2, 1, 0).ravel(),
-            eta_grid.transpose(2, 1, 0).ravel(),
-            zeta_grid.transpose(2, 1, 0).ravel(),
-        ],
-        axis=1,
-    )
-    wxi, weta, wzeta = np.meshgrid(wts, wts, wts, indexing="ij")
-    weights = (wxi * weta * wzeta).transpose(2, 1, 0).ravel()
-    return coords.astype(np.float64), weights.astype(np.float64)
-
-
-# --------------------------------------------------------------------- #
-# Triangle / tetrahedron quadrature                                     #
-# --------------------------------------------------------------------- #
-#
-# Triangles and tets use barycentric-style natural coords on the
-# **unit** triangle / tetrahedron (vertices at the origin and on the
-# axes). This is a different parent domain than tensor-product
-# rules — the parent measure is 1/2 (triangle) or 1/6 (tet), not 4 / 8
-# — and the corresponding shape functions in
-# :mod:`STKO_to_python.utilities.shape_functions` use the same domain.
-
-# Standard 1-, 3-, 7-point rules on the unit triangle.
-_TRI_RULES: Dict[int, Tuple[np.ndarray, np.ndarray]] = {
-    1: (
-        np.array([[1.0 / 3.0, 1.0 / 3.0]]),
-        np.array([0.5]),
-    ),
-    3: (
-        np.array(
-            [
-                [1.0 / 6.0, 1.0 / 6.0],
-                [2.0 / 3.0, 1.0 / 6.0],
-                [1.0 / 6.0, 2.0 / 3.0],
-            ]
-        ),
-        np.array([1.0 / 6.0] * 3),
-    ),
-}
-
-# Standard 1- and 4-point rules on the unit tetrahedron.
-_TET_A = (5.0 + 3.0 * np.sqrt(5.0)) / 20.0
-_TET_B = (5.0 - np.sqrt(5.0)) / 20.0
-_TET_RULES: Dict[int, Tuple[np.ndarray, np.ndarray]] = {
-    1: (
-        np.array([[0.25, 0.25, 0.25]]),
-        np.array([1.0 / 6.0]),
-    ),
-    4: (
-        np.array(
-            [
-                [_TET_A, _TET_B, _TET_B],
-                [_TET_B, _TET_A, _TET_B],
-                [_TET_B, _TET_B, _TET_A],
-                [_TET_B, _TET_B, _TET_B],
-            ]
-        ),
-        np.array([1.0 / 24.0] * 4),
-    ),
-}
-
-
-def gauss_triangle(n_ip: int) -> Tuple[np.ndarray, np.ndarray]:
-    """Standard Gauss rule on the unit reference triangle.
-
-    Parent domain: vertices at (0,0), (1,0), (0,1); area 1/2.
-    Sum of weights equals the parent area.
-
-    Parameters
-    ----------
-    n_ip : int
-        ``1`` (degree-1, centroid) or ``3`` (degree-2, edge midpoints
-        of the medial triangle). Other rules can be added if needed.
-
-    Returns
-    -------
-    (coords, weights) : (ndarray (n_ip, 2), ndarray (n_ip,))
-
-    Raises
-    ------
-    ValueError if ``n_ip`` is not in the supported set.
-    """
-    if n_ip not in _TRI_RULES:
-        raise ValueError(
-            f"Unsupported n_ip={n_ip!r} for triangle rule. "
-            f"Available: {sorted(_TRI_RULES)}"
+def __getattr__(name: str) -> Any:
+    if name in _REEXPORTED_NAMES:
+        warnings.warn(
+            f"`STKO_to_python.utilities.gauss_points.{name}` is deprecated; "
+            f"import from `STKO_to_python.format.gauss_points` (or "
+            f"`STKO_to_python.format`) instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-    coords, weights = _TRI_RULES[n_ip]
-    return coords.copy(), weights.copy()
+        return getattr(_canonical, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def gauss_tetrahedron(n_ip: int) -> Tuple[np.ndarray, np.ndarray]:
-    """Standard Gauss rule on the unit reference tetrahedron.
-
-    Parent domain: vertices at the origin and the three unit axis
-    points; volume 1/6. Sum of weights equals the parent volume.
-
-    Parameters
-    ----------
-    n_ip : int
-        ``1`` (degree-1, centroid) or ``4`` (degree-2). Other rules
-        (e.g. 5-point degree-3) can be added if needed.
-
-    Returns
-    -------
-    (coords, weights) : (ndarray (n_ip, 3), ndarray (n_ip,))
-    """
-    if n_ip not in _TET_RULES:
-        raise ValueError(
-            f"Unsupported n_ip={n_ip!r} for tetrahedron rule. "
-            f"Available: {sorted(_TET_RULES)}"
-        )
-    coords, weights = _TET_RULES[n_ip]
-    return coords.copy(), weights.copy()
-
-
-# --------------------------------------------------------------------- #
-# Element catalog                                                       #
-# --------------------------------------------------------------------- #
-#
-# Keys are the *base* element name carried in MPCO connectivity datasets
-# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
-# Inner keys are the integration-point count expected for the bucket.
-# Values are ``(coords, weights)`` tuples.
-#
-# Add new entries as fixtures or user models surface them. Unknown
-# (class, n_ip) pairs return ``None`` from :func:`get_ip_layout` and
-# the read path leaves ``gp_natural`` empty.
-
-ELEMENT_IP_CATALOG: Dict[str, Dict[int, Tuple[np.ndarray, np.ndarray]]] = {
-    # --- Shells (in-plane 2-D Gauss-Legendre) ---
-    "203-ASDShellQ4": {
-        4: tensor_product_2d(2),  # standard 2×2 quadrature
-    },
-    # --- Triangular shells (3-pt Gauss on the unit triangle) ---
-    "204-ASDShellT3": {
-        3: gauss_triangle(3),     # validated against Test_NLShell fixture
-    },
-    # --- 3-D continuum solids ---
-    "56-Brick": {
-        8: tensor_product_3d(2),   # standard 2×2×2
-        27: tensor_product_3d(3),  # full 3×3×3
-    },
-    # --- Plane elements (2-D quads) ---
-    # Common 4-node quad classes — names need verification against
-    # actual fixtures before relying on these in production.
-    "FourNodeQuad": {
-        4: tensor_product_2d(2),
-        9: tensor_product_2d(3),
-    },
-}
-
-
-def get_ip_layout(
-    element_class_base: str, n_ip: int
-) -> Optional[Tuple[np.ndarray, np.ndarray]]:
-    """Look up natural coords + weights for a ``(class, n_ip)`` pair.
-
-    Parameters
-    ----------
-    element_class_base : str
-        Base class name as it appears in the MPCO connectivity bracket
-        — e.g. ``"56-Brick"`` (not ``"56-Brick[401:0]"``).
-    n_ip : int
-        Number of integration points actually present in the bucket
-        (from META/GAUSS_IDS).
-
-    Returns
-    -------
-    (coords, weights) or None
-        ``coords`` shape ``(n_ip, dim)``; ``weights`` shape ``(n_ip,)``.
-        ``None`` if the class or the requested IP count is not in the
-        catalog — the read path then leaves ``gp_natural`` unset and
-        the user keeps named columns but no spatial coordinates.
-    """
-    entry = ELEMENT_IP_CATALOG.get(element_class_base)
-    if entry is None:
-        return None
-    layout = entry.get(int(n_ip))
-    if layout is None:
-        return None
-    coords, weights = layout
-    if coords.shape[0] != int(n_ip):
-        # Defensive: catch a miscataloged entry early.
-        raise RuntimeError(
-            f"Catalog inconsistency for {element_class_base!r} n_ip={n_ip}: "
-            f"got {coords.shape[0]} coords."
-        )
-    return coords, weights
+__all__ = list(_REEXPORTED_NAMES)

--- a/src/STKO_to_python/utilities/shape_functions.py
+++ b/src/STKO_to_python/utilities/shape_functions.py
@@ -1,352 +1,41 @@
-"""Shape functions and derivatives for fixed-class elements.
+"""Back-compat shim — emits ``DeprecationWarning`` on attribute access.
 
-Maps natural coordinates (ξ, η, ζ) from
-:mod:`STKO_to_python.utilities.gauss_points` to physical (x, y, z) on
-the actual element via standard FE shape functions, and provides the
-Jacobian determinants needed for physical-volume / physical-area
-integration.
+Shape functions, Jacobian primitives, and the natural-to-physical
+coordinate mapping moved to
+:mod:`STKO_to_python.format.shape_functions` as part of the
+architecture refactor. The legacy import path
 
-For each supported element class the catalog returns:
+    from STKO_to_python.utilities.shape_functions import compute_physical_coords
 
-* ``N(nat_coords)`` → ``(n_ip, n_nodes)`` shape-function values
-* ``dN_dnat(nat_coords)`` → ``(n_ip, n_nodes, parent_dim)`` derivatives
-  in the parametric directions
-* ``geom_kind`` ∈ ``{"line", "shell", "solid"}`` — determines how the
-  Jacobian determinant is computed:
+continues to work but now emits a ``DeprecationWarning`` per access via
+PEP 562 module-level ``__getattr__``. New code should prefer
 
-  - **solid** (parent_dim=3, physical_dim=3): square Jacobian, det.
-  - **shell** (parent_dim=2, physical_dim=3): rectangular Jacobian; the
-    surface measure is ``||∂x/∂ξ × ∂x/∂η||``.
-  - **line** (parent_dim=1, physical_dim=3): single-row Jacobian; the
-    line measure is the norm of ``∂x/∂ξ``.
-
-Node-ordering convention follows OpenSees's standard for each class:
-ASDShellQ4 corners CCW (1:(-1,-1) → 2:(+1,-1) → 3:(+1,+1) → 4:(-1,+1));
-Brick bottom-face CCW then top-face CCW (1..4 at ζ=-1, 5..8 at ζ=+1).
-Override these per-class if a particular model uses a different node
-order.
+    from STKO_to_python.format.shape_functions import compute_physical_coords
+    # or, equivalently:
+    from STKO_to_python.format import compute_physical_coords
 """
 from __future__ import annotations
 
-from typing import Callable, Dict, Optional, Tuple
+import warnings
+from typing import Any
 
-import numpy as np
-
-
-__all__ = [
-    "SHAPE_FUNCTIONS",
-    "get_shape_functions",
-    "compute_physical_coords",
-    "compute_jacobian_dets",
-    # Reusable shape-function primitives — exported so users can
-    # register them under their own element-class keys when those
-    # surface in fixtures (e.g. ``SHAPE_FUNCTIONS["204-ASDShellT3"] =
-    # (tri3_N, tri3_dN, "shell")``).
-    "tri3_N",
-    "tri3_dN",
-    "tet4_N",
-    "tet4_dN",
-]
+from ..format import shape_functions as _canonical
 
 
-ShapeFn = Callable[[np.ndarray], np.ndarray]
-GeomKind = str  # "line" | "shell" | "solid"
+_REEXPORTED_NAMES = frozenset(_canonical.__all__)
 
 
-# --------------------------------------------------------------------- #
-# ASDShellQ4 — 4-node bilinear quad in 3-D space (shell)                #
-# --------------------------------------------------------------------- #
-#
-# Node ordering (natural):
-#   1: (-1, -1)
-#   2: (+1, -1)
-#   3: (+1, +1)
-#   4: (-1, +1)
+def __getattr__(name: str) -> Any:
+    if name in _REEXPORTED_NAMES:
+        warnings.warn(
+            f"`STKO_to_python.utilities.shape_functions.{name}` is deprecated; "
+            f"import from `STKO_to_python.format.shape_functions` (or "
+            f"`STKO_to_python.format`) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(_canonical, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def _asd_shell_q4_N(nat: np.ndarray) -> np.ndarray:
-    """N_i(ξ, η) for i=1..4 at each row of ``nat`` shape (n_ip, 2)."""
-    xi = nat[:, 0]
-    eta = nat[:, 1]
-    return 0.25 * np.stack(
-        [
-            (1 - xi) * (1 - eta),
-            (1 + xi) * (1 - eta),
-            (1 + xi) * (1 + eta),
-            (1 - xi) * (1 + eta),
-        ],
-        axis=1,
-    )
-
-
-def _asd_shell_q4_dN(nat: np.ndarray) -> np.ndarray:
-    """∂N_i/∂(ξ, η) — shape (n_ip, 4, 2)."""
-    xi = nat[:, 0]
-    eta = nat[:, 1]
-    n_ip = nat.shape[0]
-    out = np.empty((n_ip, 4, 2), dtype=np.float64)
-    # ∂N/∂ξ
-    out[:, 0, 0] = -0.25 * (1 - eta)
-    out[:, 1, 0] = +0.25 * (1 - eta)
-    out[:, 2, 0] = +0.25 * (1 + eta)
-    out[:, 3, 0] = -0.25 * (1 + eta)
-    # ∂N/∂η
-    out[:, 0, 1] = -0.25 * (1 - xi)
-    out[:, 1, 1] = -0.25 * (1 + xi)
-    out[:, 2, 1] = +0.25 * (1 + xi)
-    out[:, 3, 1] = +0.25 * (1 - xi)
-    return out
-
-
-# --------------------------------------------------------------------- #
-# Brick — 8-node trilinear hex (solid)                                  #
-# --------------------------------------------------------------------- #
-#
-# Node ordering (natural):
-#   1: (-1, -1, -1)        5: (-1, -1, +1)
-#   2: (+1, -1, -1)        6: (+1, -1, +1)
-#   3: (+1, +1, -1)        7: (+1, +1, +1)
-#   4: (-1, +1, -1)        8: (-1, +1, +1)
-
-
-_BRICK_NODE_SIGNS = np.array(
-    [
-        [-1, -1, -1],
-        [+1, -1, -1],
-        [+1, +1, -1],
-        [-1, +1, -1],
-        [-1, -1, +1],
-        [+1, -1, +1],
-        [+1, +1, +1],
-        [-1, +1, +1],
-    ],
-    dtype=np.float64,
-)
-
-
-def _brick_N(nat: np.ndarray) -> np.ndarray:
-    """N_i(ξ, η, ζ) for i=1..8 — shape (n_ip, 8)."""
-    # nat: (n_ip, 3); _BRICK_NODE_SIGNS: (8, 3)
-    # Broadcast: (n_ip, 1, 3) * (1, 8, 3) → (n_ip, 8, 3)
-    factors = 1.0 + _BRICK_NODE_SIGNS[None, :, :] * nat[:, None, :]
-    return 0.125 * np.prod(factors, axis=2)
-
-
-def _brick_dN(nat: np.ndarray) -> np.ndarray:
-    """∂N_i/∂(ξ, η, ζ) — shape (n_ip, 8, 3)."""
-    # ∂N_i/∂x_k = (sign_ik / 8) * ∏_{j != k} (1 + sign_ij * x_j)
-    factors = 1.0 + _BRICK_NODE_SIGNS[None, :, :] * nat[:, None, :]
-    # full_prod: (n_ip, 8) — product over the 3 axes
-    full_prod = np.prod(factors, axis=2)
-    # ∂/∂x_k pulls out factor (1 + sign_ik * x_k); divide it out.
-    # Avoid division by zero when (1 + sign_ik * x_k) == 0 (only at the
-    # opposite face) by recomputing those rows manually.
-    out = np.empty((nat.shape[0], 8, 3), dtype=np.float64)
-    for k in range(3):
-        # Other two axes' factors product
-        other = np.delete(factors, k, axis=2).prod(axis=2)  # (n_ip, 8)
-        out[:, :, k] = 0.125 * _BRICK_NODE_SIGNS[None, :, k] * other
-    return out
-
-
-# --------------------------------------------------------------------- #
-# Linear line element — 2-node (line)                                   #
-# --------------------------------------------------------------------- #
-#
-# Node ordering (natural):
-#   1: (-1)
-#   2: (+1)
-
-
-def _line2_N(nat: np.ndarray) -> np.ndarray:
-    """N_i(ξ) for i=1..2 — shape (n_ip, 2)."""
-    xi = nat[:, 0]
-    return 0.5 * np.stack([1 - xi, 1 + xi], axis=1)
-
-
-def _line2_dN(nat: np.ndarray) -> np.ndarray:
-    """∂N_i/∂ξ — shape (n_ip, 2, 1)."""
-    n_ip = nat.shape[0]
-    out = np.empty((n_ip, 2, 1), dtype=np.float64)
-    out[:, 0, 0] = -0.5
-    out[:, 1, 0] = +0.5
-    return out
-
-
-# --------------------------------------------------------------------- #
-# Tri3 — 3-node linear triangle (shell or plane)                        #
-# --------------------------------------------------------------------- #
-#
-# Parent domain: unit triangle with vertices at (0,0), (1,0), (0,1).
-# Pair with ``gauss_triangle()`` from :mod:`gauss_points`.
-#
-# Node ordering (natural):
-#   1: (0, 0)
-#   2: (1, 0)
-#   3: (0, 1)
-
-
-def tri3_N(nat: np.ndarray) -> np.ndarray:
-    """Linear-triangle shape functions — shape ``(n_ip, 3)``."""
-    xi = nat[:, 0]
-    eta = nat[:, 1]
-    return np.stack([1.0 - xi - eta, xi, eta], axis=1)
-
-
-def tri3_dN(nat: np.ndarray) -> np.ndarray:
-    """Linear-triangle derivatives — shape ``(n_ip, 3, 2)``.
-
-    Derivatives are constant on the parent triangle; the per-IP
-    repetition just makes the array shape consistent with the rest of
-    the catalog.
-    """
-    n_ip = nat.shape[0]
-    out = np.empty((n_ip, 3, 2), dtype=np.float64)
-    out[:, 0, 0] = -1.0; out[:, 0, 1] = -1.0  # ∂N1/∂(ξ, η)
-    out[:, 1, 0] = +1.0; out[:, 1, 1] = +0.0  # ∂N2/∂(ξ, η)
-    out[:, 2, 0] = +0.0; out[:, 2, 1] = +1.0  # ∂N3/∂(ξ, η)
-    return out
-
-
-# --------------------------------------------------------------------- #
-# Tet4 — 4-node linear tetrahedron (solid)                              #
-# --------------------------------------------------------------------- #
-#
-# Parent domain: unit tetrahedron with vertices at the origin and the
-# three unit-axis points. Pair with ``gauss_tetrahedron()`` from
-# :mod:`gauss_points`.
-#
-# Node ordering (natural):
-#   1: (0, 0, 0)
-#   2: (1, 0, 0)
-#   3: (0, 1, 0)
-#   4: (0, 0, 1)
-
-
-def tet4_N(nat: np.ndarray) -> np.ndarray:
-    """Linear-tet shape functions — shape ``(n_ip, 4)``."""
-    xi = nat[:, 0]
-    eta = nat[:, 1]
-    zeta = nat[:, 2]
-    return np.stack(
-        [1.0 - xi - eta - zeta, xi, eta, zeta], axis=1
-    )
-
-
-def tet4_dN(nat: np.ndarray) -> np.ndarray:
-    """Linear-tet derivatives — shape ``(n_ip, 4, 3)`` (constant)."""
-    n_ip = nat.shape[0]
-    out = np.empty((n_ip, 4, 3), dtype=np.float64)
-    out[:, 0, :] = [-1.0, -1.0, -1.0]
-    out[:, 1, :] = [+1.0,  0.0,  0.0]
-    out[:, 2, :] = [ 0.0, +1.0,  0.0]
-    out[:, 3, :] = [ 0.0,  0.0, +1.0]
-    return out
-
-
-# --------------------------------------------------------------------- #
-# Catalog                                                               #
-# --------------------------------------------------------------------- #
-#
-# Keys are the *base* element name carried in MPCO connectivity datasets
-# — i.e. ``"<classTag>-<className>"`` with the bracket suffix stripped.
-
-SHAPE_FUNCTIONS: Dict[str, Tuple[ShapeFn, ShapeFn, GeomKind]] = {
-    "203-ASDShellQ4": (_asd_shell_q4_N, _asd_shell_q4_dN, "shell"),
-    "204-ASDShellT3": (tri3_N, tri3_dN, "shell"),
-    "56-Brick":       (_brick_N, _brick_dN, "solid"),
-    # Beam/disp-based-beam line elements use 2-node linear interpolation
-    # for the geometric mapping (the integration scheme is independent;
-    # custom rules carry their own GP_X). Only used here when the user
-    # asks for physical coordinates of beam IPs.
-    "5-ElasticBeam3d":      (_line2_N, _line2_dN, "line"),
-    "64-DispBeamColumn3d":  (_line2_N, _line2_dN, "line"),
-}
-
-
-def get_shape_functions(
-    element_class_base: str,
-) -> Optional[Tuple[ShapeFn, ShapeFn, GeomKind]]:
-    """Look up shape functions for a base element class.
-
-    Returns
-    -------
-    (N, dN_dnat, geom_kind) or None
-        ``None`` if the class is not in the catalog. The caller should
-        leave physical coords / Jacobians unset and surface a clear
-        message rather than guessing.
-    """
-    return SHAPE_FUNCTIONS.get(element_class_base)
-
-
-# --------------------------------------------------------------------- #
-# Vectorized mapping                                                    #
-# --------------------------------------------------------------------- #
-
-
-def compute_physical_coords(
-    natural_coords: np.ndarray,
-    element_node_coords: np.ndarray,
-    N_fn: ShapeFn,
-) -> np.ndarray:
-    """Map natural-coord IP positions to physical (x, y, z).
-
-    Parameters
-    ----------
-    natural_coords : np.ndarray, shape (n_ip, parent_dim)
-        IP positions in the parent domain (output of
-        :mod:`STKO_to_python.utilities.gauss_points`).
-    element_node_coords : np.ndarray, shape (n_elements, n_nodes_per, 3)
-        Physical coordinates of each element's nodes, in node-ordering
-        consistent with the shape function.
-    N_fn : callable
-        Shape-function evaluator returning ``(n_ip, n_nodes_per)``.
-
-    Returns
-    -------
-    np.ndarray, shape (n_elements, n_ip, 3)
-        Physical position of each IP for each element.
-    """
-    N = N_fn(natural_coords)  # (n_ip, n_nodes)
-    # einsum: (i,n) @ (e,n,3) → (e,i,3)
-    return np.einsum("in,enj->eij", N, element_node_coords)
-
-
-def compute_jacobian_dets(
-    natural_coords: np.ndarray,
-    element_node_coords: np.ndarray,
-    dN_fn: ShapeFn,
-    geom_kind: GeomKind,
-) -> np.ndarray:
-    """Jacobian determinants at each IP for each element.
-
-    Returns
-    -------
-    np.ndarray, shape (n_elements, n_ip)
-        - ``"solid"``: ``det(J)`` where ``J`` is the 3x3 ∂x/∂ξ matrix.
-        - ``"shell"``: surface measure ``||∂x/∂ξ × ∂x/∂η||``.
-        - ``"line"``: line measure ``||∂x/∂ξ||``.
-
-    All three are non-negative scalars; multiplying a Gauss-point value
-    by ``weight * |J|`` produces a contribution to the integral over
-    the physical element.
-    """
-    dN = dN_fn(natural_coords)  # (n_ip, n_nodes, parent_dim)
-    # J: ∂x_a/∂ξ_k for a ∈ physical (3), k ∈ parent.
-    # einsum: (i,n,k) @ (e,n,a) → (e,i,k,a)
-    J = np.einsum("ink,ena->eika", dN, element_node_coords)
-    # J shape: (n_elements, n_ip, parent_dim, 3)
-
-    if geom_kind == "solid":
-        # J is (e, i, 3, 3) — square matrix per IP; take det.
-        return np.abs(np.linalg.det(J))
-    if geom_kind == "shell":
-        # J is (e, i, 2, 3); cross product of the two parent rows.
-        cross = np.cross(J[..., 0, :], J[..., 1, :])
-        return np.linalg.norm(cross, axis=-1)
-    if geom_kind == "line":
-        # J is (e, i, 1, 3); norm of the single row.
-        return np.linalg.norm(J[..., 0, :], axis=-1)
-    raise ValueError(
-        f"Unknown geom_kind {geom_kind!r}; expected 'solid', 'shell', or 'line'."
-    )
+__all__ = list(_REEXPORTED_NAMES)

--- a/tests/unit/test_gauss_points.py
+++ b/tests/unit/test_gauss_points.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from STKO_to_python.utilities.gauss_points import (
+from STKO_to_python.format.gauss_points import (
     ELEMENT_IP_CATALOG,
     gauss_legendre_1d,
     get_ip_layout,

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -90,6 +90,32 @@ DEPRECATED_DEEP_IMPORTS = [
         "STKO_to_python.plotting.plot_settings",
         "PlotSettings",
     ),
+    # Format-package relocation: gauss_points / shape_functions moved
+    # from utilities/ to format/. Old paths re-export with warnings.
+    (
+        "STKO_to_python.utilities.gauss_points",
+        "get_ip_layout",
+        "STKO_to_python.format.gauss_points",
+        "get_ip_layout",
+    ),
+    (
+        "STKO_to_python.utilities.gauss_points",
+        "ELEMENT_IP_CATALOG",
+        "STKO_to_python.format.gauss_points",
+        "ELEMENT_IP_CATALOG",
+    ),
+    (
+        "STKO_to_python.utilities.shape_functions",
+        "compute_physical_coords",
+        "STKO_to_python.format.shape_functions",
+        "compute_physical_coords",
+    ),
+    (
+        "STKO_to_python.utilities.shape_functions",
+        "SHAPE_FUNCTIONS",
+        "STKO_to_python.format.shape_functions",
+        "SHAPE_FUNCTIONS",
+    ),
 ]
 
 

--- a/tests/unit/test_shape_functions.py
+++ b/tests/unit/test_shape_functions.py
@@ -15,12 +15,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from STKO_to_python.utilities.gauss_points import (
+from STKO_to_python.format.gauss_points import (
     gauss_legendre_1d,
     tensor_product_2d,
     tensor_product_3d,
 )
-from STKO_to_python.utilities.shape_functions import (
+from STKO_to_python.format.shape_functions import (
     SHAPE_FUNCTIONS,
     compute_jacobian_dets,
     compute_physical_coords,

--- a/tests/unit/test_tri_tet_primitives.py
+++ b/tests/unit/test_tri_tet_primitives.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from STKO_to_python.utilities.gauss_points import (
+from STKO_to_python.format.gauss_points import (
     gauss_tetrahedron,
     gauss_triangle,
 )
-from STKO_to_python.utilities.shape_functions import (
+from STKO_to_python.format.shape_functions import (
     compute_jacobian_dets,
     compute_physical_coords,
     tet4_N,
@@ -184,7 +184,7 @@ def test_tet4_volume_works_with_1pt_rule():
 def test_user_registration_pattern_works():
     """Document the API contract: user adds a class to the catalog by
     assigning to the SHAPE_FUNCTIONS dict."""
-    from STKO_to_python.utilities.shape_functions import (
+    from STKO_to_python.format.shape_functions import (
         SHAPE_FUNCTIONS,
         get_shape_functions,
     )


### PR DESCRIPTION
## Summary
Consolidates per-element-class MPCO format quirks into a single `format/` package, matching the architecture proposal's "MPCO format quirks live in one place" intent. The Gauss-point catalog and shape functions had been left under `utilities/` even after `MpcoFormatPolicy` landed in `io/format_policy.py`, splitting the format-policy concern across two trees.

## Layout
- **New:** `src/STKO_to_python/format/__init__.py` — re-exports the public API of both modules for one-import access (`from STKO_to_python.format import get_ip_layout, compute_physical_coords, ...`).
- **Move:** `utilities/gauss_points.py` → `format/gauss_points.py`
- **Move:** `utilities/shape_functions.py` → `format/shape_functions.py`
- Old paths become PEP 562 `__getattr__` shims emitting `DeprecationWarning` per attribute access (same pattern as PR #46).

## Decisions deliberately not made here
The proposal also envisioned:
- A `GaussPointMapper` class wrapper.
- A `coords="natural" | "global"` flag on element fetches.

Neither is introduced here. The registries (`ELEMENT_IP_CATALOG`, `SHAPE_FUNCTIONS`) and free functions are simpler than a class wrapper and have no instance state to carry — dispatch already happens via dict lookup. The "coords flag changes return shape" idea is an anti-pattern; the current `ElementResults.physical_coords()` / `.jacobian_dets()` separate-method API is cleaner and stays. Both decisions will be recorded in the upcoming architecture docs page (Phase 5b).

## Internal updates
`elements/elements.py` and `elements/element_results.py` import directly from `format/` so the library never trips its own deprecation.

## Tests
- The three test files using the old `utilities/` path are switched to `format/`.
- The deprecation parametrize block in `test_public_api.py` grows four cases (one per old-path symbol) to lock in the warning + same-object-identity contract.
- Full suite: **620 passed**.

## Behavior
| Import | After this PR |
|---|---|
| `from STKO_to_python.format.gauss_points import get_ip_layout` | quiet (canonical) |
| `from STKO_to_python.format import get_ip_layout` | quiet (canonical) |
| `from STKO_to_python.utilities.gauss_points import get_ip_layout` | **DeprecationWarning** (resolves to same object) |

Same identity in every case.

## Test plan
- [ ] CI green (test + bench)
- [ ] No warnings on direct `from STKO_to_python.format import ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)