### PR TITLE
Add ElementSelector + ResultMask filter pipeline

### DIFF
--- a/docs/api/element-results.md
+++ b/docs/api/element-results.md
@@ -167,6 +167,145 @@ df_summary = er.summary()
 
 ---
 
+## Element selectors (pre-fetch)
+
+Build chainable, composable element-id queries against the cached
+element index — no HDF5 reads required. Pass the resolved selector
+into `get_element_results(selector=...)` to fetch only what you need.
+
+```python
+sel = (ds.elements.select()
+       .of_type("DispBeamColumn3d")           # universe anchor
+       .from_selection("CoreColumns")          # set membership
+       .within_box(min=(0, 0, 0), max=(10, 10, 30))
+       .nearest_to((5, 5, 15), k=20))
+
+ids = sel.ids()          # np.ndarray[int64]
+df  = sel.df()           # element-index rows
+mask = sel.mask()        # bool Series indexed by element_id
+n   = sel.count()        # int
+
+er = ds.elements.get_element_results("globalForces", selector=sel)
+```
+
+**Spatial primitives** — every primitive narrows AND-style in chain
+order:
+
+| Primitive | Notes |
+|---|---|
+| `.within_box(min, max, mode="centroid")` | `mode` ∈ `"centroid"`, `"any_node"`, `"all_nodes"` |
+| `.within_distance(point, radius)` | centroid-distance test |
+| `.nearest_to(point, k=1)` | k-NN by centroid; result rows sorted by distance |
+| `.on_plane(z=2.5)` / `.on_plane(point=, normal=)` | element crosses (or touches) the plane |
+| `.near_line(p0, p1, radius)` | distance to segment |
+| `.centroid_in(axis, lo=, hi=)` | one-sided or two-sided range |
+| `.where(fn)` | predicate escape hatch — `fn(df) -> bool_mask` |
+
+**Anchors** — set the type-bound universe used for negation:
+
+| Anchor | Purpose |
+|---|---|
+| `.of_type(name)` | base class (decorated `[bracket]` is stripped automatically) |
+| `.from_selection(name_or_id)` | one or more selection sets |
+| `.with_ids(ids)` | explicit element IDs |
+
+**Boolean composition** — combine independently anchored selectors:
+
+```python
+a = ds.elements.select().of_type("Beam").within_box(...)
+b = ds.elements.select().of_type("Beam").from_selection("Core")
+
+(a & b).ids()       # intersection
+(a | b).ids()       # union
+(~a).ids()          # complement WITHIN a's of_type universe
+```
+
+Negation requires an anchor (`of_type` / `from_selection` / `with_ids`)
+on every leaf — otherwise the universe is undefined and the call
+raises. The combinator's universe is the intersection of its leaves'
+universes for `&`, the union for `|`.
+
+---
+
+## Result masks (post-fetch)
+
+`er.where(...)` builds a per-element boolean mask from a value
+condition. Combine with `& / | / ~` and apply via `er[mask]` to get a
+fresh trimmed `ElementResults`.
+
+```python
+mask = (er.where(time=(0.0, 10.0))           # default time window
+        .component("Mz_ip0")                  # or .canonical("axial_force")
+        .abs_peak()                           # reduction over the window
+        .gt(50.0))                            # comparator → ResultMask
+
+hot = er[mask]              # fresh ElementResults with only matched ids
+ids = mask.ids()            # int64 array
+n   = mask.count()          # int
+```
+
+**Reductions over time**
+
+| Reduction | Returns one scalar per element |
+|---|---|
+| `at_step(s)` | value at exactly step `s` |
+| `at_time(t)` | value at the step nearest to time `t` |
+| `peak(time=...)` | signed maximum over the window |
+| `trough(time=...)` | signed minimum over the window |
+| `abs_peak(time=...)` | maximum of `|·|` over the window |
+| `mean(time=...)` | mean over the window |
+| `residual(time=...)` | last step in the window |
+| `over_threshold(v, time=...)` | fraction of steps above `v` (chain a comparator) |
+
+**Comparators** — `gt`, `lt`, `ge`, `le`, `between(lo, hi, inclusive=True)`,
+`outside(lo, hi)`, `eq(v, atol=0)`, `near(v, atol=...)`.
+
+**Time-spec grammar** — the `time=` argument on `er.where()` and on
+every reduction accepts:
+
+| Spec | Meaning |
+|---|---|
+| `None` | all steps in `er.time` |
+| `int` | one step index (negative wraps) |
+| `float` | step nearest to that time value |
+| `slice(t0, t1)` | half-open *time* range `t0 ≤ time < t1` |
+| `(t0, t1)` tuple | same as the slice form |
+| `list[int]` / `np.ndarray[int]` | explicit step indices |
+| `list[float]` / `np.ndarray[float]` | nearest step for each |
+
+The chain inherits the default window from `er.where(time=...)`; any
+reduction may override with its own `time=` argument.
+
+**Composition**
+
+```python
+m1 = er.where().component("Mz_ip0").peak().gt(50.0)
+m2 = er.where().component("N_1").at_step(100).between(-100.0, 0.0)
+
+mask = m1 & m2          # both conditions
+mask = m1 | m2          # either condition
+mask = ~m1              # complement (vs all elements in `er`)
+```
+
+Masks must come from the same `ElementResults` instance — combining
+masks across instances raises `ValueError`.
+
+**Predicate escape hatch**
+
+```python
+mask = er.where().predicate(
+    lambda df: df["Mz_ip0"].abs() > 60.0    # full (e_id, step) index
+)
+# The full-index form is reduced via `any` to a per-element mask.
+
+mask = er.where().predicate(
+    lambda df: np.array([True, False, True])    # length == n_elements
+)
+# Per-element mask used directly.
+```
+
+---
+
 ## DataFrame export
 
 ```python

--- a/docs/cookbook/05-selector-and-mask-pipeline.md
+++ b/docs/cookbook/05-selector-and-mask-pipeline.md
@@ -1,0 +1,273 @@
+# Find the highly-loaded beams in a region — selector + mask pipeline
+
+> Locate every beam-column inside a chosen plan region whose absolute
+> peak bending moment over the seismic window exceeds a yield-style
+> threshold, then plot the survivors. Demonstrates the
+> chainable-selector + result-mask pipeline end-to-end.
+
+The new pipeline has two layers, executed in this order:
+
+1. **`ds.elements.select()` — pre-fetch.** Chainable, lazy queries
+   over the cached element index. Decides *which elements* to read
+   from disk before any HDF5 access. Spatial primitives, type/selection
+   anchors, and `&` / `|` / `~` boolean composition.
+2. **`er.where(...)` — post-fetch.** Builds a per-element boolean
+   `ResultMask` from a value condition over a time window. Compose
+   masks with `&` / `|` / `~`; apply with `er[mask]` to get a fresh
+   `ElementResults` trimmed to the matched elements.
+
+The example below uses the small
+`stko_results_examples/elasticFrame/elasticFrame_mesh_displacementBased_results`
+fixture: 11 `64-DispBeamColumn3d` elements with five Lobatto integration
+stations each. Pushover stage is `MODEL_STAGE[2]`.
+
+```python
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+
+from STKO_to_python import MPCODataSet
+
+REPO_ROOT = Path("path/to/STKO_to_python")
+DATASET = (
+    REPO_ROOT / "stko_results_examples" / "elasticFrame"
+    / "elasticFrame_mesh_displacementBased_results"
+)
+PUSHOVER_STAGE = "MODEL_STAGE[2]"
+
+ds = MPCODataSet(str(DATASET), "results", verbose=False)
+```
+
+---
+
+## 1. Pre-fetch: pick beams in a region
+
+The model is small enough that we *could* fetch every beam — but the
+recipe stays exactly the same on a 100k-element job. Build a selector,
+inspect the resolved id list, then hand it to the fetch path.
+
+```python
+sel = (ds.elements.select()
+       .of_type("DispBeamColumn3d")          # universe anchor
+       .within_box(min=(-0.5, -0.5, 0.0),    # ground-floor band
+                   max=( 9.5,  9.5, 4.0))
+       .centroid_in("z", lo=0.0, hi=4.0))    # belt-and-braces
+
+print(sel)
+# ElementSelector(of_type='DispBeamColumn3d', WithinBoxOp, CentroidInOp)
+print(sel.count(), "beams matched")
+print(sel.ids().tolist())
+```
+
+`sel.df()` returns the matching rows of the element-index DataFrame
+(useful for sanity checking — element_id, decorated_type, node_list,
+centroids).
+
+### Composing two anchors
+
+The same shape works with named selection sets — a selector can mix
+spatial geometry with STKO selection sets via `&`/`|`. Each leaf needs
+its own anchor:
+
+```python
+near_origin = (ds.elements.select()
+               .of_type("DispBeamColumn3d")
+               .within_distance(point=(0.0, 0.0, 0.0), radius=3.0))
+
+corner_set = (ds.elements.select()
+              .of_type("DispBeamColumn3d")
+              .from_selection("CornerBeams"))   # if present
+
+both = near_origin & corner_set
+either = near_origin | corner_set
+not_corner = (ds.elements.select()
+              .of_type("DispBeamColumn3d")
+              .from_selection("CornerBeams"))    # universe = corner beams
+just_other_corners = ~not_corner   # same universe, complement → other beams
+```
+
+The `~` rule is strict: a leaf must declare its universe via
+`.of_type(...)`, `.from_selection(...)`, or `.with_ids(...)` for
+negation to be defined. An unanchored `~sel` raises a
+`ValueError` rather than silently negating against every element in
+the model.
+
+---
+
+## 2. Fetch results, scoped by the selector
+
+`get_element_results` accepts a selector directly — its anchor's
+`of_type` becomes the fetch's `element_type`, and its resolved ids
+become the `element_ids` filter:
+
+```python
+er = ds.elements.get_element_results(
+    results_name="section.force",
+    selector=sel,
+    model_stage=PUSHOVER_STAGE,
+)
+print(er)
+# ElementResults(results_name='section.force',
+#                element_type='DispBeamColumn3d',
+#                n_elements=…, n_steps=10, n_components=20, n_ip=5, …)
+```
+
+You can still pass `element_type=` and `element_ids=` explicitly; the
+selector's ids are unioned with anything else you pass.
+
+---
+
+## 3. Build a result mask
+
+Imagine we want to flag every beam whose absolute peak `M_y` over the
+back half of the pushover exceeds a yield-style threshold of
+`5e6 N·m` at *any* IP. We'll handle the per-IP question in two ways
+to show both styles.
+
+### 3a. Pick one IP and threshold its abs-peak
+
+`component(name)` is the simplest path — pick a single column and
+reduce over time:
+
+```python
+m_ip2 = (er.where(time=(0.0, 5.0))                # default window
+         .component("My_ip2")                      # mid-element station
+         .abs_peak()                               # |peak| over window
+         .gt(5e6))
+
+print(m_ip2)            # ResultMask(n_true=…, n_total=…)
+print(m_ip2.ids())      # element ids that pass
+hot = er[m_ip2]         # fresh ElementResults
+```
+
+### 3b. Combine masks across IPs
+
+For "any IP exceeds the threshold", build one mask per IP and OR them
+together:
+
+```python
+ip_cols = er.canonical_columns("bending_moment_y")    # ('My_ip0', …, 'My_ip4')
+
+masks = [
+    er.where().component(col).abs_peak().gt(5e6)
+    for col in ip_cols
+]
+any_ip_hot = masks[0]
+for m in masks[1:]:
+    any_ip_hot = any_ip_hot | m
+
+hot = er[any_ip_hot]
+print(hot.element_ids, "out of", er.element_ids)
+```
+
+The ergonomic shortcut for "any step where any IP exceeds X" is the
+`predicate` escape hatch — the full `(element_id, step)` index lets you
+bake your own per-row boolean and the chain reduces it via `any` per
+element:
+
+```python
+any_ip_any_step = er.where().predicate(
+    lambda df: df[list(ip_cols)].abs().max(axis=1) > 5e6
+)
+hot = er[any_ip_any_step]
+```
+
+---
+
+## 4. Compose: selector AND mask in one shot
+
+Spatial filter (Layer A) and value filter (Layer B) compose naturally
+because they live in different objects: layer A produces `element_ids`
+that go into the fetch; layer B produces a `ResultMask` that goes into
+`er[...]`.
+
+```python
+sel = (ds.elements.select()
+       .of_type("DispBeamColumn3d")
+       .centroid_in("z", lo=0.0, hi=4.0)
+       .nearest_to((4.5, 4.5, 2.0), k=8))           # 8 beams near a column line
+
+er = ds.elements.get_element_results(
+    "section.force", selector=sel, model_stage=PUSHOVER_STAGE,
+)
+
+mask = (er.where(time=(2.0, 5.0))
+        .component("My_ip2").abs_peak().gt(5e6)
+        & er.where().component("N_ip2").trough().lt(0.0))   # also in compression
+
+hot = er[mask]
+print(f"{hot.n_elements} beams: in box, near (4.5,4.5,2), |My_ip2| > 5e6, axially compressed")
+```
+
+`hot` is a fully-formed `ElementResults` — pickle-able, plottable,
+indexable. `er.plot.history`, `er.plot.diagram`, `er.physical_coords`,
+and `er.integrate_canonical` all work on it.
+
+---
+
+## 5. Inspect intermediate values for tuning
+
+Every reduction is also exposed as a `pd.Series` so you can pick a
+threshold informed by the data instead of hard-coding it:
+
+```python
+peaks = er.where().component("My_ip2").abs_peak().values()
+print(peaks.describe())     # min/max/mean/std per element
+threshold = peaks.quantile(0.75)    # top 25%
+
+mask = er.where().component("My_ip2").abs_peak().gt(threshold)
+hot = er[mask]
+```
+
+The `over_threshold(v)` reduction returns the *fraction* of steps
+above `v`, so chain a comparator to find elements that spend a
+significant share of the window above some level:
+
+```python
+mask = (er.where(time=(0.0, 5.0))
+        .component("My_ip2")
+        .over_threshold(3e6)
+        .gt(0.25))           # at least 25% of the window above 3 MN·m
+```
+
+---
+
+## 6. Plot the survivors
+
+The plotting helpers carry over verbatim — `hot` behaves exactly like
+the original `er`, just with fewer rows:
+
+```python
+fig, ax = plt.subplots(figsize=(7, 4))
+hot.plot.history("My_ip2", ax=ax)
+ax.axhline( 5e6, color="k", lw=0.7, ls="--")
+ax.axhline(-5e6, color="k", lw=0.7, ls="--")
+ax.set_ylabel("M_y at IP 2 (N·m)")
+ax.set_title(f"{hot.n_elements} beams above the threshold")
+plt.show()
+```
+
+---
+
+## Cheat sheet
+
+| Goal | One-liner |
+|---|---|
+| All beams of a class | `ds.elements.select().of_type("DispBeamColumn3d").ids()` |
+| In a 3-D AABB | `…of_type("…").within_box(min=(0,0,0), max=(10,10,10)).ids()` |
+| Within radius of a point | `…within_distance((5,5,5), r=2.0).ids()` |
+| k nearest to a point | `…nearest_to((5,5,5), k=10).ids()` |
+| Crossing a plane | `…on_plane(z=2.5).ids()` (or `point=, normal=`) |
+| Inside a slab | `…centroid_in("z", lo=2.0, hi=4.0).ids()` |
+| In named selection set | `…from_selection("Walls").ids()` |
+| Combine | `(a & b).ids()`, `(a | b).ids()`, `(~a).ids()` |
+| Threshold abs-peak | `er.where().component(col).abs_peak().gt(v)` |
+| At a step | `er.where().component(col).at_step(s).between(lo, hi)` |
+| Over a time window | `er.where(time=(t0, t1)).component(col).peak().gt(v)` |
+| Over time as fraction | `er.where().component(col).over_threshold(v).gt(0.25)` |
+| Composing masks | `m1 & m2`, `m1 | m2`, `~m1` |
+| Apply | `er[mask]` → fresh `ElementResults` |
+
+For the full API reference and the time-spec grammar see
+[ElementResults — Element selectors](../api/element-results.md#element-selectors-pre-fetch)
+and [ElementResults — Result masks](../api/element-results.md#result-masks-post-fetch).

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -15,6 +15,7 @@ workflows the library is built around. Each tutorial:
 | 2 | [Stress contour on a shear wall](02-stress-contour-on-a-wall.md) | `elasticFrame/QuadFrame_results` | `203-ASDShellQ4` |
 | 3 | [Peak moment per beam over a pushover](03-peak-moment-per-beam.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | `64-DispBeamColumn3d` |
 | 4 | [Volume integral of σ_11 over a brick subdomain](04-volume-integral-on-bricks.md) | `solid_partition_example` (gitignored — skip-if-absent) | `56-Brick` |
+| 5 | [Selector + mask pipeline](05-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | `64-DispBeamColumn3d` |
 
 For broader tours of the API on a single fixture see the
 [Examples](../examples/usage_tour.md) section. For the reference

--- a/src/STKO_to_python/elements/__init__.py
+++ b/src/STKO_to_python/elements/__init__.py
@@ -1,5 +1,7 @@
 from .element_manager import ElementManager
 from .element_results import ElementResults
+from .result_mask import ResultMask
+from .selector import ElementSelector
 
 # Back-compat alias preserved on the package surface (quiet); the deep
 # path ``STKO_to_python.elements.elements.Elements`` emits a
@@ -10,4 +12,6 @@ __all__ = [
     'ElementManager',
     'Elements',
     'ElementResults',
+    'ElementSelector',
+    'ResultMask',
 ]

--- a/src/STKO_to_python/elements/element_manager.py
+++ b/src/STKO_to_python/elements/element_manager.py
@@ -10,6 +10,7 @@ import pandas as pd
 if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
     from .element_results import ElementResults
+    from .selector import ElementSelector
 
 logger = logging.getLogger(__name__)
 
@@ -308,6 +309,32 @@ class ElementManager:
             base = element_type.split("[")[0]
             df = df[df["element_type"].str.startswith(base)]
         return df
+
+    # ------------------------------------------------------------------ #
+    # Selector entry point                                                #
+    # ------------------------------------------------------------------ #
+
+    def select(self) -> "ElementSelector":
+        """Build a lazy, chainable element-id query.
+
+        Returns a fresh :class:`~STKO_to_python.elements.selector.ElementSelector`
+        anchored to nothing; chain ``of_type`` / ``from_selection`` /
+        ``with_ids`` to set its universe, then add spatial primitives
+        (``within_box``, ``nearest_to``, ``on_plane``, ``near_line``,
+        ``within_distance``, ``centroid_in``) or a ``where(fn)``
+        predicate. Combine with ``&`` / ``|`` / ``~``.
+
+        Examples
+        --------
+        >>> ids = (dataset.elements.select()
+        ...        .of_type("DispBeamColumn3d")
+        ...        .within_box(min=(0, 0, 0), max=(10, 10, 30))
+        ...        .nearest_to((5, 5, 15), k=20)
+        ...        .ids())
+        """
+        from .selector import ElementSelector
+
+        return ElementSelector(self)
 
     # ------------------------------------------------------------------ #
     # Element ID resolution (mirrors Nodes._resolve_node_ids)
@@ -779,17 +806,65 @@ class ElementManager:
     def get_element_results(
         self,
         results_name: str,
-        element_type: str,
+        element_type: Optional[str] = None,
         *,
         element_ids: Union[list[int], np.ndarray, None] = None,
         selection_set_id: Union[int, Sequence[int], None] = None,
         selection_set_name: Union[str, Sequence[str], None] = None,
+        selector: Optional["ElementSelector"] = None,
         model_stage: Union[str, Sequence[str], None] = None,
         verbose: bool = False,
     ) -> "ElementResults":
         """Public entry point — routes through the dataset-owned query
         engine so every call benefits from the LRU cache. Thin wrapper.
+
+        Parameters
+        ----------
+        selector : ElementSelector, optional
+            Resolved id list from a chainable selector
+            (:meth:`ElementManager.select`). When provided, its ids are
+            merged with ``element_ids``, and the selector's
+            ``of_type`` anchor (if any) overrides ``element_type`` when
+            ``element_type`` is left as ``None``.
         """
+        if selector is not None:
+            from .selector import ElementSelector  # avoid import cycle
+
+            if not isinstance(selector, ElementSelector):
+                raise TypeError(
+                    "selector must be an ElementSelector instance "
+                    f"(got {type(selector).__name__})."
+                )
+            sel_ids = selector.ids()
+            if element_ids is None:
+                element_ids = sel_ids
+            else:
+                element_ids = np.unique(
+                    np.concatenate(
+                        [
+                            np.asarray(element_ids, dtype=np.int64).ravel(),
+                            sel_ids,
+                        ]
+                    )
+                )
+            if element_type is None:
+                anchor_type = getattr(selector, "_anchor", None)
+                anchor_type = (
+                    anchor_type.of_type if anchor_type is not None else None
+                )
+                if anchor_type is None:
+                    raise ValueError(
+                        "get_element_results: selector has no of_type "
+                        "anchor; pass element_type= explicitly."
+                    )
+                element_type = anchor_type
+
+        if element_type is None:
+            raise ValueError(
+                "get_element_results: element_type is required (or pass "
+                "a selector with .of_type(...) set)."
+            )
+
         engine = getattr(self.dataset, "_element_query_engine", None)
         if engine is not None:
             return engine.fetch(

--- a/src/STKO_to_python/elements/element_results.py
+++ b/src/STKO_to_python/elements/element_results.py
@@ -884,6 +884,50 @@ class ElementResults:
         return self.at_step(idx)
 
     # ------------------------------------------------------------------ #
+    # Threshold / time-window query (Phase 2)                             #
+    # ------------------------------------------------------------------ #
+
+    def where(self, *, time: Any = None) -> "Any":
+        """Start a threshold / time-window mask query.
+
+        Returns a ``_ResultQuery`` object; chain ``.component(...)`` /
+        ``.canonical(...)`` / ``.predicate(...)`` to build a
+        :class:`~STKO_to_python.elements.result_mask.ResultMask`. The
+        ``time`` argument sets a default window for every reduction in
+        the chain (each reduction can override with its own ``time=``).
+
+        See :mod:`STKO_to_python.elements.result_mask` for the full
+        time-spec grammar.
+
+        Examples
+        --------
+        >>> mask = (er.where(time=(0.0, 10.0))
+        ...        .component("Mz_ip0").abs_peak().gt(50.0))
+        >>> hot = er[mask]                      # filtered ElementResults
+        >>> ids = mask.ids()                    # int64 array
+        """
+        from .result_mask import _ResultQuery
+
+        return _ResultQuery(self, default_time=time)
+
+    def __getitem__(self, key: Any) -> Any:
+        """Apply a :class:`ResultMask` (``er[mask]``) to get a fresh
+        trimmed :class:`ElementResults`.
+
+        Column / view access still goes through the dynamic
+        ``__getattr__`` proxies (``er.Mz_ip0``); slicing here is for
+        masks only.
+        """
+        from .result_mask import ResultMask
+
+        if isinstance(key, ResultMask):
+            return key.apply()
+        raise TypeError(
+            f"ElementResults[...] expects a ResultMask; got "
+            f"{type(key).__name__}. Use attribute access for columns."
+        )
+
+    # ------------------------------------------------------------------ #
     # Pickle support
     # ------------------------------------------------------------------ #
 

--- a/src/STKO_to_python/elements/result_mask.py
+++ b/src/STKO_to_python/elements/result_mask.py
@@ -1,0 +1,579 @@
+"""ResultMask — threshold / time-window filters on :class:`ElementResults`.
+
+The selector layer (``ElementSelector``) decides *which elements* before
+any HDF5 read; this layer decides *which of the fetched elements
+satisfy a value condition*. Output is a per-element boolean mask that
+can be combined with ``&`` / ``|`` / ``~`` and applied to the parent
+``ElementResults`` via ``er[mask]`` to get a fresh, trimmed result.
+
+The chain shape is::
+
+    er.where(time=...)                # default time window (optional)
+      .component("Mz_ip0")            # or .canonical("axial_force")
+      .abs_peak(time=...)             # reduction over time → scalar/elem
+      .gt(50)                         # comparator → ResultMask
+
+Each step returns a new immutable object — chains are safe to share.
+
+Reductions
+----------
+``at_step(s)``         scalar at one step (s as ``int`` step index)
+``at_time(t)``         scalar at the step nearest to time ``t`` (``float``)
+``peak(time=...)``     signed max over the window
+``trough(time=...)``   signed min over the window
+``abs_peak(time=...)`` max of \\|.\\| over the window
+``mean(time=...)``     arithmetic mean over the window
+``residual(time=...)`` last step in the window
+``over_threshold(v, frac=..., time=...)``
+                       fraction of steps where the value is above ``v``;
+                       ``frac`` can be omitted (returns the fraction
+                       itself, ready for ``.gt(...)``).
+
+Comparators
+-----------
+``gt(v)``, ``lt(v)``, ``ge(v)``, ``le(v)``, ``between(lo, hi)``,
+``outside(lo, hi)``, ``eq(v, atol=0.0)``, ``near(v, atol)``.
+
+Time grammar (``time=`` argument)
+---------------------------------
+``None``                all steps in the parent ``time`` array
+``int``                 single step index
+``float``               step nearest to that time value
+``slice(t0, t1)``       half-open *time* range (``t0`` ≤ time < ``t1``)
+``(t0, t1)`` tuple       same as ``slice(t0, t1)``
+``list[int]``            explicit step indices
+``list[float]``          nearest step for each time value
+``np.ndarray[int]``      explicit step indices (must be 1-D)
+
+The default window from ``er.where(time=...)`` is overridden by any
+explicit ``time=`` on a reduction.
+"""
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .element_results import ElementResults
+
+
+TimeSpec = Union[None, int, float, slice, Tuple[float, float], Sequence[int], Sequence[float], np.ndarray]
+
+
+# Sentinel for "no override; use the chain's default time window".
+_DEFAULT: Any = object()
+
+
+# ---------------------------------------------------------------------- #
+# Time resolver                                                           #
+# ---------------------------------------------------------------------- #
+
+def resolve_step_indices(spec: TimeSpec, time_arr: np.ndarray) -> np.ndarray:
+    """Map a time-spec to an int64 array of step indices.
+
+    The spec semantics are documented in the module docstring.
+    Returns a sorted, deduplicated ``np.ndarray[int64]``.
+    """
+    if spec is None:
+        return np.arange(time_arr.size, dtype=np.int64)
+
+    if isinstance(spec, (int, np.integer)):
+        s = int(spec)
+        if s < 0:
+            s += time_arr.size
+        if s < 0 or s >= time_arr.size:
+            raise IndexError(
+                f"time step index {spec} out of range [0, {time_arr.size})."
+            )
+        return np.asarray([s], dtype=np.int64)
+
+    if isinstance(spec, float):
+        if time_arr.size == 0:
+            raise ValueError("Cannot resolve time= float against empty time array.")
+        return np.asarray(
+            [int(np.argmin(np.abs(time_arr - spec)))], dtype=np.int64
+        )
+
+    if isinstance(spec, slice):
+        t0, t1 = spec.start, spec.stop
+        if spec.step is not None:
+            raise ValueError("time= slice with step is not supported.")
+        return _time_range(time_arr, t0, t1)
+
+    if isinstance(spec, tuple) and len(spec) == 2:
+        return _time_range(time_arr, spec[0], spec[1])
+
+    if isinstance(spec, np.ndarray):
+        if spec.dtype.kind in ("i", "u"):
+            return np.unique(spec.astype(np.int64))
+        if spec.dtype.kind == "f":
+            return _nearest_steps(time_arr, spec)
+        raise TypeError(
+            f"time=ndarray must be int or float dtype, got {spec.dtype!r}."
+        )
+
+    if isinstance(spec, (list, tuple)):
+        if len(spec) == 0:
+            return np.empty(0, dtype=np.int64)
+        first = spec[0]
+        if isinstance(first, (int, np.integer)):
+            return np.unique(np.asarray(spec, dtype=np.int64))
+        if isinstance(first, float):
+            return _nearest_steps(time_arr, np.asarray(spec, dtype=np.float64))
+        raise TypeError(
+            f"time= list/tuple element type {type(first).__name__} not supported."
+        )
+
+    raise TypeError(f"Unsupported time= spec type: {type(spec).__name__}.")
+
+
+def _time_range(
+    time_arr: np.ndarray,
+    t0: Optional[float],
+    t1: Optional[float],
+) -> np.ndarray:
+    if time_arr.size == 0:
+        return np.empty(0, dtype=np.int64)
+    lo = -np.inf if t0 is None else float(t0)
+    hi = np.inf if t1 is None else float(t1)
+    mask = (time_arr >= lo) & (time_arr < hi)
+    return np.flatnonzero(mask).astype(np.int64)
+
+
+def _nearest_steps(time_arr: np.ndarray, targets: np.ndarray) -> np.ndarray:
+    if time_arr.size == 0:
+        raise ValueError("Cannot resolve nearest time against empty time array.")
+    out = np.empty(targets.size, dtype=np.int64)
+    for i, t in enumerate(targets):
+        out[i] = int(np.argmin(np.abs(time_arr - t)))
+    return np.unique(out)
+
+
+# ---------------------------------------------------------------------- #
+# ResultMask — boolean mask with composition                              #
+# ---------------------------------------------------------------------- #
+
+class ResultMask:
+    """Per-element boolean mask, composable via ``& / | / ~``.
+
+    Created by the comparator step of a ``er.where().<...>`` chain or
+    by the ``predicate(fn)`` escape hatch. Apply via ``er[mask]`` (a
+    fresh :class:`ElementResults`) or extract the matching ids via
+    ``mask.ids()``.
+    """
+
+    __slots__ = ("_er", "_series")
+
+    def __init__(self, er: "ElementResults", series: pd.Series) -> None:
+        if not isinstance(series, pd.Series):
+            raise TypeError("ResultMask: series must be a pandas Series.")
+        # Coerce to bool, fill NaNs with False (NaN reductions can't
+        # match thresholds — defensive default).
+        s = series.astype("boolean").fillna(False).astype(bool)
+        # Reindex to the canonical element_id order from the parent
+        # results so that & / | over masks built from different
+        # reductions align correctly.
+        canonical_idx = pd.Index(np.asarray(er.element_ids, dtype=np.int64))
+        s = s.reindex(canonical_idx, fill_value=False)
+        s.name = "mask"
+        s.index.name = "element_id"
+        self._er = er
+        self._series = s
+
+    # ------------------------------------------------------------------ #
+    # Outputs                                                            #
+    # ------------------------------------------------------------------ #
+    def mask(self) -> pd.Series:
+        """Boolean Series indexed by ``element_id``."""
+        return self._series.copy()
+
+    def ids(self) -> np.ndarray:
+        """``int64`` array of element IDs where the mask is ``True``."""
+        return self._series.index[self._series].to_numpy(dtype=np.int64)
+
+    def count(self) -> int:
+        """Number of elements where the mask is ``True``."""
+        return int(self._series.sum())
+
+    def apply(self) -> "ElementResults":
+        """Return a fresh :class:`ElementResults` trimmed to matched ids."""
+        return _subset_er(self._er, self.ids())
+
+    # ------------------------------------------------------------------ #
+    # Boolean composition                                                 #
+    # ------------------------------------------------------------------ #
+    def __and__(self, other: "ResultMask") -> "ResultMask":
+        if not isinstance(other, ResultMask):
+            return NotImplemented  # type: ignore[return-value]
+        if self._er is not other._er:
+            raise ValueError(
+                "Cannot AND masks from different ElementResults instances."
+            )
+        return ResultMask(self._er, self._series & other._series)
+
+    def __or__(self, other: "ResultMask") -> "ResultMask":
+        if not isinstance(other, ResultMask):
+            return NotImplemented  # type: ignore[return-value]
+        if self._er is not other._er:
+            raise ValueError(
+                "Cannot OR masks from different ElementResults instances."
+            )
+        return ResultMask(self._er, self._series | other._series)
+
+    def __invert__(self) -> "ResultMask":
+        return ResultMask(self._er, ~self._series)
+
+    def __repr__(self) -> str:
+        return (
+            f"ResultMask(n_true={self.count()}, "
+            f"n_total={len(self._series)})"
+        )
+
+    def __len__(self) -> int:
+        return int(self.count())
+
+
+# ---------------------------------------------------------------------- #
+# _ScalarPerElement — reduced values, exposes comparators                 #
+# ---------------------------------------------------------------------- #
+
+class _ScalarPerElement:
+    """One float per element, ready for a comparator step.
+
+    Construction is internal — produced by :class:`_ComponentQuery`
+    reductions. The series is indexed by ``element_id`` and aligned
+    with the parent ``ElementResults.element_ids``.
+    """
+
+    __slots__ = ("_er", "_values")
+
+    def __init__(self, er: "ElementResults", values: pd.Series) -> None:
+        self._er = er
+        # Align on element_ids; missing rows fill NaN so comparators
+        # produce False (defensive).
+        canonical_idx = pd.Index(np.asarray(er.element_ids, dtype=np.int64))
+        self._values = values.reindex(canonical_idx)
+        self._values.index.name = "element_id"
+
+    # -- introspection --------------------------------------------------
+    def values(self) -> pd.Series:
+        """The underlying scalar Series (indexed by ``element_id``)."""
+        return self._values.copy()
+
+    # -- comparators ----------------------------------------------------
+    def gt(self, value: float) -> ResultMask:
+        return ResultMask(self._er, self._values > value)
+
+    def lt(self, value: float) -> ResultMask:
+        return ResultMask(self._er, self._values < value)
+
+    def ge(self, value: float) -> ResultMask:
+        return ResultMask(self._er, self._values >= value)
+
+    def le(self, value: float) -> ResultMask:
+        return ResultMask(self._er, self._values <= value)
+
+    def between(self, lo: float, hi: float, *, inclusive: bool = True) -> ResultMask:
+        if inclusive:
+            s = (self._values >= lo) & (self._values <= hi)
+        else:
+            s = (self._values > lo) & (self._values < hi)
+        return ResultMask(self._er, s)
+
+    def outside(self, lo: float, hi: float, *, inclusive: bool = False) -> ResultMask:
+        if inclusive:
+            s = (self._values <= lo) | (self._values >= hi)
+        else:
+            s = (self._values < lo) | (self._values > hi)
+        return ResultMask(self._er, s)
+
+    def eq(self, value: float, *, atol: float = 0.0) -> ResultMask:
+        if atol == 0.0:
+            return ResultMask(self._er, self._values == value)
+        return self.near(value, atol=atol)
+
+    def near(self, value: float, *, atol: float) -> ResultMask:
+        return ResultMask(self._er, (self._values - value).abs() <= atol)
+
+    def __repr__(self) -> str:
+        return f"_ScalarPerElement(n={len(self._values)})"
+
+
+# ---------------------------------------------------------------------- #
+# _ComponentQuery — selects column(s), exposes reductions                 #
+# ---------------------------------------------------------------------- #
+
+class _ComponentQuery:
+    """One column of an :class:`ElementResults`, with reductions over
+    the time axis. Produced by ``er.where(...).component(name)``.
+    """
+
+    __slots__ = ("_er", "_column", "_default_time")
+
+    def __init__(
+        self,
+        er: "ElementResults",
+        column: str,
+        default_time: TimeSpec,
+    ) -> None:
+        self._er = er
+        if column not in er.df.columns:
+            raise ValueError(
+                f"component {column!r} not in this ElementResults. "
+                f"Available: {list(er.df.columns)}"
+            )
+        self._column = column
+        self._default_time = default_time
+
+    # ------------------------------------------------------------------ #
+    # Reductions                                                          #
+    # ------------------------------------------------------------------ #
+    def at_step(self, step: int) -> _ScalarPerElement:
+        s = self._slice_steps([int(step)])
+        return _ScalarPerElement(self._er, s.droplevel("step"))
+
+    def at_time(self, t: float) -> _ScalarPerElement:
+        idx = resolve_step_indices(float(t), self._time_arr())
+        if idx.size == 0:
+            raise ValueError(f"at_time({t}): no step found.")
+        s = self._slice_steps([int(idx[0])])
+        return _ScalarPerElement(self._er, s.droplevel("step"))
+
+    def peak(self, *, time: Any = _DEFAULT) -> _ScalarPerElement:
+        return self._reduce_over_time(time, "max")
+
+    def trough(self, *, time: Any = _DEFAULT) -> _ScalarPerElement:
+        return self._reduce_over_time(time, "min")
+
+    def abs_peak(self, *, time: Any = _DEFAULT) -> _ScalarPerElement:
+        return self._reduce_over_time(time, "abs_max")
+
+    def mean(self, *, time: Any = _DEFAULT) -> _ScalarPerElement:
+        return self._reduce_over_time(time, "mean")
+
+    def residual(self, *, time: Any = _DEFAULT) -> _ScalarPerElement:
+        return self._reduce_over_time(time, "last")
+
+    def over_threshold(
+        self,
+        value: float,
+        *,
+        time: Any = _DEFAULT,
+    ) -> _ScalarPerElement:
+        """Fraction of steps in the window where value > ``threshold``.
+
+        Chain a comparator (e.g. ``.gt(0.1)``) to mask elements that
+        spend at least 10% of the window above the threshold.
+        """
+        eff = self._effective_time(time)
+        steps = resolve_step_indices(eff, self._time_arr())
+        if steps.size == 0:
+            raise ValueError("over_threshold: empty step window.")
+        df = self._sliced_frame(steps)
+        ser = (df > value).groupby(level="element_id").mean()[self._column]
+        return _ScalarPerElement(self._er, ser)
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                          #
+    # ------------------------------------------------------------------ #
+    def _time_arr(self) -> np.ndarray:
+        t = self._er.time
+        if not isinstance(t, np.ndarray):
+            t = np.asarray(t, dtype=np.float64)
+        return t
+
+    def _effective_time(self, time: Any) -> TimeSpec:
+        return self._default_time if time is _DEFAULT else time
+
+    def _slice_steps(self, steps: Sequence[int]) -> pd.Series:
+        df = self._er.df
+        lvl = df.index.get_level_values("step")
+        sub = df.loc[lvl.isin(np.asarray(steps, dtype=np.int64))][self._column]
+        return sub
+
+    def _sliced_frame(self, steps: np.ndarray) -> pd.DataFrame:
+        df = self._er.df
+        lvl = df.index.get_level_values("step")
+        return df.loc[lvl.isin(steps)][[self._column]]
+
+    def _reduce_over_time(self, time: TimeSpec, op: str) -> _ScalarPerElement:
+        eff = self._effective_time(time)
+        steps = resolve_step_indices(eff, self._time_arr())
+        if steps.size == 0:
+            raise ValueError(f"{op}: empty step window.")
+        df = self._sliced_frame(steps)[self._column]
+        if op == "max":
+            ser = df.groupby(level="element_id").max()
+        elif op == "min":
+            ser = df.groupby(level="element_id").min()
+        elif op == "abs_max":
+            ser = df.abs().groupby(level="element_id").max()
+        elif op == "mean":
+            ser = df.groupby(level="element_id").mean()
+        elif op == "last":
+            # Pick the largest selected step per element.
+            sorted_df = df.reset_index().sort_values("step").set_index(
+                ["element_id", "step"]
+            )[self._column]
+            ser = sorted_df.groupby(level="element_id").last()
+        else:
+            raise ValueError(f"unknown reduction {op!r}")
+        return _ScalarPerElement(self._er, ser)
+
+    def __repr__(self) -> str:
+        return f"_ComponentQuery({self._column!r})"
+
+
+# ---------------------------------------------------------------------- #
+# _ResultQuery — er.where() entry point                                   #
+# ---------------------------------------------------------------------- #
+
+class _ResultQuery:
+    """Entry point produced by :meth:`ElementResults.where`.
+
+    Carries the default time window for the chain; delegates to
+    :class:`_ComponentQuery` for column-level work and to
+    :func:`_predicate_mask` for the escape hatch.
+    """
+
+    __slots__ = ("_er", "_default_time")
+
+    def __init__(self, er: "ElementResults", default_time: TimeSpec) -> None:
+        self._er = er
+        self._default_time = default_time
+
+    def component(self, name: str) -> _ComponentQuery:
+        """Pick one column by exact name (e.g. ``"Mz_ip2"``, ``"Px_1"``)."""
+        return _ComponentQuery(self._er, name, self._default_time)
+
+    def canonical(self, name: str) -> _ComponentQuery:
+        """Pick a column via canonical engineering name.
+
+        Restricted to canonicals that resolve to exactly one column. For
+        multi-IP buckets the user must pick a specific column with
+        :meth:`component` (Phase 4 will add a multi-column reduction).
+        """
+        cols = self._er.canonical_columns(name)
+        if not cols:
+            raise ValueError(
+                f"canonical {name!r}: no matching column. "
+                f"Available canonicals: {self._er.list_canonicals()}"
+            )
+        if len(cols) > 1:
+            raise ValueError(
+                f"canonical {name!r} resolves to {len(cols)} columns "
+                f"({list(cols)}); pick one via .component(name)."
+            )
+        return _ComponentQuery(self._er, cols[0], self._default_time)
+
+    def predicate(
+        self,
+        fn: Callable[[pd.DataFrame], Union[pd.Series, np.ndarray]],
+    ) -> ResultMask:
+        """Escape hatch — ``fn`` receives the parent ``df`` and must
+        return a bool mask aligned with ``element_id`` (length =
+        ``n_elements``) or aligned with the full ``(element_id, step)``
+        index (in which case it is reduced via ``any``).
+        """
+        df = self._er.df
+        out = fn(df)
+        arr = np.asarray(out)
+        n_elems = len(self._er.element_ids)
+        if arr.shape == (n_elems,):
+            ser = pd.Series(
+                arr.astype(bool),
+                index=pd.Index(
+                    np.asarray(self._er.element_ids, dtype=np.int64),
+                    name="element_id",
+                ),
+            )
+        elif arr.shape == (len(df),):
+            tmp = pd.Series(arr.astype(bool), index=df.index)
+            ser = tmp.groupby(level="element_id").any()
+        else:
+            raise ValueError(
+                f"predicate(fn): returned shape {arr.shape}; expected "
+                f"({n_elems},) or ({len(df)},)."
+            )
+        return ResultMask(self._er, ser)
+
+    def __repr__(self) -> str:
+        return f"_ResultQuery(default_time={self._default_time!r})"
+
+
+# ---------------------------------------------------------------------- #
+# Subsetting helper — fresh ElementResults from a mask                    #
+# ---------------------------------------------------------------------- #
+
+def _subset_er(er: "ElementResults", ids: np.ndarray) -> "ElementResults":
+    """Build a fresh :class:`ElementResults` keeping only ``ids``.
+
+    Trims ``df``, ``element_ids``, ``element_node_coords``, and
+    ``element_node_ids``. Preserves ``time``, ``gp_*``, ``model_*``,
+    ``results_name``, ``element_type``, and ``name`` unchanged.
+    """
+    from .element_results import ElementResults
+
+    keep = np.asarray(sorted(int(x) for x in ids), dtype=np.int64)
+    if keep.size == 0:
+        new_df = er.df.iloc[0:0]
+        new_coords = (
+            er.element_node_coords[0:0]
+            if er.element_node_coords is not None
+            else None
+        )
+        new_ids = (
+            er.element_node_ids[0:0]
+            if er.element_node_ids is not None
+            else None
+        )
+    else:
+        new_df = er.df.loc[
+            er.df.index.get_level_values("element_id").isin(keep)
+        ]
+        # Build coords/ids subset aligned to the kept-id sorted order.
+        if (
+            er.element_node_coords is not None
+            and er.element_node_ids is not None
+        ):
+            id_to_pos = {
+                int(eid): i for i, eid in enumerate(er.element_ids)
+            }
+            row_idx = np.array(
+                [id_to_pos[int(eid)] for eid in keep], dtype=np.int64
+            )
+            new_coords = er.element_node_coords[row_idx]
+            new_ids = er.element_node_ids[row_idx]
+        else:
+            new_coords = None
+            new_ids = None
+
+    return ElementResults(
+        df=new_df,
+        time=er.time,
+        name=er.name,
+        element_ids=tuple(int(x) for x in keep),
+        element_type=er.element_type,
+        results_name=er.results_name,
+        model_stage=er.model_stage,
+        model_stages=er.model_stages,
+        stage_step_ranges=dict(er.stage_step_ranges),
+        gp_xi=er.gp_xi,
+        gp_natural=er.gp_natural,
+        gp_weights=er.gp_weights,
+        element_node_coords=new_coords,
+        element_node_ids=new_ids,
+    )
+
+
+__all__ = ["ResultMask", "resolve_step_indices"]

--- a/src/STKO_to_python/elements/selector.py
+++ b/src/STKO_to_python/elements/selector.py
@@ -1,0 +1,826 @@
+"""ElementSelector — lazy, chainable, composable element-id queries.
+
+The selector layer answers *which elements* before any HDF5 result is
+read. Every public method returns a new selector (selectors are
+immutable); resolution to an ID array happens on demand via
+:meth:`ElementSelector.ids` / :meth:`mask` / :meth:`df` / :meth:`count`.
+
+The composition primitives are:
+
+* **Chain** — ``sel.of_type(...).within_box(...).nearest_to(...)`` —
+  each call AND-narrows the candidate set in source order.
+* **Boolean algebra** — ``a & b``, ``a | b``, ``~a`` — operate on the
+  resolved id sets via ``np.intersect1d`` / ``np.union1d`` /
+  ``np.setdiff1d`` against a *type-anchored universe*.
+
+Universe rule for negation
+--------------------------
+``~sel`` is always taken relative to the elements that match ``sel``'s
+own ``of_type`` / ``from_selection`` / ``with_ids`` anchor. If no
+anchor was set the call raises rather than silently negating against
+every element in the model.
+
+Combinators inherit a derived universe:
+
+* ``(a & b)._universe`` = ``a._universe ∩ b._universe``
+* ``(a | b)._universe`` = ``a._universe ∪ b._universe``
+* ``(~a)._universe``  = ``a._universe``  (idempotent)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import reduce
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .element_manager import ElementManager
+
+
+ArrayLike = Union[Sequence[float], np.ndarray]
+
+
+# ---------------------------------------------------------------------- #
+# Filter ops — one tiny dataclass per primitive, each with .apply(df)    #
+# ---------------------------------------------------------------------- #
+
+class _FilterOp:
+    """Marker base. Each op narrows a DataFrame; ops compose by stacking."""
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class _WithinBoxOp(_FilterOp):
+    bbox_min: Tuple[float, float, float]
+    bbox_max: Tuple[float, float, float]
+    mode: str  # "centroid" | "any_node" | "all_nodes"
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        bmin = np.asarray(self.bbox_min, dtype=np.float64)
+        bmax = np.asarray(self.bbox_max, dtype=np.float64)
+        if self.mode == "centroid":
+            cx = df["centroid_x"].to_numpy()
+            cy = df["centroid_y"].to_numpy()
+            cz = df["centroid_z"].to_numpy()
+            mask = (
+                (cx >= bmin[0]) & (cx <= bmax[0]) &
+                (cy >= bmin[1]) & (cy <= bmax[1]) &
+                (cz >= bmin[2]) & (cz <= bmax[2])
+            )
+            return df.loc[mask]
+        node_xyz = _node_coord_lookup(manager)
+        if node_xyz is None:
+            raise ValueError(
+                "within_box(mode!='centroid') needs node coordinates "
+                "but the dataset has no nodes_info table."
+            )
+        in_box_mask: list[bool] = []
+        for nl in df["node_list"]:
+            arr = node_xyz.get_many(nl)
+            if arr is None:
+                in_box_mask.append(False)
+                continue
+            inside = (
+                (arr[:, 0] >= bmin[0]) & (arr[:, 0] <= bmax[0]) &
+                (arr[:, 1] >= bmin[1]) & (arr[:, 1] <= bmax[1]) &
+                (arr[:, 2] >= bmin[2]) & (arr[:, 2] <= bmax[2])
+            )
+            if self.mode == "any_node":
+                in_box_mask.append(bool(inside.any()))
+            elif self.mode == "all_nodes":
+                in_box_mask.append(bool(inside.all()))
+            else:
+                raise ValueError(
+                    f"within_box: unknown mode {self.mode!r}; "
+                    f"expected 'centroid', 'any_node', or 'all_nodes'."
+                )
+        return df.loc[np.asarray(in_box_mask, dtype=bool)]
+
+
+@dataclass(frozen=True)
+class _WithinDistanceOp(_FilterOp):
+    point: Tuple[float, float, float]
+    radius: float
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        p = np.asarray(self.point, dtype=np.float64)
+        cx = df["centroid_x"].to_numpy()
+        cy = df["centroid_y"].to_numpy()
+        cz = df["centroid_z"].to_numpy()
+        d = np.sqrt((cx - p[0]) ** 2 + (cy - p[1]) ** 2 + (cz - p[2]) ** 2)
+        return df.loc[d <= self.radius]
+
+
+@dataclass(frozen=True)
+class _NearestToOp(_FilterOp):
+    point: Tuple[float, float, float]
+    k: int
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty or self.k <= 0:
+            return df.iloc[0:0]
+        p = np.asarray(self.point, dtype=np.float64)
+        cx = df["centroid_x"].to_numpy()
+        cy = df["centroid_y"].to_numpy()
+        cz = df["centroid_z"].to_numpy()
+        d = np.sqrt((cx - p[0]) ** 2 + (cy - p[1]) ** 2 + (cz - p[2]) ** 2)
+        if self.k >= len(df):
+            return df.iloc[np.argsort(d, kind="stable")]
+        idx = np.argpartition(d, self.k - 1)[: self.k]
+        # Stable sort within the top-k for deterministic ordering.
+        idx = idx[np.argsort(d[idx], kind="stable")]
+        return df.iloc[idx]
+
+
+@dataclass(frozen=True)
+class _OnPlaneOp(_FilterOp):
+    point: Tuple[float, float, float]
+    normal: Tuple[float, float, float]
+    tol: float
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        node_xyz = _node_coord_lookup(manager)
+        if node_xyz is None:
+            raise ValueError(
+                "on_plane needs node coordinates but the dataset has "
+                "no nodes_info table."
+            )
+        p = np.asarray(self.point, dtype=np.float64)
+        n = np.asarray(self.normal, dtype=np.float64)
+        norm = np.linalg.norm(n)
+        if norm < 1e-15:
+            raise ValueError("on_plane: normal vector has zero length.")
+        n = n / norm
+        keep: list[bool] = []
+        for nl in df["node_list"]:
+            arr = node_xyz.get_many(nl)
+            if arr is None:
+                keep.append(False)
+                continue
+            signed = (arr - p) @ n
+            has_pos = bool(np.any(signed > self.tol))
+            has_neg = bool(np.any(signed < -self.tol))
+            on_plane = bool(np.any(np.abs(signed) <= self.tol))
+            keep.append(on_plane or (has_pos and has_neg))
+        return df.loc[np.asarray(keep, dtype=bool)]
+
+
+@dataclass(frozen=True)
+class _NearLineOp(_FilterOp):
+    p0: Tuple[float, float, float]
+    p1: Tuple[float, float, float]
+    radius: float
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        a = np.asarray(self.p0, dtype=np.float64)
+        b = np.asarray(self.p1, dtype=np.float64)
+        ab = b - a
+        ab2 = float(np.dot(ab, ab))
+        if ab2 < 1e-30:
+            raise ValueError("near_line: p0 and p1 coincide.")
+        c = np.column_stack(
+            (
+                df["centroid_x"].to_numpy(),
+                df["centroid_y"].to_numpy(),
+                df["centroid_z"].to_numpy(),
+            )
+        )
+        t = np.clip(((c - a) @ ab) / ab2, 0.0, 1.0)
+        proj = a + t[:, None] * ab
+        d = np.linalg.norm(c - proj, axis=1)
+        return df.loc[d <= self.radius]
+
+
+@dataclass(frozen=True)
+class _CentroidInOp(_FilterOp):
+    axis: str
+    lo: Optional[float]
+    hi: Optional[float]
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        col = f"centroid_{self.axis.lower()}"
+        if col not in df.columns:
+            raise ValueError(f"centroid_in: unknown axis {self.axis!r}.")
+        v = df[col].to_numpy()
+        mask = np.ones(len(v), dtype=bool)
+        if self.lo is not None:
+            mask &= v >= self.lo
+        if self.hi is not None:
+            mask &= v <= self.hi
+        return df.loc[mask]
+
+
+@dataclass(frozen=True)
+class _PredicateOp(_FilterOp):
+    fn: Callable[[pd.DataFrame], np.ndarray]
+
+    def apply(self, df: pd.DataFrame, manager: "ElementManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        mask = self.fn(df)
+        mask_arr = np.asarray(mask, dtype=bool)
+        if mask_arr.shape != (len(df),):
+            raise ValueError(
+                f"where(fn): predicate returned shape {mask_arr.shape}, "
+                f"expected ({len(df)},)."
+            )
+        return df.loc[mask_arr]
+
+
+# ---------------------------------------------------------------------- #
+# Lightweight node-coord lookup (cached on the manager via attribute)    #
+# ---------------------------------------------------------------------- #
+
+class _NodeCoordLookup:
+    """Vectorized node_id -> xyz lookup, built once per manager."""
+
+    __slots__ = ("_pos", "_coords")
+
+    def __init__(self, df_nodes: pd.DataFrame) -> None:
+        nids = df_nodes["node_id"].to_numpy(dtype=np.int64)
+        coords = df_nodes[["x", "y", "z"]].to_numpy(dtype=np.float64)
+        self._pos: dict[int, int] = {int(n): i for i, n in enumerate(nids)}
+        self._coords = coords
+
+    def get_many(self, node_ids: Iterable[int]) -> Optional[np.ndarray]:
+        out: list[np.ndarray] = []
+        for nid in node_ids:
+            i = self._pos.get(int(nid))
+            if i is None:
+                return None
+            out.append(self._coords[i])
+        return np.asarray(out, dtype=np.float64) if out else None
+
+
+def _match_type(elem_type_col: pd.Series, query: str) -> pd.Series:
+    """Boolean mask matching element-type strings against a query.
+
+    The element index stores the full ``<classTag>-<ClassName>`` form
+    (e.g. ``"64-DispBeamColumn3d"``). Users typically pass just the
+    class name (``"DispBeamColumn3d"``), but the tagged form is also
+    valid. This helper accepts both: the query matches a row when the
+    full string equals the query, or when the row's class-tag prefix
+    is stripped and the remainder equals the query.
+    """
+    q = str(query).strip()
+    s = elem_type_col.astype(str)
+    direct = s == q
+    no_tag = s.str.replace(r"^\d+-", "", regex=True) == q
+    return direct | no_tag
+
+
+def _node_coord_lookup(manager: "ElementManager") -> Optional[_NodeCoordLookup]:
+    cache = getattr(manager, "_selector_node_lookup", None)
+    if cache is not None:
+        return cache
+    nodes_info = getattr(manager.dataset, "nodes_info", None)
+    if not isinstance(nodes_info, dict):
+        return None
+    df_nodes = nodes_info.get("dataframe")
+    if df_nodes is None or df_nodes.empty:
+        return None
+    cache = _NodeCoordLookup(df_nodes)
+    manager._selector_node_lookup = cache  # type: ignore[attr-defined]
+    return cache
+
+
+# ---------------------------------------------------------------------- #
+# Anchor — defines the type-bound universe for a selector                #
+# ---------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class _Anchor:
+    of_type: Optional[str] = None
+    selection: Optional[Tuple[Any, ...]] = None  # names or set ids
+    explicit_ids: Optional[Tuple[int, ...]] = None
+
+    def is_set(self) -> bool:
+        return (
+            self.of_type is not None
+            or self.selection is not None
+            or self.explicit_ids is not None
+        )
+
+    def with_(
+        self,
+        *,
+        of_type: Optional[str] = None,
+        selection: Optional[Tuple[Any, ...]] = None,
+        explicit_ids: Optional[Tuple[int, ...]] = None,
+    ) -> "_Anchor":
+        return _Anchor(
+            of_type=of_type if of_type is not None else self.of_type,
+            selection=selection if selection is not None else self.selection,
+            explicit_ids=(
+                explicit_ids
+                if explicit_ids is not None
+                else self.explicit_ids
+            ),
+        )
+
+
+# ---------------------------------------------------------------------- #
+# ElementSelector                                                        #
+# ---------------------------------------------------------------------- #
+
+class ElementSelector:
+    """Lazy, immutable element-id query.
+
+    Construct via :meth:`ElementManager.select` and chain primitives.
+    Resolution to ids is deferred until :meth:`ids`, :meth:`mask`,
+    :meth:`df`, or :meth:`count` is called.
+
+    Examples
+    --------
+    >>> sel = (dataset.elements.select()
+    ...        .of_type("DispBeamColumn3d")
+    ...        .within_box(min=(0, 0, 0), max=(10, 10, 30))
+    ...        .nearest_to((5, 5, 15), k=20))
+    >>> ids = sel.ids()                      # np.ndarray[int64]
+    >>> df  = sel.df()                       # element-index rows
+    >>> mask = sel.mask()                    # bool Series indexed by id
+    >>> n   = sel.count()                    # int
+
+    Composition
+    -----------
+    >>> a = dataset.elements.select().of_type("Beam").within_box(...)
+    >>> b = dataset.elements.select().of_type("Beam").from_selection("Core")
+    >>> (a & b).ids()        # intersection
+    >>> (a | b).ids()        # union
+    >>> (~a).ids()           # complement within a's of_type universe
+    """
+
+    def __init__(
+        self,
+        manager: "ElementManager",
+        *,
+        anchor: Optional[_Anchor] = None,
+        ops: Tuple[_FilterOp, ...] = (),
+    ) -> None:
+        self._manager = manager
+        self._anchor = anchor or _Anchor()
+        self._ops = ops
+
+    # ------------------------------------------------------------------ #
+    # Anchor primitives — narrow the universe                            #
+    # ------------------------------------------------------------------ #
+
+    def of_type(self, name: str) -> "ElementSelector":
+        """Anchor universe to a base element type (e.g. ``"DispBeamColumn3d"``).
+
+        Strips any decorated ``[bracket]`` suffix — the anchor is on the
+        OpenSees class name, not the per-rule decorated key.
+        """
+        base = str(name).split("[", 1)[0]
+        return ElementSelector(
+            self._manager, anchor=self._anchor.with_(of_type=base), ops=self._ops
+        )
+
+    def from_selection(
+        self,
+        name_or_id: Union[str, int, Sequence[Union[str, int]]],
+    ) -> "ElementSelector":
+        """Anchor universe to one or more selection sets (by name or id)."""
+        if isinstance(name_or_id, (str, int, np.integer)):
+            sel_tup: Tuple[Any, ...] = (name_or_id,)
+        else:
+            sel_tup = tuple(name_or_id)
+        existing = self._anchor.selection or ()
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(selection=existing + sel_tup),
+            ops=self._ops,
+        )
+
+    def with_ids(
+        self, ids: Union[int, Sequence[int], np.ndarray]
+    ) -> "ElementSelector":
+        """Anchor universe to an explicit set of element ids."""
+        if isinstance(ids, (int, np.integer)):
+            arr = (int(ids),)
+        else:
+            arr = tuple(int(x) for x in np.asarray(ids).ravel())
+        existing = self._anchor.explicit_ids or ()
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(explicit_ids=existing + arr),
+            ops=self._ops,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Spatial primitives — append a filter op                            #
+    # ------------------------------------------------------------------ #
+
+    def within_box(
+        self,
+        *,
+        min: ArrayLike,
+        max: ArrayLike,
+        mode: str = "centroid",
+    ) -> "ElementSelector":
+        """Keep elements inside an axis-aligned bounding box.
+
+        Parameters
+        ----------
+        min, max : (x, y, z)
+            Box corners.
+        mode : "centroid" | "any_node" | "all_nodes"
+            * ``"centroid"``: element centroid lies in the box (default,
+              fastest — uses pre-computed centroid columns).
+            * ``"any_node"``: at least one node of the element is in the
+              box.
+            * ``"all_nodes"``: every node of the element is in the box.
+        """
+        op = _WithinBoxOp(
+            bbox_min=tuple(np.asarray(min, dtype=np.float64).tolist()),
+            bbox_max=tuple(np.asarray(max, dtype=np.float64).tolist()),
+            mode=mode,
+        )
+        return self._with_op(op)
+
+    def within_distance(
+        self, point: ArrayLike, radius: float
+    ) -> "ElementSelector":
+        """Keep elements whose centroid is within ``radius`` of ``point``."""
+        if radius < 0:
+            raise ValueError("within_distance: radius must be non-negative.")
+        op = _WithinDistanceOp(
+            point=tuple(np.asarray(point, dtype=np.float64).tolist()),
+            radius=float(radius),
+        )
+        return self._with_op(op)
+
+    def nearest_to(self, point: ArrayLike, k: int = 1) -> "ElementSelector":
+        """Keep the ``k`` elements whose centroids are nearest to ``point``.
+
+        Result rows are sorted by ascending distance (deterministic, with
+        a stable tie-break on the original index order).
+        """
+        if k < 0:
+            raise ValueError("nearest_to: k must be non-negative.")
+        op = _NearestToOp(
+            point=tuple(np.asarray(point, dtype=np.float64).tolist()),
+            k=int(k),
+        )
+        return self._with_op(op)
+
+    def on_plane(
+        self,
+        *,
+        point: Optional[ArrayLike] = None,
+        normal: Optional[ArrayLike] = None,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        tol: float = 1e-6,
+    ) -> "ElementSelector":
+        """Keep elements that *cross* a plane (any node on each side, or
+        any node on the plane within ``tol``).
+
+        Either pass ``point`` + ``normal`` for a general plane, or one
+        of ``x=``, ``y=``, ``z=`` for an axis-aligned plane.
+        """
+        axis_args = sum(arg is not None for arg in (x, y, z))
+        if axis_args > 1:
+            raise ValueError("on_plane: pass at most one of x=, y=, z=.")
+        if axis_args == 1 and (point is not None or normal is not None):
+            raise ValueError(
+                "on_plane: cannot mix x/y/z= with point/normal."
+            )
+        if axis_args == 1:
+            if x is not None:
+                p, n = (x, 0.0, 0.0), (1.0, 0.0, 0.0)
+            elif y is not None:
+                p, n = (0.0, y, 0.0), (0.0, 1.0, 0.0)
+            else:
+                p, n = (0.0, 0.0, z), (0.0, 0.0, 1.0)  # type: ignore[arg-type]
+        else:
+            if point is None or normal is None:
+                raise ValueError(
+                    "on_plane: pass point=+normal= or one of x=/y=/z=."
+                )
+            p = tuple(np.asarray(point, dtype=np.float64).tolist())  # type: ignore[assignment]
+            n = tuple(np.asarray(normal, dtype=np.float64).tolist())  # type: ignore[assignment]
+        op = _OnPlaneOp(point=p, normal=n, tol=float(tol))  # type: ignore[arg-type]
+        return self._with_op(op)
+
+    def near_line(
+        self,
+        p0: ArrayLike,
+        p1: ArrayLike,
+        radius: float,
+    ) -> "ElementSelector":
+        """Keep elements whose centroid is within ``radius`` of the line
+        segment from ``p0`` to ``p1``."""
+        if radius < 0:
+            raise ValueError("near_line: radius must be non-negative.")
+        op = _NearLineOp(
+            p0=tuple(np.asarray(p0, dtype=np.float64).tolist()),
+            p1=tuple(np.asarray(p1, dtype=np.float64).tolist()),
+            radius=float(radius),
+        )
+        return self._with_op(op)
+
+    def centroid_in(
+        self,
+        axis: str,
+        *,
+        lo: Optional[float] = None,
+        hi: Optional[float] = None,
+    ) -> "ElementSelector":
+        """Keep elements with ``centroid_<axis>`` in ``[lo, hi]``.
+
+        Either bound may be ``None`` for a one-sided constraint. Axis
+        is one of ``"x"``, ``"y"``, ``"z"``.
+        """
+        if lo is None and hi is None:
+            raise ValueError("centroid_in: pass at least one of lo=, hi=.")
+        return self._with_op(_CentroidInOp(axis=str(axis), lo=lo, hi=hi))
+
+    def where(
+        self, fn: Callable[[pd.DataFrame], np.ndarray]
+    ) -> "ElementSelector":
+        """Predicate escape hatch.
+
+        ``fn`` receives the candidate element-index DataFrame and must
+        return a boolean array of equal length.
+
+        Example
+        -------
+        >>> sel.where(lambda df: df["num_nodes"] >= 4)
+        """
+        return self._with_op(_PredicateOp(fn=fn))
+
+    # ------------------------------------------------------------------ #
+    # Resolution                                                         #
+    # ------------------------------------------------------------------ #
+
+    def df(self) -> pd.DataFrame:
+        """Return the element-index DataFrame matching this selector."""
+        df = self._resolve_universe_df()
+        for op in self._ops:
+            df = op.apply(df, self._manager)
+            if df.empty:
+                break
+        return df
+
+    def ids(self) -> np.ndarray:
+        """Return matched element ids as ``int64`` array.
+
+        Order matches the underlying op chain — for ``nearest_to`` this
+        is by ascending distance; otherwise by ascending element_id.
+        """
+        df = self.df()
+        if df.empty:
+            return np.empty(0, dtype=np.int64)
+        return df["element_id"].to_numpy(dtype=np.int64)
+
+    def mask(self) -> pd.Series:
+        """Boolean Series indexed by element_id over the universe."""
+        uni = self._universe_ids()
+        matched = set(int(x) for x in self.ids().tolist())
+        values = np.fromiter(
+            (int(eid) in matched for eid in uni), dtype=bool, count=uni.size
+        )
+        return pd.Series(values, index=uni, name="mask")
+
+    def count(self) -> int:
+        """Number of matched elements."""
+        return int(self.ids().size)
+
+    # ------------------------------------------------------------------ #
+    # Boolean composition                                                #
+    # ------------------------------------------------------------------ #
+
+    def __and__(self, other: "ElementSelector") -> "ElementSelector":
+        if not isinstance(other, ElementSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="and", parts=(self, other))
+
+    def __or__(self, other: "ElementSelector") -> "ElementSelector":
+        if not isinstance(other, ElementSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="or", parts=(self, other))
+
+    def __invert__(self) -> "ElementSelector":
+        if not self._anchor.is_set():
+            raise ValueError(
+                "Cannot negate a selector without an of_type/"
+                "from_selection/with_ids anchor — call .of_type(...) "
+                "first to define the universe."
+            )
+        return _CombinedSelector(self._manager, kind="not", parts=(self,))
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _with_op(self, op: _FilterOp) -> "ElementSelector":
+        return ElementSelector(
+            self._manager, anchor=self._anchor, ops=self._ops + (op,)
+        )
+
+    def _resolve_universe_df(self) -> pd.DataFrame:
+        df = self._manager._ensure_elem_index_df()
+        a = self._anchor
+        if a.of_type is not None:
+            df = df[_match_type(df["element_type"], a.of_type)]
+        if a.selection is not None:
+            names: list[str] = []
+            ids: list[int] = []
+            for s in a.selection:
+                if isinstance(s, (int, np.integer)):
+                    ids.append(int(s))
+                else:
+                    names.append(str(s))
+            sel_ids = self._manager.dataset._selection_resolver.resolve_elements(
+                names=names or None, ids=ids or None
+            )
+            df = df[df["element_id"].isin(sel_ids)]
+        if a.explicit_ids is not None:
+            df = df[df["element_id"].isin(a.explicit_ids)]
+        return df
+
+    def _universe_ids(self) -> np.ndarray:
+        if not self._anchor.is_set():
+            raise ValueError(
+                "Selector has no anchor; cannot compute a universe."
+            )
+        return (
+            self._resolve_universe_df()["element_id"]
+            .to_numpy(dtype=np.int64)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Repr                                                               #
+    # ------------------------------------------------------------------ #
+
+    def __repr__(self) -> str:
+        bits: list[str] = []
+        if self._anchor.of_type:
+            bits.append(f"of_type={self._anchor.of_type!r}")
+        if self._anchor.selection:
+            bits.append(f"from_selection={list(self._anchor.selection)!r}")
+        if self._anchor.explicit_ids:
+            bits.append(f"with_ids({len(self._anchor.explicit_ids)})")
+        for op in self._ops:
+            bits.append(type(op).__name__.strip("_"))
+        return f"ElementSelector({', '.join(bits)})"
+
+
+# ---------------------------------------------------------------------- #
+# Combined (AND/OR/NOT) selector                                          #
+# ---------------------------------------------------------------------- #
+
+class _CombinedSelector(ElementSelector):
+    """Boolean combinator over child selectors. Honors the same protocol
+    as :class:`ElementSelector` so combinators are themselves chainable
+    via further ``&`` / ``|`` / ``~``.
+    """
+
+    def __init__(
+        self,
+        manager: "ElementManager",
+        *,
+        kind: str,
+        parts: Tuple[ElementSelector, ...],
+    ) -> None:
+        # Bypass the regular __init__: combinators carry no anchor/ops
+        # of their own; resolution is delegated to the parts.
+        self._manager = manager
+        self._anchor = _Anchor()
+        self._ops = ()
+        if kind not in {"and", "or", "not"}:
+            raise ValueError(f"_CombinedSelector: unknown kind {kind!r}.")
+        if kind == "not" and len(parts) != 1:
+            raise ValueError("_CombinedSelector('not'): expects one part.")
+        if kind in {"and", "or"} and len(parts) < 2:
+            raise ValueError(f"_CombinedSelector({kind!r}): expects ≥2 parts.")
+        self._kind = kind
+        self._parts = parts
+
+    # -- resolution -----------------------------------------------------
+    def ids(self) -> np.ndarray:
+        if self._kind == "and":
+            arrs = [p.ids() for p in self._parts]
+            return reduce(np.intersect1d, arrs) if arrs else np.empty(0, np.int64)
+        if self._kind == "or":
+            arrs = [p.ids() for p in self._parts]
+            return (
+                reduce(np.union1d, arrs) if arrs else np.empty(0, np.int64)
+            )
+        # not
+        inner = self._parts[0]
+        uni = inner._universe_ids()
+        return np.setdiff1d(uni, inner.ids(), assume_unique=False)
+
+    def df(self) -> pd.DataFrame:
+        ids = self.ids()
+        if ids.size == 0:
+            return self._manager._ensure_elem_index_df().iloc[0:0]
+        df_all = self._manager._ensure_elem_index_df()
+        return df_all[df_all["element_id"].isin(ids)]
+
+    def mask(self) -> pd.Series:
+        uni = self._universe_ids()
+        matched = set(int(x) for x in self.ids().tolist())
+        values = np.fromiter(
+            (int(eid) in matched for eid in uni), dtype=bool, count=uni.size
+        )
+        return pd.Series(values, index=uni, name="mask")
+
+    def count(self) -> int:
+        return int(self.ids().size)
+
+    # -- universe -------------------------------------------------------
+    def _universe_ids(self) -> np.ndarray:
+        unis = [p._universe_ids() for p in self._parts]
+        if self._kind == "and":
+            return reduce(np.intersect1d, unis) if unis else np.empty(0, np.int64)
+        if self._kind == "or":
+            return reduce(np.union1d, unis) if unis else np.empty(0, np.int64)
+        return unis[0]  # not
+
+    # -- composition ----------------------------------------------------
+    def __and__(self, other: "ElementSelector") -> "ElementSelector":
+        if not isinstance(other, ElementSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="and", parts=(self, other))
+
+    def __or__(self, other: "ElementSelector") -> "ElementSelector":
+        if not isinstance(other, ElementSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="or", parts=(self, other))
+
+    def __invert__(self) -> "ElementSelector":
+        # All parts must have anchors so the universe is well-defined.
+        for p in self._parts:
+            try:
+                p._universe_ids()
+            except ValueError as e:
+                raise ValueError(
+                    "Cannot negate a combinator whose parts lack anchors. "
+                    f"Inner error: {e}"
+                ) from e
+        return _CombinedSelector(self._manager, kind="not", parts=(self,))
+
+    # Anchor / chain primitives are intentionally not supported on a
+    # combinator — they would be ambiguous (which leaf gets the new
+    # anchor?). Users should anchor each leaf and combine.
+    def of_type(self, name: str) -> "ElementSelector":  # noqa: D401
+        raise TypeError(
+            "Cannot call .of_type() on a combined selector; anchor each "
+            "leaf selector before combining."
+        )
+
+    def from_selection(self, name_or_id):  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .from_selection() on a combined selector; "
+            "anchor each leaf selector before combining."
+        )
+
+    def with_ids(self, ids):  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .with_ids() on a combined selector; anchor "
+            "each leaf selector before combining."
+        )
+
+    def _with_op(self, op: _FilterOp) -> "ElementSelector":
+        raise TypeError(
+            "Cannot append filter ops directly to a combined selector. "
+            "Apply primitives to leaf selectors before combining, or "
+            "pass the combined result through .ids() and rebuild."
+        )
+
+    # -- repr -----------------------------------------------------------
+    def __repr__(self) -> str:
+        op = {"and": " & ", "or": " | "}.get(self._kind)
+        if self._kind == "not":
+            return f"~({self._parts[0]!r})"
+        return "(" + op.join(repr(p) for p in self._parts) + ")"  # type: ignore[arg-type]
+
+
+__all__ = ["ElementSelector"]

--- a/tests/unit/elements/test_result_mask.py
+++ b/tests/unit/elements/test_result_mask.py
@@ -1,0 +1,379 @@
+"""Unit tests for ``ResultMask`` and the ``er.where(...)`` chain.
+
+Builds a small synthetic :class:`ElementResults` (3 elements × 5 steps
+× 2 components) with known values so each reduction's expected output
+can be reasoned about by hand. No HDF5 fixture required.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.elements.element_results import ElementResults
+from STKO_to_python.elements.result_mask import (
+    ResultMask,
+    resolve_step_indices,
+)
+
+
+# ---------------------------------------------------------------------- #
+# Fixture — synthetic ElementResults                                     #
+# ---------------------------------------------------------------------- #
+
+@pytest.fixture
+def er() -> ElementResults:
+    """3 elements × 5 steps; explicit hand-tuned values."""
+    eids = (1, 2, 3)
+    steps = list(range(5))
+    time = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+
+    # Hand-tuned values:
+    mz = {
+        1: [10.0, 20.0, -30.0, 5.0, 0.0],     # peak=20, trough=-30, |peak|=30, mean=1, last=0
+        2: [-50.0, 60.0, -70.0, 80.0, 90.0],  # peak=90, trough=-70, |peak|=90, mean=22, last=90
+        3: [1.0, 2.0, 3.0, 4.0, 5.0],         # peak=5, trough=1, |peak|=5, mean=3, last=5
+    }
+    n1 = {
+        1: [100.0, 100.0, 100.0, 100.0, 100.0],
+        2: [-50.0, -50.0, -50.0, -50.0, -50.0],
+        3: [0.0, 25.0, 50.0, 75.0, 100.0],
+    }
+    rows: list[dict] = []
+    for e in eids:
+        for s in steps:
+            rows.append(
+                {
+                    "element_id": e,
+                    "step": s,
+                    "Mz_ip0": mz[e][s],
+                    "N_1": n1[e][s],
+                }
+            )
+    df = (
+        pd.DataFrame(rows)
+        .set_index(["element_id", "step"])
+        .sort_index()
+    )
+    return ElementResults(
+        df=df,
+        time=time,
+        element_ids=eids,
+        element_type="DispBeamColumn3d",
+        results_name="globalForces",
+        model_stage="MODEL_STAGE[1]",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Time-spec resolver                                                     #
+# ---------------------------------------------------------------------- #
+
+class TestTimeResolver:
+    time = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+
+    def test_none_returns_all(self):
+        out = resolve_step_indices(None, self.time)
+        assert out.tolist() == [0, 1, 2, 3, 4]
+
+    def test_int_returns_single(self):
+        assert resolve_step_indices(2, self.time).tolist() == [2]
+
+    def test_negative_int_wraps(self):
+        assert resolve_step_indices(-1, self.time).tolist() == [4]
+
+    def test_int_out_of_range_raises(self):
+        with pytest.raises(IndexError):
+            resolve_step_indices(99, self.time)
+
+    def test_float_picks_nearest(self):
+        assert resolve_step_indices(2.4, self.time).tolist() == [2]
+        assert resolve_step_indices(2.6, self.time).tolist() == [3]
+
+    def test_slice_is_time_range(self):
+        # half-open: 1.0 included, 3.0 excluded
+        out = resolve_step_indices(slice(1.0, 3.0), self.time)
+        assert out.tolist() == [1, 2]
+
+    def test_tuple_is_time_range(self):
+        out = resolve_step_indices((1.0, 4.0), self.time)
+        assert out.tolist() == [1, 2, 3]
+
+    def test_slice_with_step_raises(self):
+        with pytest.raises(ValueError, match="step is not supported"):
+            resolve_step_indices(slice(0.0, 4.0, 1.0), self.time)
+
+    def test_list_int_returns_steps(self):
+        out = resolve_step_indices([0, 2, 4], self.time)
+        assert out.tolist() == [0, 2, 4]
+
+    def test_list_float_returns_nearest(self):
+        out = resolve_step_indices([0.4, 2.6], self.time)
+        assert out.tolist() == [0, 3]
+
+    def test_ndarray_int(self):
+        out = resolve_step_indices(np.array([1, 3]), self.time)
+        assert out.tolist() == [1, 3]
+
+
+# ---------------------------------------------------------------------- #
+# Component reductions                                                    #
+# ---------------------------------------------------------------------- #
+
+class TestReductions:
+    def test_at_step(self, er: ElementResults):
+        s = er.where().component("Mz_ip0").at_step(2).values()
+        # Mz at step 2: e1=-30, e2=-70, e3=3
+        assert s.loc[1] == -30.0
+        assert s.loc[2] == -70.0
+        assert s.loc[3] == 3.0
+
+    def test_at_time(self, er: ElementResults):
+        # time=2.5 → nearest step 2 or 3; 0.5 distance both, argmin picks 2
+        s = er.where().component("Mz_ip0").at_time(2.4).values()
+        assert s.loc[2] == -70.0  # step 2
+
+    def test_peak_no_window(self, er: ElementResults):
+        s = er.where().component("Mz_ip0").peak().values()
+        assert s.loc[1] == 20.0
+        assert s.loc[2] == 90.0
+        assert s.loc[3] == 5.0
+
+    def test_trough_no_window(self, er: ElementResults):
+        s = er.where().component("Mz_ip0").trough().values()
+        assert s.loc[1] == -30.0
+        assert s.loc[2] == -70.0
+        assert s.loc[3] == 1.0
+
+    def test_abs_peak_no_window(self, er: ElementResults):
+        s = er.where().component("Mz_ip0").abs_peak().values()
+        assert s.loc[1] == 30.0
+        assert s.loc[2] == 90.0
+        assert s.loc[3] == 5.0
+
+    def test_mean_no_window(self, er: ElementResults):
+        s = er.where().component("Mz_ip0").mean().values()
+        assert pytest.approx(s.loc[1]) == 1.0  # (10+20-30+5+0)/5
+        assert pytest.approx(s.loc[2]) == 22.0  # (-50+60-70+80+90)/5
+        assert pytest.approx(s.loc[3]) == 3.0
+
+    def test_residual_no_window(self, er: ElementResults):
+        s = er.where().component("Mz_ip0").residual().values()
+        assert s.loc[1] == 0.0
+        assert s.loc[2] == 90.0
+        assert s.loc[3] == 5.0
+
+    def test_peak_with_explicit_window(self, er: ElementResults):
+        # Window steps 0..2 (time 0..3 half-open) → look at first 3 steps
+        s = (
+            er.where()
+            .component("Mz_ip0")
+            .peak(time=(0.0, 3.0))
+            .values()
+        )
+        # e1 first 3: max(10,20,-30) = 20
+        # e2 first 3: max(-50,60,-70) = 60
+        # e3 first 3: max(1,2,3) = 3
+        assert s.loc[1] == 20.0
+        assert s.loc[2] == 60.0
+        assert s.loc[3] == 3.0
+
+    def test_default_window_picked_up(self, er: ElementResults):
+        s = (
+            er.where(time=(0.0, 3.0))
+            .component("Mz_ip0")
+            .peak()
+            .values()
+        )
+        assert s.loc[2] == 60.0  # 90 was at step 4, outside window
+
+    def test_explicit_overrides_default(self, er: ElementResults):
+        s = (
+            er.where(time=(0.0, 3.0))
+            .component("Mz_ip0")
+            .peak(time=None)  # explicit override → all steps
+            .values()
+        )
+        assert s.loc[2] == 90.0
+
+    def test_over_threshold_returns_fraction(self, er: ElementResults):
+        # Element 2 |Mz| values: 50,60,70,80,90 — fraction > 60: 3/5 = 0.6
+        s = (
+            er.where()
+            .component("Mz_ip0")
+            .over_threshold(60.0)
+            .values()
+        )
+        # Mz raw (not |.|), so >60: e2 has steps 3 (80) and 4 (90) → 2/5 = 0.4
+        assert pytest.approx(s.loc[2]) == 0.4
+        assert s.loc[1] == 0.0  # never above 60
+
+    def test_unknown_component_raises(self, er: ElementResults):
+        with pytest.raises(ValueError, match="not in this ElementResults"):
+            er.where().component("nonexistent")
+
+
+# ---------------------------------------------------------------------- #
+# Comparators                                                            #
+# ---------------------------------------------------------------------- #
+
+class TestComparators:
+    def test_gt(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().gt(50.0)
+        assert sorted(m.ids().tolist()) == [2]
+
+    def test_lt(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").trough().lt(-40.0)
+        assert sorted(m.ids().tolist()) == [2]
+
+    def test_ge_le(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().ge(20.0)
+        assert sorted(m.ids().tolist()) == [1, 2]
+        m = er.where().component("Mz_ip0").peak().le(20.0)
+        assert sorted(m.ids().tolist()) == [1, 3]
+
+    def test_between_inclusive(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().between(5.0, 20.0)
+        assert sorted(m.ids().tolist()) == [1, 3]
+
+    def test_between_exclusive(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().between(
+            5.0, 20.0, inclusive=False
+        )
+        # peak values: e1=20, e2=90, e3=5; strictly between 5 and 20 → none
+        assert sorted(m.ids().tolist()) == []
+
+    def test_outside(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().outside(0.0, 30.0)
+        # peaks: 20, 90, 5; outside [0,30] strictly → e2=90
+        assert sorted(m.ids().tolist()) == [2]
+
+    def test_eq_exact(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().eq(20.0)
+        assert sorted(m.ids().tolist()) == [1]
+
+    def test_near_atol(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().near(21.0, atol=2.0)
+        # e1 peak=20 → |20-21|=1 ≤ 2; others not
+        assert sorted(m.ids().tolist()) == [1]
+
+
+# ---------------------------------------------------------------------- #
+# Boolean composition                                                    #
+# ---------------------------------------------------------------------- #
+
+class TestComposition:
+    def test_and(self, er: ElementResults):
+        m1 = er.where().component("Mz_ip0").peak().gt(10.0)  # {1,2}
+        m2 = er.where().component("Mz_ip0").trough().gt(-40.0)  # {1, 3} (e1=-30, e3=1)
+        # Wait: e1 trough = -30 > -40 yes. e3 trough = 1 > -40 yes. e2=-70 no.
+        # But m1 = {1, 2}; m2 = {1, 3}; AND = {1}
+        m = m1 & m2
+        assert sorted(m.ids().tolist()) == [1]
+
+    def test_or(self, er: ElementResults):
+        m1 = er.where().component("Mz_ip0").peak().gt(50.0)  # {2}
+        m2 = er.where().component("Mz_ip0").trough().lt(-25.0)  # {1, 2}
+        m = m1 | m2
+        assert sorted(m.ids().tolist()) == [1, 2]
+
+    def test_invert(self, er: ElementResults):
+        m1 = er.where().component("Mz_ip0").peak().gt(50.0)  # {2}
+        m_not = ~m1
+        assert sorted(m_not.ids().tolist()) == [1, 3]
+
+    def test_cross_er_raises(self, er: ElementResults):
+        # Build a second er instance with same shape; AND across them must raise.
+        df = er.df.copy()
+        er2 = ElementResults(
+            df=df,
+            time=er.time,
+            element_ids=er.element_ids,
+            element_type=er.element_type,
+            results_name=er.results_name,
+            model_stage=er.model_stage,
+        )
+        m1 = er.where().component("Mz_ip0").peak().gt(0.0)
+        m2 = er2.where().component("Mz_ip0").peak().gt(0.0)
+        with pytest.raises(ValueError, match="different ElementResults"):
+            m1 & m2
+
+
+# ---------------------------------------------------------------------- #
+# Predicate escape hatch                                                  #
+# ---------------------------------------------------------------------- #
+
+class TestPredicate:
+    def test_predicate_per_element(self, er: ElementResults):
+        # element_ids are (1,2,3); pick e1 and e3
+        m = er.where().predicate(lambda df: np.array([True, False, True]))
+        assert sorted(m.ids().tolist()) == [1, 3]
+
+    def test_predicate_full_index_any_reduction(self, er: ElementResults):
+        # mask aligned with full (e_id, step) index; "any True step per element"
+        df = er.df
+        # True wherever Mz_ip0 > 60 — only e2 has such steps
+        m = er.where().predicate(lambda d: d["Mz_ip0"] > 60.0)
+        assert sorted(m.ids().tolist()) == [2]
+
+    def test_predicate_bad_shape_raises(self, er: ElementResults):
+        with pytest.raises(ValueError, match="returned shape"):
+            er.where().predicate(lambda df: np.array([True, False]))
+
+
+# ---------------------------------------------------------------------- #
+# Apply / __getitem__                                                     #
+# ---------------------------------------------------------------------- #
+
+class TestApply:
+    def test_er_getitem_returns_filtered(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().gt(50.0)
+        out = er[m]
+        assert isinstance(out, ElementResults)
+        assert out.element_ids == (2,)
+        # df is trimmed to one element × 5 steps
+        assert len(out.df) == 5
+        # time array preserved
+        assert np.array_equal(out.time, er.time)
+        # element_type, results_name, model_stage preserved
+        assert out.element_type == er.element_type
+        assert out.results_name == er.results_name
+
+    def test_apply_empty_mask(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().gt(1e9)
+        out = m.apply()
+        assert out.element_ids == ()
+        assert out.empty
+
+    def test_er_getitem_rejects_non_mask(self, er: ElementResults):
+        with pytest.raises(TypeError, match="ResultMask"):
+            er[42]
+
+    def test_apply_preserves_column_layout(self, er: ElementResults):
+        m = er.where().component("Mz_ip0").peak().gt(0.0)  # all ids
+        out = er[m]
+        assert list(out.df.columns) == list(er.df.columns)
+
+
+# ---------------------------------------------------------------------- #
+# Canonical resolution                                                    #
+# ---------------------------------------------------------------------- #
+
+class TestCanonical:
+    def test_canonical_single_column_works(self, er: ElementResults):
+        # N_1 maps to a canonical (axial_force) on closed-form beams.
+        # If canonical_columns returns one column we can use it.
+        cols = er.canonical_columns("axial_force")
+        if len(cols) == 1:
+            m = er.where().canonical("axial_force").peak().gt(50.0)
+            # e1 N_1 always 100 → True; e2 always -50; e3 max=100 → True
+            assert sorted(m.ids().tolist()) == [1, 3]
+        else:
+            pytest.skip(
+                "canonical 'axial_force' did not resolve to a single column "
+                "in this synthetic fixture"
+            )
+
+    def test_canonical_unknown_raises(self, er: ElementResults):
+        with pytest.raises(ValueError):
+            er.where().canonical("totally_made_up_name_xyz")

--- a/tests/unit/elements/test_selector.py
+++ b/tests/unit/elements/test_selector.py
@@ -1,0 +1,583 @@
+"""Unit tests for ``ElementSelector``.
+
+The tests use a synthetic, self-contained ``ElementManager`` stand-in so
+they don't depend on any ``.mpco`` fixture being on disk. The mock
+exposes the two interfaces the selector touches:
+
+* ``_ensure_elem_index_df()`` — pandas DataFrame matching
+  :attr:`ElementManager._ELEM_DTYPE`'s columns.
+* ``dataset._selection_resolver.resolve_elements(...)`` — the same
+  resolver protocol used in production.
+
+The geometry is a uniform 3 × 3 × 3 cubic grid of beam-column elements
+plus a 3 × 3 × 3 grid of shell-quad elements (offset on the y-axis), so
+that universe behavior under ``of_type`` is exercised across multiple
+classes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.elements.selector import ElementSelector
+
+
+# ---------------------------------------------------------------------- #
+# Fixtures — synthetic element index                                     #
+# ---------------------------------------------------------------------- #
+
+BEAM_TYPE = "64-DispBeamColumn3d"
+SHELL_TYPE = "203-ASDShellQ4"
+
+
+def _build_index() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return (elements_df, nodes_df).
+
+    27 beam elements at integer grid positions (x, y=0, z) for x∈[0,2],
+    z∈[0,2], with one beam per cell; plus 27 shell elements offset to
+    y=10 so the two element classes are spatially well-separated.
+    """
+    # ----- nodes -----
+    nodes: list[dict] = []
+    nid = 1
+    # Beam nodes: integer grid + (0..2) x (0) x (0..2)
+    beam_node_ids: dict[tuple[int, int, int], int] = {}
+    for ix in range(4):  # 0..3 → 4 layers per axis to support cells
+        for iz in range(4):
+            beam_node_ids[(ix, 0, iz)] = nid
+            nodes.append(
+                {"node_id": nid, "x": float(ix), "y": 0.0, "z": float(iz)}
+            )
+            nid += 1
+    # Shell nodes: offset by y=10
+    shell_node_ids: dict[tuple[int, int, int], int] = {}
+    for ix in range(4):
+        for iy in range(4):
+            shell_node_ids[(ix, iy, 0)] = nid
+            nodes.append(
+                {
+                    "node_id": nid,
+                    "x": float(ix),
+                    "y": 10.0 + float(iy),
+                    "z": 0.0,
+                }
+            )
+            nid += 1
+
+    df_nodes = pd.DataFrame(nodes)
+
+    # ----- beam elements (line, 2 nodes each) -----
+    beam_rows: list[dict] = []
+    eid = 1
+    beam_decorated = f"{BEAM_TYPE}[1000:0]"
+    for ix in range(3):  # x cell index 0..2
+        for iz in range(3):  # z cell index 0..2
+            n1 = beam_node_ids[(ix, 0, iz)]
+            n2 = beam_node_ids[(ix + 1, 0, iz)]
+            cx = (float(ix) + float(ix + 1)) / 2.0
+            cz = float(iz)
+            beam_rows.append(
+                {
+                    "element_id": eid,
+                    "element_idx": eid - 1,
+                    "file_id": 0,
+                    "element_type": BEAM_TYPE,
+                    "decorated_type": beam_decorated,
+                    "node_list": (n1, n2),
+                    "num_nodes": 2,
+                    "centroid_x": cx,
+                    "centroid_y": 0.0,
+                    "centroid_z": cz,
+                }
+            )
+            eid += 1
+
+    # ----- shell elements (quad, 4 nodes each) -----
+    shell_rows: list[dict] = []
+    shell_decorated = f"{SHELL_TYPE}[200:0]"
+    for ix in range(3):
+        for iy in range(3):
+            n1 = shell_node_ids[(ix, iy, 0)]
+            n2 = shell_node_ids[(ix + 1, iy, 0)]
+            n3 = shell_node_ids[(ix + 1, iy + 1, 0)]
+            n4 = shell_node_ids[(ix, iy + 1, 0)]
+            cx = float(ix) + 0.5
+            cy = 10.0 + float(iy) + 0.5
+            shell_rows.append(
+                {
+                    "element_id": eid,
+                    "element_idx": eid - 28,
+                    "file_id": 0,
+                    "element_type": SHELL_TYPE,
+                    "decorated_type": shell_decorated,
+                    "node_list": (n1, n2, n3, n4),
+                    "num_nodes": 4,
+                    "centroid_x": cx,
+                    "centroid_y": cy,
+                    "centroid_z": 0.0,
+                }
+            )
+            eid += 1
+
+    df_elems = pd.DataFrame(beam_rows + shell_rows)
+    return df_elems, df_nodes
+
+
+# ---------------------------------------------------------------------- #
+# Mock manager / dataset                                                  #
+# ---------------------------------------------------------------------- #
+
+@dataclass
+class _MockSelResolver:
+    element_sets: dict  # name -> np.ndarray; also accepts int ids in id_sets
+    id_sets: dict  # int -> np.ndarray
+
+    def resolve_elements(
+        self,
+        *,
+        names: Optional[Sequence[str]] = None,
+        ids: Optional[Sequence[int]] = None,
+        explicit_ids: Optional[Sequence[int]] = None,
+    ) -> np.ndarray:
+        gathered: list[np.ndarray] = []
+        if names:
+            for n in names:
+                key = str(n).strip().lower()
+                if key not in self.element_sets:
+                    raise ValueError(f"unknown set: {n}")
+                gathered.append(self.element_sets[key])
+        if ids:
+            for sid in ids:
+                if int(sid) not in self.id_sets:
+                    raise ValueError(f"unknown set id: {sid}")
+                gathered.append(self.id_sets[int(sid)])
+        if explicit_ids is not None:
+            gathered.append(np.asarray(list(explicit_ids), dtype=np.int64))
+        if not gathered:
+            raise ValueError("no inputs")
+        return np.unique(np.concatenate(gathered))
+
+
+class _MockDataset:
+    def __init__(self, df_nodes: pd.DataFrame, resolver: _MockSelResolver):
+        self.nodes_info = {"dataframe": df_nodes}
+        self._selection_resolver = resolver
+
+
+class _MockManager:
+    """Stand-in for :class:`ElementManager` exposing only the surface
+    that :class:`ElementSelector` touches."""
+
+    def __init__(self, df_elems: pd.DataFrame, df_nodes: pd.DataFrame, resolver):
+        self._df = df_elems
+        self.dataset = _MockDataset(df_nodes, resolver)
+
+    def _ensure_elem_index_df(self) -> pd.DataFrame:
+        return self._df
+
+
+@pytest.fixture
+def mgr() -> _MockManager:
+    df_elems, df_nodes = _build_index()
+    # Two named sets:
+    #   "FirstColumn"  — beams at x∈[0,1] with low z
+    #   "Outer"        — shells on the perimeter (outermost ring)
+    beam_first = (
+        df_elems[
+            (df_elems["element_type"] == BEAM_TYPE)
+            & (df_elems["centroid_x"] <= 1.0)
+        ]["element_id"]
+        .to_numpy(np.int64)
+    )
+    shell_outer = (
+        df_elems[
+            (df_elems["element_type"] == SHELL_TYPE)
+            & (
+                (df_elems["centroid_x"] < 1.0)
+                | (df_elems["centroid_x"] > 2.0)
+                | (df_elems["centroid_y"] < 11.0)
+                | (df_elems["centroid_y"] > 12.0)
+            )
+        ]["element_id"]
+        .to_numpy(np.int64)
+    )
+    resolver = _MockSelResolver(
+        element_sets={"firstcolumn": beam_first, "outer": shell_outer},
+        id_sets={1: beam_first, 2: shell_outer},
+    )
+    return _MockManager(df_elems, df_nodes, resolver)
+
+
+# ---------------------------------------------------------------------- #
+# Tests — anchors                                                        #
+# ---------------------------------------------------------------------- #
+
+def test_select_returns_empty_selector(mgr: _MockManager):
+    sel = ElementSelector(mgr)
+    # No anchor → unanchored selector still resolves over the full index
+    assert sel.df().shape[0] == 18  # 9 beams + 9 shells
+    assert sel.count() == 18
+
+
+def test_of_type_filters_to_class(mgr: _MockManager):
+    sel = ElementSelector(mgr).of_type("DispBeamColumn3d")
+    assert sel.count() == 9
+    assert set(sel.ids().tolist()) == set(range(1, 10))
+
+
+def test_of_type_strips_decorated_bracket(mgr: _MockManager):
+    """``.of_type`` should accept either bare or decorated names."""
+    bare = ElementSelector(mgr).of_type("DispBeamColumn3d")
+    decorated = ElementSelector(mgr).of_type("64-DispBeamColumn3d[1000:0]")
+    # Both anchors should resolve to the same 27 beams.
+    assert set(bare.ids().tolist()) == set(decorated.ids().tolist())
+
+
+def test_from_selection_by_name(mgr: _MockManager):
+    sel = ElementSelector(mgr).from_selection("FirstColumn")
+    assert sel.count() > 0
+    # All resolved IDs are within the beam class.
+    df = mgr._ensure_elem_index_df()
+    beam_ids = set(
+        df[df["element_type"] == BEAM_TYPE]["element_id"].tolist()
+    )
+    assert set(sel.ids().tolist()).issubset(beam_ids)
+
+
+def test_from_selection_by_id(mgr: _MockManager):
+    sel = ElementSelector(mgr).from_selection(2)  # "Outer" by id
+    df = mgr._ensure_elem_index_df()
+    shell_ids = set(
+        df[df["element_type"] == SHELL_TYPE]["element_id"].tolist()
+    )
+    assert set(sel.ids().tolist()).issubset(shell_ids)
+
+
+def test_with_ids_anchor(mgr: _MockManager):
+    sel = ElementSelector(mgr).with_ids([1, 5, 9, 12])
+    assert sorted(sel.ids().tolist()) == [1, 5, 9, 12]
+
+
+# ---------------------------------------------------------------------- #
+# Tests — spatial primitives                                             #
+# ---------------------------------------------------------------------- #
+
+def test_within_box_centroid(mgr: _MockManager):
+    """Box covering the lower-left 2x2 of the beam grid (x∈[0,1.5])."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 1.5))
+    )
+    # Beams with centroid_x ∈ {0.5, 1.5} and centroid_z ∈ {0,1} → 2*2 = 4
+    # but centroid_x=1.5 is on the boundary (inclusive) — yes.
+    assert sel.count() == 4
+
+
+def test_within_box_any_node(mgr: _MockManager):
+    """``any_node`` mode picks up edge elements that the centroid mode misses."""
+    sel_centroid = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(0.4, 0.5, 0.5), mode="centroid")
+    )
+    sel_any = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(0.4, 0.5, 0.5), mode="any_node")
+    )
+    # Centroid mode catches nothing (smallest beam centroid x=0.5).
+    assert sel_centroid.count() == 0
+    # any_node: only beam 1 has a node (0,0,0) within the small box;
+    # beams 2 and 3 sit at z>=1 so are out of the box.
+    assert sel_any.count() == 1
+    assert sel_any.ids().tolist() == [1]
+
+
+def test_within_distance(mgr: _MockManager):
+    """Sphere centered at first-row beam midpoint."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_distance(point=(0.5, 0.0, 0.0), radius=0.1)
+    )
+    assert sel.count() == 1
+    assert sel.ids().tolist() == [1]
+
+
+def test_nearest_to_k(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .nearest_to(point=(0.5, 0.0, 0.0), k=3)
+    )
+    assert sel.count() == 3
+    # First should be element 1 (centroid (0.5, 0, 0)).
+    assert sel.ids()[0] == 1
+
+
+def test_nearest_to_zero_returns_empty(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .nearest_to(point=(0.0, 0.0, 0.0), k=0)
+    )
+    assert sel.count() == 0
+
+
+def test_on_plane_axis_aligned(mgr: _MockManager):
+    """Plane z=1 cuts beams whose nodes straddle it. Beams are line
+    elements with both nodes at the same z, so only beams *exactly on*
+    z=1 are kept."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .on_plane(z=1.0)
+    )
+    # Beams in the z=1 row → 3.
+    assert sel.count() == 3
+    assert all(
+        mgr._ensure_elem_index_df()
+        .set_index("element_id")
+        .loc[eid, "centroid_z"]
+        == 1.0
+        for eid in sel.ids()
+    )
+
+
+def test_on_plane_general_normal(mgr: _MockManager):
+    """A plane normal (1,0,0) at x=1.0 — should pick up beams that span
+    x=1 (beams whose two endpoints are at x=ix and x=ix+1)."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .on_plane(point=(1.0, 0.0, 0.0), normal=(1.0, 0.0, 0.0))
+    )
+    # Beams with endpoints (0,1) → straddle x=1: yes, plus (1,2) just
+    # touch x=1. Specifically, every beam with endpoint at x=1 OR
+    # straddling x=1 → ix=0 (endpoints 0,1; touches plane) and ix=1
+    # (endpoints 1,2; touches plane). 6 beams.
+    assert sel.count() == 6
+
+
+def test_near_line(mgr: _MockManager):
+    """A line along x at y=0,z=0 — radius 0.1 catches the bottom row of beams."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .near_line(p0=(0.0, 0.0, 0.0), p1=(3.0, 0.0, 0.0), radius=0.1)
+    )
+    # Beams at z=0 (y always 0): 3 of them.
+    assert sel.count() == 3
+
+
+def test_centroid_in_axis(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .centroid_in("z", lo=0.5, hi=1.5)
+    )
+    # Beams with centroid_z = 1 → 3.
+    assert sel.count() == 3
+
+
+def test_centroid_in_one_sided(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .centroid_in("z", hi=0.5)
+    )
+    # centroid_z = 0 → 3 beams.
+    assert sel.count() == 3
+
+
+def test_where_predicate(mgr: _MockManager):
+    """Predicate escape hatch — keep beams with even element_id."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .where(lambda df: (df["element_id"] % 2 == 0).to_numpy())
+    )
+    # 9 beams; even ids are 2,4,6,8 → 4.
+    assert sel.count() == 4
+
+
+def test_where_predicate_shape_mismatch_raises(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .where(lambda df: np.array([True, False]))
+    )
+    with pytest.raises(ValueError, match="predicate returned shape"):
+        sel.ids()
+
+
+# ---------------------------------------------------------------------- #
+# Tests — chaining (AND-narrowing)                                        #
+# ---------------------------------------------------------------------- #
+
+def test_chain_combines_via_and(mgr: _MockManager):
+    """Chained primitives narrow conjunctively."""
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 1.5))
+        .nearest_to(point=(0.5, 0.0, 0.0), k=2)
+    )
+    assert sel.count() == 2
+    assert sel.ids()[0] == 1
+
+
+# ---------------------------------------------------------------------- #
+# Tests — boolean composition (& | ~)                                    #
+# ---------------------------------------------------------------------- #
+
+def test_intersection(mgr: _MockManager):
+    a = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(2.5, 0.5, 0.5))
+    )
+    b = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .centroid_in("x", lo=0.0, hi=1.0)
+    )
+    out = (a & b).ids().tolist()
+    # a: beams at z=0 → 3, b: beams with centroid_x ∈ [0,1] → 3 (x=0.5).
+    # Intersection: beams at z=0 AND x≤1 → 1 (element 1 at (0.5, 0, 0)).
+    assert sorted(out) == [1]
+
+
+def test_union(mgr: _MockManager):
+    a = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([1, 2])
+    b = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([2, 3])
+    assert sorted((a | b).ids().tolist()) == [1, 2, 3]
+
+
+def test_negation_universe_is_of_type_anchor(mgr: _MockManager):
+    """``~`` against ``of_type``-anchored selector returns the *other*
+    elements of that same class — never crosses class boundaries."""
+    a = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 1.5))
+    )
+    in_a = set(a.ids().tolist())
+    not_a = set((~a).ids().tolist())
+    all_beams = set(range(1, 10))
+    assert in_a.union(not_a) == all_beams
+    assert in_a.intersection(not_a) == set()
+    # No shells leak into the negation.
+    assert not_a.intersection(set(range(10, 19))) == set()
+
+
+def test_negation_without_anchor_raises(mgr: _MockManager):
+    sel = ElementSelector(mgr).within_box(
+        min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 1.5)
+    )
+    with pytest.raises(ValueError, match="without an of_type"):
+        ~sel
+
+
+def test_double_negation_returns_original(mgr: _MockManager):
+    a = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 1.5))
+    )
+    assert sorted((~~a).ids().tolist()) == sorted(a.ids().tolist())
+
+
+def test_combined_universe_for_or_is_union(mgr: _MockManager):
+    """For ``a | b``, the negation universe is the union of universes."""
+    a = ElementSelector(mgr).of_type("DispBeamColumn3d").within_box(
+        min=(0.0, -0.5, 0.0), max=(0.6, 0.5, 0.6)
+    )
+    b = ElementSelector(mgr).of_type("ASDShellQ4").within_box(
+        min=(0.0, 9.5, -0.1), max=(0.6, 10.6, 0.1)
+    )
+    union_uni = (a | b)._universe_ids()
+    # Beams (universe of a) have ids 1..9, shells 10..18 → 1..18.
+    assert sorted(union_uni.tolist()) == list(range(1, 19))
+
+
+def test_combined_universe_for_and_is_intersection(mgr: _MockManager):
+    """For ``a & b``, the negation universe is the intersection of universes."""
+    a = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([1, 2])
+    b = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([2, 3, 4])
+    intersect_uni = (a & b)._universe_ids()
+    # Both beams: universe is {1,2} ∩ {2,3,4} = {2}.
+    assert intersect_uni.tolist() == [2]
+
+
+def test_combinator_cannot_take_anchor_methods(mgr: _MockManager):
+    a = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([1])
+    b = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([2])
+    combo = a & b
+    with pytest.raises(TypeError, match="combined selector"):
+        combo.of_type("ASDShellQ4")
+
+
+def test_combinator_chains_via_boolean_again(mgr: _MockManager):
+    a = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([1, 2, 3])
+    b = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([2, 3, 4])
+    c = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([3, 4, 5])
+    # (a & b) | c == {2,3} ∪ {3,4,5} = {2,3,4,5}
+    assert sorted(((a & b) | c).ids().tolist()) == [2, 3, 4, 5]
+
+
+# ---------------------------------------------------------------------- #
+# Tests — outputs (.ids/.df/.mask/.count)                                 #
+# ---------------------------------------------------------------------- #
+
+def test_mask_indexed_by_universe(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .with_ids([1, 5, 9])
+    )
+    m = sel.mask()
+    assert m.sum() == 3
+    # Mask universe is the of_type ∩ with_ids anchor → {1, 5, 9}
+    assert sorted(m.index.tolist()) == [1, 5, 9]
+    assert all(m.values)
+
+
+def test_df_returns_index_rows(mgr: _MockManager):
+    sel = ElementSelector(mgr).of_type("DispBeamColumn3d").with_ids([7])
+    out = sel.df()
+    assert len(out) == 1
+    assert int(out["element_id"].iloc[0]) == 7
+    assert out["element_type"].iloc[0] == BEAM_TYPE
+
+
+def test_repr_includes_anchor_and_ops(mgr: _MockManager):
+    sel = (
+        ElementSelector(mgr)
+        .of_type("DispBeamColumn3d")
+        .within_box(min=(0, 0, 0), max=(1, 1, 1))
+    )
+    r = repr(sel)
+    assert "DispBeamColumn3d" in r
+    assert "WithinBoxOp" in r
+
+
+# ---------------------------------------------------------------------- #
+# Tests — immutability                                                   #
+# ---------------------------------------------------------------------- #
+
+def test_selectors_are_immutable(mgr: _MockManager):
+    base = ElementSelector(mgr).of_type("DispBeamColumn3d")
+    a = base.within_box(min=(0, -1, 0), max=(1, 1, 1))
+    b = base.within_box(min=(2, -1, 0), max=(3, 1, 3))
+    # base unchanged; a and b are independent views
+    assert base.count() == 9
+    # Strict check: re-resolving base still gives 9 (no mutation).
+    assert base.count() == 9
+    # a and b cover disjoint x-ranges so produce disjoint id sets.
+    assert set(a.ids().tolist()).isdisjoint(set(b.ids().tolist()))


### PR DESCRIPTION
## Summary

Two new composable filter layers on top of `ElementManager` and `ElementResults`:

- **`ElementSelector` (pre-fetch).** Chainable, immutable, lazy queries over the cached element index. Spatial primitives (`within_box` with centroid/any_node/all_nodes modes, `within_distance`, `nearest_to`, `on_plane`, `near_line`, `centroid_in`), type/selection/explicit anchors, a `where(fn)` predicate escape hatch, and `& / | / ~` boolean algebra. Negation requires an anchor; combinator universes are intersection (`&`) / union (`|`) of leaves. Wired into `get_element_results(selector=...)` and exposed as `ds.elements.select()`.
- **`ResultMask` (post-fetch).** `er.where(time=...)` builds a per-element boolean mask via `component`/`canonical` → reduction → comparator. Reductions: `at_step`, `at_time`, `peak`, `trough`, `abs_peak`, `mean`, `residual`, `over_threshold`. Comparators: `gt`/`lt`/`ge`/`le`/`between`/`outside`/`eq`/`near`. Default time window from `er.where()` is overridable per reduction. Time grammar accepts `None`/`int`/`float`/`slice`/`tuple`/`list[int|float]`/`ndarray`. Masks compose with `& / | / ~`; `er[mask]` returns a fresh trimmed `ElementResults`.

Composes naturally — selectors decide which elements to read; masks decide which fetched elements satisfy a value condition. See the new cookbook entry for an end-to-end example.

## Test plan
- [x] 32 new unit tests for `ElementSelector` covering every primitive, anchor type, boolean op, anchor-required-for-negation rule, and immutability (synthetic 9-beam + 9-shell index, no fixtures needed)
- [x] 44 new unit tests for `ResultMask` covering time grammar, every reduction, every comparator, `& / | / ~` composition, predicate escape hatch, and `er[mask]` subset semantics
- [x] Full suite: 714 passed (no regressions across unit + integration)

## Docs
- New cookbook entry: [docs/cookbook/05-selector-and-mask-pipeline.md](https://github.com/nmorabowen/STKO_to_python/blob/guppi/elastic-pike-192b2f/docs/cookbook/05-selector-and-mask-pipeline.md) — complete worked example on the `elasticFrame` fixture, including spatial filters, boolean composition, mask reductions over a time window, and combining the two layers.
- Reference sections added to [docs/api/element-results.md](https://github.com/nmorabowen/STKO_to_python/blob/guppi/elastic-pike-192b2f/docs/api/element-results.md): "Element selectors (pre-fetch)" and "Result masks (post-fetch)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)