### PR TITLE
Bump version to v1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "STKO_to_python"
-version = "1.1.0"
+version = "1.2.0"
 description = "STKO tools for Python"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
Bumps `pyproject.toml` from `1.1.0` → `1.2.0` to reflect the seven backward-compatible PRs that have landed since v1.1.0.

## What's in v1.2.0 vs v1.1.0
- **#44** Bench CI workflow + benchmark.json artifact
- **#45** Test CI workflow (Python 3.11 / 3.12 / 3.13 matrix)
- **#46** Group A deprecation warnings on legacy compat shims (`core.dataclasses.MetaData`, `plotting.plot_dataclasses.ModelPlotSettings`)
- **#47** `__slots__` discipline on `NodalResults` + `_ResultView`
- **#48** `format/` package: `gauss_points` + `shape_functions` relocated from `utilities/` with deprecation re-exports at the old paths
- **#49** Group B file renames: `nodes.py` → `node_manager.py`, `elements.py` → `element_manager.py`, `model_info.py` → `model_info_reader.py`, `cdata.py` → `cdata_reader.py`, with `__getattr__`-based DeprecationWarning shims at the legacy paths
- **#50** Architecture docs refreshed to document what actually landed

## Why MINOR
The new canonical module paths (`STKO_to_python.format`, `STKO_to_python.nodes.node_manager`, `.elements.element_manager`, `.model.model_info_reader`, `.model.cdata_reader`) are new public surface — fully backward-compatible since every legacy path still resolves to the same canonical class object. Per the versioning policy in [CLAUDE.md](CLAUDE.md), backward-compatible feature additions warrant a MINOR bump.

## Follow-up after merge
Tag the merge commit: `git tag v1.2.0 <sha> && git push origin v1.2.0`.

## Test plan
- [ ] CI passes (no code changes, version string only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)