### PR TITLE
Add NodeSelector + NodeResultMask filter pipeline

### DIFF
--- a/docs/NodalResults.md
+++ b/docs/NodalResults.md
@@ -124,6 +124,215 @@ s = nr.fetch_nearest(
 )
 ```
 
+## Selecting nodes lazily — `ds.nodes.select()`
+
+`fetch(...)` filters an *already-read* result by node ids; for picking
+*which nodes to read* in the first place, use the chainable selector
+returned by `ds.nodes.select()`. It is the node-side analogue of
+`ds.elements.select()` and the full pipeline is documented in
+[Cookbook 06: node selector + mask pipeline](cookbook/06-node-selector-and-mask-pipeline.md).
+
+A selector is **lazy** — every call returns a new selector; nothing
+hits HDF5 until you call `.ids()`, `.df()`, `.mask()`, `.count()`, or
+pass it to `get_nodal_results(selector=…)`.
+
+### Anchors
+
+```python
+# By selection set (name or id, case-insensitive)
+ds.nodes.select().from_selection("Roof")
+ds.nodes.select().from_selection(2)
+ds.nodes.select().from_selection(["Roof", "Mezzanine"])
+
+# By explicit ids
+ds.nodes.select().with_ids([10, 42, 99])
+```
+
+Anchors define the universe for negation (`~`); without an anchor the
+universe is "every node in the model" — fine for spatial filtering and
+unions, but `~sel` raises `ValueError` so you must anchor before
+negating.
+
+### Spatial primitives
+
+```python
+ds.nodes.select().within_box(min=(0, 0, 0), max=(10, 10, 30))
+ds.nodes.select().within_distance((5, 5, 15), radius=2.0)
+ds.nodes.select().nearest_to((5, 5, 15), k=8)             # rows sorted by distance
+ds.nodes.select().on_plane(z=3000.0, tol=1e-3)            # axis-aligned
+ds.nodes.select().on_plane(point=(0,0,0), normal=(1,1,0)) # general plane
+ds.nodes.select().near_line((0,0,0), (0,0,3000), radius=50.0)
+ds.nodes.select().coord_in("z", lo=2.0, hi=4.0)           # one bound is OK
+ds.nodes.select().at_level("z", value=3000.0, tol=1e-3)   # story floor sugar
+```
+
+### Bridge to elements: `attached_to(...)`
+
+Closes the loop between node and element selectors — every node that
+participates in a chosen element set:
+
+```python
+shells = (
+    ds.elements.select()
+    .of_type("ASDShellQ4")
+    .centroid_in("z", lo=0.0, hi=3.0)
+)
+diaphragm_nodes = ds.nodes.select().attached_to(element_selector=shells)
+
+# Or with explicit ids
+ds.nodes.select().attached_to(element_ids=[101, 102, 103])
+```
+
+### Custom predicate
+
+```python
+# Anything not covered by a primitive
+ds.nodes.select().where(
+    lambda df: (df["x"]**2 + df["y"]**2) < 25.0
+)
+```
+
+The callable receives the node-index DataFrame (`node_id, file_id,
+index, x, y, z`) and must return a bool array of equal length.
+
+### Boolean composition
+
+```python
+a = ds.nodes.select().from_selection("Roof")
+b = ds.nodes.select().at_level("x", 0.0)
+(a & b).ids()    # intersection
+(a | b).ids()    # union
+(~a).ids()       # complement of a within a's anchored universe
+```
+
+### Plug into `get_nodal_results`
+
+```python
+roof = (
+    ds.nodes.select()
+    .at_level("z", 3000.0, tol=1e-3)
+    .coord_in("x", lo=1000.0, hi=4000.0)
+)
+
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    selector=roof,
+    model_stage="MODEL_STAGE[2]",
+)
+```
+
+The selector's resolved ids are unioned with anything else you pass
+(`node_ids`, `selection_set_id`, `selection_set_name`).
+
+## Filtering by result value — `nr.where(...)`
+
+After the data is read, build a per-node boolean mask from a value
+condition over a time window. The mask composes with `&` / `|` / `~`
+and applies via `nr[mask]` to get a fresh, trimmed `NodalResults`.
+
+### Single-component pick
+
+```python
+mask = (
+    nr.where(time=(0.0, 10.0))                  # default time window
+      .component("DISPLACEMENT", 1)             # (result_name, component)
+      .abs_peak()                               # |max| over the window
+      .gt(0.05)                                 # comparator → mask
+)
+hot = nr[mask]                                   # trimmed NodalResults
+ids = mask.ids()                                 # int64 array
+```
+
+### Vector-magnitude pick
+
+For the most common "filter nodes by `|U|` peak" case, `magnitude(...)`
+reduces to a per-`(node, step)` scalar via `sqrt(sum(comp_i**2))`
+*before* the time-axis reduction. With `components=()` (default) all
+components for the result are used:
+
+```python
+# All components — typical for 3-DOF DISPLACEMENT / VELOCITY / ACCELERATION
+nr.where().magnitude("DISPLACEMENT").peak().gt(0.05)
+
+# Planar magnitude (X-Y only)
+nr.where().magnitude("DISPLACEMENT", components=(1, 2)).abs_peak().gt(0.05)
+```
+
+### Reductions and comparators
+
+| Reduction | Meaning |
+|---|---|
+| `at_step(s)` | scalar at one step (int step index) |
+| `at_time(t)` | scalar at the step nearest to time `t` |
+| `peak(time=…)` | signed max over the window |
+| `trough(time=…)` | signed min over the window |
+| `abs_peak(time=…)` | max of `|·|` over the window |
+| `mean(time=…)` | arithmetic mean over the window |
+| `residual(time=…)` | last step in the window |
+| `over_threshold(v, time=…)` | fraction of steps where value > `v` |
+
+| Comparator | Mask predicate |
+|---|---|
+| `.gt(v)` | `> v` |
+| `.lt(v)` | `< v` |
+| `.ge(v)` | `>= v` |
+| `.le(v)` | `<= v` |
+| `.between(lo, hi, inclusive=True)` | `lo <= x <= hi` |
+| `.outside(lo, hi, inclusive=False)` | `x < lo` or `x > hi` |
+| `.eq(v, atol=0.0)` | `x == v` (or `near` if `atol > 0`) |
+| `.near(v, atol=…)` | `|x - v| <= atol` |
+
+The chain default `time=` argument is overridden by any explicit
+`time=` on a reduction. The grammar:
+
+```python
+nr.where(time=None)               # all steps (the default)
+nr.where(time=42)                 # int step index
+nr.where(time=2.5)                # nearest step to time 2.5
+nr.where(time=slice(0.0, 10.0))   # half-open time range
+nr.where(time=(0.0, 10.0))        # tuple form, same meaning
+nr.where(time=[0, 5, 10])         # explicit step indices
+nr.where(time=[0.0, 1.0, 5.0])    # nearest step per time
+```
+
+### Tuning thresholds from the data
+
+Every reduction is also exposed as a `pd.Series` so you can pick a
+threshold informed by the distribution rather than guessing:
+
+```python
+peaks = nr.where().magnitude("DISPLACEMENT").peak().values()
+print(peaks.describe())                    # min/max/mean/std per node
+threshold = float(peaks.quantile(0.75))    # top 25 %
+
+mask = nr.where().magnitude("DISPLACEMENT").peak().gt(threshold)
+hot = nr[mask]
+```
+
+### Predicate escape hatch
+
+The full `(node_id, step)` index is exposed if you need an arbitrary
+shape of comparison. The callable is reduced via `any` per node:
+
+```python
+# Any step where |Ux| beats |Uy|
+mask = nr.where().predicate(
+    lambda df: df[("DISPLACEMENT", 1)].abs() > df[("DISPLACEMENT", 2)].abs()
+)
+```
+
+### Mask composition
+
+```python
+m_x   = nr.where().component("DISPLACEMENT", 1).abs_peak().gt(0.05)
+m_mag = nr.where().magnitude("DISPLACEMENT").peak().gt(0.06)
+
+both    = m_x & m_mag
+either  = m_x | m_mag
+not_x   = ~m_x
+hot     = nr[both]
+```
+
 ## Drift Analysis
 
 ### Relative displacement (delta_u)

--- a/docs/api/nodal-results.md
+++ b/docs/api/nodal-results.md
@@ -188,6 +188,174 @@ env = nr.residual_drift_envelope(
 
 ---
 
+## Node selectors (pre-fetch)
+
+Build chainable, composable node-id queries against the cached node
+index — no HDF5 reads required. Pass the resolved selector into
+`get_nodal_results(selector=...)` to fetch only what you need.
+
+```python
+sel = (ds.nodes.select()
+       .from_selection("Roof")                   # universe anchor (optional)
+       .within_box(min=(0, 0, 0), max=(10, 10, 30))
+       .nearest_to((5, 5, 30), k=8))
+
+ids = sel.ids()          # np.ndarray[int64]
+df  = sel.df()           # node-index rows (node_id, file_id, index, x, y, z)
+mask = sel.mask()        # bool Series indexed by node_id over the universe
+n   = sel.count()        # int
+
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    selector=sel,
+    model_stage="MODEL_STAGE[2]",
+)
+```
+
+**Anchors** — set the universe used for negation. Without an anchor the
+universe is "all nodes" (fine for spatial filtering and unions; `~`
+raises `ValueError`).
+
+| Anchor | Purpose |
+|---|---|
+| `.from_selection(name_or_id)` | one or more selection sets (case-insensitive on names) |
+| `.with_ids(ids)` | explicit node IDs |
+
+**Spatial primitives** — every primitive narrows AND-style in chain
+order, against the actual node coordinates:
+
+| Primitive | Notes |
+|---|---|
+| `.within_box(min, max)` | axis-aligned bounding box |
+| `.within_distance(point, radius)` | Euclidean distance |
+| `.nearest_to(point, k=1)` | k-NN; result rows sorted by ascending distance |
+| `.on_plane(z=…)` / `.on_plane(point=, normal=)` | node coordinates within `tol` of the plane |
+| `.near_line(p0, p1, radius)` | distance to line segment |
+| `.coord_in(axis, lo=, hi=)` | one-sided or two-sided range on `x`, `y`, or `z` |
+| `.at_level(axis="z", value=, tol=1e-6)` | story-floor sugar for an axis-aligned plane |
+| `.attached_to(element_ids=… \| element_selector=…)` | every node referenced by the element set |
+| `.where(fn)` | predicate escape hatch — `fn(df) -> bool_mask` |
+
+**Bridge to elements** — `attached_to` accepts either explicit element
+ids or a live `ElementSelector`, so you can build a node set from a
+geometric-element pick without manual id wrangling:
+
+```python
+shells = (ds.elements.select()
+          .of_type("ASDShellQ4")
+          .centroid_in("z", lo=0, hi=3))
+diaphragm = ds.nodes.select().attached_to(element_selector=shells)
+```
+
+**Boolean composition** — combine selectors:
+
+```python
+a = ds.nodes.select().from_selection("Roof").coord_in("x", lo=0, hi=10)
+b = ds.nodes.select().at_level("z", 30.0)
+
+(a & b).ids()       # intersection
+(a | b).ids()       # union
+(~a).ids()          # complement WITHIN a's anchored universe
+```
+
+Negation requires an anchor (`from_selection` / `with_ids`) on every
+leaf — otherwise the call raises. The combinator's universe is the
+intersection of its leaves' universes for `&`, the union for `|`.
+
+---
+
+## Result masks (post-fetch)
+
+`nr.where(...)` builds a per-node boolean mask from a value condition.
+Combine with `& / | / ~` and apply via `nr[mask]` to get a fresh
+trimmed `NodalResults`.
+
+```python
+# Single component
+mask = (nr.where(time=(0.0, 10.0))             # default time window
+        .component("DISPLACEMENT", 1)           # (result_name, component)
+        .abs_peak()                             # reduction over the window
+        .gt(0.05))                              # comparator → NodeResultMask
+
+# Vector magnitude (the typical 3-DOF case)
+mask = nr.where().magnitude("DISPLACEMENT").peak().gt(0.05)
+
+# Planar magnitude
+mask = (nr.where()
+        .magnitude("DISPLACEMENT", components=(1, 2))
+        .abs_peak()
+        .gt(0.05))
+
+hot = nr[mask]              # fresh NodalResults with only matched ids
+ids = mask.ids()            # int64 array
+n   = mask.count()          # int
+```
+
+**Reductions over time**
+
+| Reduction | Returns one scalar per node |
+|---|---|
+| `at_step(s)` | value at exactly step `s` |
+| `at_time(t)` | value at the step nearest to time `t` |
+| `peak(time=...)` | signed maximum over the window |
+| `trough(time=...)` | signed minimum over the window |
+| `abs_peak(time=...)` | maximum of `|·|` over the window |
+| `mean(time=...)` | mean over the window |
+| `residual(time=...)` | last step in the window |
+| `over_threshold(v, time=...)` | fraction of steps above `v` (chain a comparator) |
+
+**Comparators** — `gt`, `lt`, `ge`, `le`, `between(lo, hi, inclusive=True)`,
+`outside(lo, hi)`, `eq(v, atol=0)`, `near(v, atol=...)`.
+
+**Time-spec grammar** — the `time=` argument on `nr.where()` and on
+every reduction accepts:
+
+| Spec | Meaning |
+|---|---|
+| `None` | all steps in `nr.time` |
+| `int` | one step index (negative wraps) |
+| `float` | step nearest to that time value |
+| `slice(t0, t1)` | half-open *time* range `t0 ≤ time < t1` |
+| `(t0, t1)` tuple | same as the slice form |
+| `list[int]` / `np.ndarray[int]` | explicit step indices |
+| `list[float]` / `np.ndarray[float]` | nearest step for each |
+
+The chain inherits the default window from `nr.where(time=...)`; any
+reduction may override with its own `time=` argument.
+
+**Composition**
+
+```python
+m1 = nr.where().component("DISPLACEMENT", 1).abs_peak().gt(0.05)
+m2 = nr.where().magnitude("DISPLACEMENT").peak().gt(0.06)
+
+mask = m1 & m2          # both conditions
+mask = m1 | m2          # either condition
+mask = ~m1              # complement (vs all nodes in `nr`)
+```
+
+Masks must come from the same `NodalResults` instance — combining
+masks across instances raises `ValueError`.
+
+**Predicate escape hatch**
+
+```python
+# Per-row mask — full (node_id, step) index, reduced via `any` per node
+mask = nr.where().predicate(
+    lambda df: df[("DISPLACEMENT", 1)].abs() > df[("DISPLACEMENT", 2)].abs()
+)
+
+# Per-node mask — length == len(nr.info.nodes_ids), used directly
+mask = nr.where().predicate(
+    lambda df: np.array([True, False, True])
+)
+```
+
+For the full worked example see
+[Cookbook 06: node selector + mask pipeline](../cookbook/06-node-selector-and-mask-pipeline.md).
+
+---
+
 ## Plotting
 
 ```python
@@ -236,3 +404,45 @@ you can write `nr.ACCELERATION[1, [14, 25]]` instead of
     options:
       filters: []
       show_root_heading: true
+
+---
+
+## NodeSelector (selector reference)
+
+::: STKO_to_python.nodes.selector.NodeSelector
+    options:
+      show_root_heading: true
+      members_order: source
+
+---
+
+## NodeResultMask (mask reference)
+
+::: STKO_to_python.nodes.result_mask.NodeResultMask
+    options:
+      show_root_heading: true
+      members_order: source
+
+::: STKO_to_python.nodes.result_mask._ResultQuery
+    options:
+      show_root_heading: true
+      members_order: source
+      filters: []
+
+::: STKO_to_python.nodes.result_mask._ComponentQuery
+    options:
+      show_root_heading: true
+      members_order: source
+      filters: []
+
+::: STKO_to_python.nodes.result_mask._MagnitudeQuery
+    options:
+      show_root_heading: true
+      members_order: source
+      filters: []
+
+::: STKO_to_python.nodes.result_mask._ScalarPerNode
+    options:
+      show_root_heading: true
+      members_order: source
+      filters: []

--- a/docs/cookbook/05-selector-and-mask-pipeline.md
+++ b/docs/cookbook/05-selector-and-mask-pipeline.md
@@ -271,3 +271,8 @@ plt.show()
 For the full API reference and the time-spec grammar see
 [ElementResults — Element selectors](../api/element-results.md#element-selectors-pre-fetch)
 and [ElementResults — Result masks](../api/element-results.md#result-masks-post-fetch).
+
+The mirror-image recipe on the node side is documented in
+[Cookbook 06 — node selector + mask pipeline](06-node-selector-and-mask-pipeline.md);
+it covers `at_level`, `attached_to`, and the `magnitude(...)` reduction
+that has no element-side counterpart.

--- a/docs/cookbook/06-node-selector-and-mask-pipeline.md
+++ b/docs/cookbook/06-node-selector-and-mask-pipeline.md
@@ -1,0 +1,539 @@
+# Find the highly-displaced nodes in a region — node selector + mask pipeline
+
+> Locate every node inside a chosen plan region whose absolute peak
+> displacement magnitude over the seismic window exceeds a threshold,
+> then plot the survivors. Demonstrates the chainable
+> `NodeSelector` + `NodeResultMask` pipeline end-to-end. The shape of
+> the recipe is the mirror image of
+> [the element pipeline](05-selector-and-mask-pipeline.md) — the same
+> two layers, the same boolean algebra, the same time-spec grammar.
+
+The pipeline has two layers, executed in this order:
+
+1. **`ds.nodes.select()` — pre-fetch.** Chainable, lazy queries over the
+   cached node index. Decides *which nodes* to read from disk before any
+   HDF5 access. Spatial primitives, selection / id anchors,
+   `attached_to(...)` to bridge to elements, and `&` / `|` / `~`
+   boolean composition.
+2. **`nr.where(...)` — post-fetch.** Builds a per-node boolean
+   `NodeResultMask` from a value condition over a time window. Compose
+   masks with `&` / `|` / `~`; apply with `nr[mask]` to get a fresh
+   `NodalResults` trimmed to the matched nodes.
+
+The example below uses the
+`stko_results_examples/elasticFrame/elasticFrame_mesh_displacementBased_results`
+fixture (the same one cookbook 05 builds on): a planar moment frame
+with 12 nodes at four z-levels (`0, 1000, 2000, 3000` mm) and 11
+`64-DispBeamColumn3d` elements. `MODEL_STAGE[1]` is gravity,
+`MODEL_STAGE[2]` is the pushover.
+
+```python
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+
+from STKO_to_python import MPCODataSet
+
+REPO_ROOT = Path("path/to/STKO_to_python")
+DATASET = (
+    REPO_ROOT / "stko_results_examples" / "elasticFrame"
+    / "elasticFrame_mesh_displacementBased_results"
+)
+PUSHOVER_STAGE = "MODEL_STAGE[2]"
+
+ds = MPCODataSet(str(DATASET), "results", verbose=False)
+```
+
+---
+
+## 1. Pre-fetch: pick nodes by geometry
+
+Build a selector, inspect the resolved id list, then hand it to the
+fetch path. The selector is **lazy** — nothing happens until you call
+`.ids()`, `.df()`, `.mask()`, `.count()`, or pass it through
+`get_nodal_results(selector=…)`.
+
+### 1a. The most common pick: a story floor
+
+```python
+roof = ds.nodes.select().at_level("z", value=3000.0, tol=1e-3)
+print(roof)                  # NodeSelector(AtLevelOp)
+print(roof.count())          # 6 (one node per beam end at z=3000 mm)
+print(roof.ids().tolist())   # int64 ids
+```
+
+`at_level("z", v, tol=…)` is sugar for "every node within `tol` of
+elevation `v`". Use it for support rows (`at_level("z", 0)`), story
+floors, or any axis-aligned slice.
+
+### 1b. Box, sphere, plane, line
+
+```python
+# Inside an axis-aligned box
+in_box = ds.nodes.select().within_box(min=(0, -1, 1000), max=(2500, 1, 2000))
+
+# Within a radius of a point
+near_pt = ds.nodes.select().within_distance((2500, 0, 1500), radius=400.0)
+
+# k nearest nodes to a point (rows sorted by ascending distance)
+nearest8 = ds.nodes.select().nearest_to((2500, 0, 1500), k=8)
+
+# On an arbitrary plane (point + unit normal); axis-aligned form below
+plane_y = ds.nodes.select().on_plane(point=(0, 0, 0), normal=(0, 1, 0), tol=1e-6)
+plane_z = ds.nodes.select().on_plane(z=1500.0, tol=1e-3)   # equivalent of at_level
+
+# Within a tube around a line segment
+along_col = ds.nodes.select().near_line((0, 0, 0), (0, 0, 3000), radius=50.0)
+
+# One-sided coordinate range
+upper_half = ds.nodes.select().coord_in("z", lo=1500.0)   # hi defaults to +∞
+
+print(in_box.count(), near_pt.count(), nearest8.count(),
+      plane_y.count(), along_col.count(), upper_half.count())
+```
+
+`sel.df()` returns the matching rows of the node-index DataFrame
+(`node_id, file_id, index, x, y, z`) — useful for sanity checking.
+
+### 1c. Custom predicate (escape hatch)
+
+```python
+# Anything not covered by a primitive
+upper_left = ds.nodes.select().where(
+    lambda df: (df["x"].to_numpy() < 1500) & (df["z"].to_numpy() > 1500)
+)
+print(upper_left.count())
+```
+
+The callable receives the node-index DataFrame and must return a
+boolean numpy array of equal length.
+
+---
+
+## 2. Anchoring the universe
+
+By default a `NodeSelector` has no anchor — its universe is *every node
+in the model*, which is fine for spatial filtering. **Negation (`~`)**
+needs an explicit universe; otherwise `~sel` would silently complement
+against the whole model. There are two anchors:
+
+### 2a. By selection set (name or id)
+
+```python
+# Named selection set (case-insensitive)
+roof_set = ds.nodes.select().from_selection("Roof")
+
+# Or by selection-set id
+roof_set = ds.nodes.select().from_selection(2)
+
+# Multiple sets unioned
+combined = ds.nodes.select().from_selection(["Roof", "Mezzanine"])
+```
+
+### 2b. By explicit ids
+
+```python
+sel = ds.nodes.select().with_ids([10, 42, 99, 1234])
+```
+
+`from_selection` and `with_ids` can be combined with the spatial
+primitives — anchor first, then narrow:
+
+```python
+# Roof nodes inside a plan box
+roof_in_box = (
+    ds.nodes.select()
+    .from_selection("Roof")
+    .within_box(min=(1000, -1, 0), max=(4000, 1, 4000))
+)
+```
+
+---
+
+## 3. Bridge to elements: `attached_to(...)`
+
+`attached_to(...)` returns "every node that participates in the
+connectivity of these elements" — it closes the loop between node and
+element selectors. Pass either explicit element ids or a live
+`ElementSelector`:
+
+```python
+# Every node attached to the lower-half beams (z ∈ [0, 1500])
+lower_beams = (
+    ds.elements.select()
+    .of_type("DispBeamColumn3d")
+    .centroid_in("z", lo=0.0, hi=1500.0)
+)
+lower_nodes = ds.nodes.select().attached_to(element_selector=lower_beams)
+
+print(f"{lower_beams.count()} beams → {lower_nodes.count()} unique nodes")
+```
+
+In a richer model with mixed element classes (shells, solids, ties)
+the same call works without changes: pass any `ElementSelector`,
+including a boolean combination of element selectors:
+
+```python
+mixed = (
+    ds.elements.select().of_type("ASDShellQ4").centroid_in("z", lo=0, hi=2)
+    | ds.elements.select().of_type("DispBeamColumn3d").centroid_in("z", lo=0, hi=2)
+)
+nodes_in_diaphragm = ds.nodes.select().attached_to(element_selector=mixed)
+```
+
+Or with explicit ids:
+
+```python
+nodes_of_two = ds.nodes.select().attached_to(element_ids=[101, 102])
+```
+
+This is the most powerful primitive when you want to do "everything in
+the diaphragm at level X": pick the elements that make up the
+diaphragm, then derive their node set. The reverse-style operation
+(elements via nodes) is already covered by `ElementSelector.where(fn)`.
+
+---
+
+## 4. Boolean composition
+
+The selector algebra is the same as the element side:
+
+```python
+roof   = ds.nodes.select().from_selection("Roof")
+ground = ds.nodes.select().from_selection("Base")
+
+both    = roof & ground            # intersection (likely empty here)
+either  = roof | ground            # union
+just_roof_corner = roof & ds.nodes.select().within_box(
+    min=(0, -1, 0), max=(0, 1, 4000)
+)
+
+# Negation requires an anchor on the *leaf* selectors
+roof_inner = roof & ~ds.nodes.select().from_selection("Roof").within_box(
+    min=(-1e-6, -1, -1e-6), max=(0,  1, 4000)
+)
+```
+
+The `~` rule is strict: a leaf must declare its universe via
+`.from_selection(...)` or `.with_ids(...)` for negation to be defined.
+An unanchored `~sel` raises a `ValueError` rather than silently
+negating against every node in the model.
+
+`(a & b)`, `(a | b)`, `(~a)` are themselves selectors — they expose
+`.ids()`, `.count()`, `.df()`, `.mask()`. They cannot be re-anchored
+or take new spatial primitives (would be ambiguous as to which leaf
+gets the new op); apply primitives to the leaves, not the combinator.
+
+---
+
+## 5. Fetch results, scoped by the selector
+
+`get_nodal_results(...)` accepts a selector directly — its resolved
+ids are unioned with anything else you pass through `node_ids` /
+`selection_set_*`:
+
+```python
+sel = ds.nodes.select().at_level("z", 3000.0, tol=1e-3)
+
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    selector=sel,
+    model_stage=PUSHOVER_STAGE,
+)
+print(nr)
+# NodalResults(name=..., results=('DISPLACEMENT',), components=('1','2','3'), ...)
+print(nr.df.shape)        # (n_nodes * n_steps, 3)
+print(nr.info.nodes_ids)  # tuple of node ids in the result
+```
+
+You can mix selector-driven and explicit-id selection on the same call;
+the resolved id list is the union:
+
+```python
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    selector=sel,
+    node_ids=[10, 42],                 # add two more
+    selection_set_name="ControlPoints",  # and union a named set
+    model_stage=PUSHOVER_STAGE,
+)
+```
+
+---
+
+## 6. Build a result mask
+
+`nr.where(...)` opens a chain that ends in a `NodeResultMask`. There
+are two shapes for picking the value: **single component** or **vector
+magnitude**.
+
+### 6a. Single component → reduce → threshold
+
+```python
+# Roof X-displacement, absolute peak over the pushover, above 0.1 mm
+mask = (
+    nr.where(time=(0.0, 5.0))                # default time window
+      .component("DISPLACEMENT", 1)          # (result_name, component)
+      .abs_peak()                            # |max| over the window
+      .gt(0.1)
+)
+print(mask)              # NodeResultMask(n_true=…, n_total=…)
+print(mask.ids())        # node ids that pass
+hot = nr[mask]           # fresh NodalResults, trimmed to matched ids
+```
+
+The available reductions on a component:
+
+| Reduction | Meaning |
+|---|---|
+| `at_step(s)` | scalar at one step (int step index) |
+| `at_time(t)` | scalar at the step nearest to time `t` |
+| `peak(time=…)` | signed max over the window |
+| `trough(time=…)` | signed min over the window |
+| `abs_peak(time=…)` | max of `|·|` over the window |
+| `mean(time=…)` | arithmetic mean over the window |
+| `residual(time=…)` | last step in the window |
+| `over_threshold(v, time=…)` | fraction of steps where value > `v` |
+
+The `time=` argument on each reduction overrides the chain default.
+The `time` grammar accepts:
+
+```python
+nr.where(time=None)                          # all steps (the default)
+nr.where(time=42)                            # int step index
+nr.where(time=2.5)                           # nearest step to time 2.5
+nr.where(time=slice(0.0, 10.0))              # half-open time range
+nr.where(time=(0.0, 10.0))                   # tuple form, same meaning
+nr.where(time=[0, 5, 10])                    # explicit step indices
+nr.where(time=[0.0, 1.0, 5.0])               # nearest step per time
+```
+
+### 6b. Vector magnitude
+
+For 3-DOF nodal vectors (`DISPLACEMENT`, `VELOCITY`, `ACCELERATION`),
+`magnitude(...)` reduces to a per-`(node, step)` scalar via
+`sqrt(sum(comp_i**2))` *before* the time-axis reduction. With
+`components=()` (default) every component for the result is used:
+
+```python
+# |U| peak over the full record, > 0.1 mm
+hot_mag = nr.where().magnitude("DISPLACEMENT").peak().gt(0.1)
+print(hot_mag.count())
+
+# Planar magnitude (X-Y only)
+hot_planar = (
+    nr.where()
+    .magnitude("DISPLACEMENT", components=(1, 2))
+    .abs_peak()
+    .ge(0.1)
+)
+```
+
+### 6c. Comparators
+
+The reductions return a `_ScalarPerNode` object — call any of:
+
+```python
+.gt(v)                  # >
+.lt(v)                  # <
+.ge(v)                  # >=
+.le(v)                  # <=
+.between(lo, hi, inclusive=True)
+.outside(lo, hi, inclusive=False)
+.eq(v, atol=0.0)        # equal (with optional absolute tolerance)
+.near(v, atol=…)        # |x - v| <= atol
+```
+
+Each returns a `NodeResultMask` ready for composition or `nr[mask]`.
+
+### 6d. Predicate escape hatch
+
+The full-`(node_id, step)` index is exposed if you need an arbitrary
+shape of comparison. The callable is reduced via `any` per node:
+
+```python
+# Any step where Ux beats Uy — for orbit-style screening
+mask = nr.where().predicate(
+    lambda df: df[("DISPLACEMENT", 1)].abs() > df[("DISPLACEMENT", 2)].abs()
+)
+print(mask.count())
+```
+
+If the callable returns a per-node bool array (length =
+`len(nr.info.nodes_ids)`), it's used as-is; if it returns a per-row
+array (length = `len(nr.df)`), it's `groupby("node_id").any()`-reduced.
+
+---
+
+## 7. Compose: selector AND mask in one shot
+
+Spatial filter (Layer A) and value filter (Layer B) compose naturally
+because they live in different objects: the selector produces ids that
+go into the fetch; the mask produces a boolean over the fetched ids
+that goes into `nr[...]`.
+
+```python
+# Story-floor X-displacement above 0.1 mm AND |U| above 0.12 mm
+story = ds.nodes.select().at_level("z", 3000.0, tol=1e-3)
+
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    selector=story,
+    model_stage=PUSHOVER_STAGE,
+)
+
+m_x   = nr.where().component("DISPLACEMENT", 1).abs_peak().gt(0.10)
+m_mag = nr.where().magnitude("DISPLACEMENT").peak().gt(0.12)
+
+both    = m_x & m_mag
+either  = m_x | m_mag
+not_x   = ~m_x
+
+hot = nr[both]
+print(f"{hot.info.nodes_ids} pass both criteria")
+```
+
+`hot` is a fully-formed `NodalResults` — pickle-able, plottable, and
+every aggregation (`drift`, `interstory_drift_envelope`, `orbit`, …)
+works on it.
+
+---
+
+## 8. Tune thresholds from the data
+
+Every reduction is exposed as a `pd.Series` so you can pick a
+threshold informed by the distribution rather than guessing:
+
+```python
+# All roof nodes; what does the |U| peak distribution look like?
+roof = ds.nodes.select().at_level("z", 3000.0, tol=1e-3)
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT", selector=roof, model_stage=PUSHOVER_STAGE
+)
+
+peaks = nr.where().magnitude("DISPLACEMENT").peak().values()
+print(peaks.describe())          # min/max/mean/std per node
+threshold = float(peaks.quantile(0.75))   # top 25 %
+
+mask = nr.where().magnitude("DISPLACEMENT").peak().gt(threshold)
+hot = nr[mask]
+```
+
+`over_threshold(v)` returns the *fraction* of steps in the window where
+`value > v`, so chain a comparator to find nodes that *spend* a
+significant share of the window above some level — useful for shake-
+table or buffeting analyses where the all-time peak is less indicative
+than sustained excursions:
+
+```python
+mask = (
+    nr.where()
+      .component("DISPLACEMENT", 1)
+      .over_threshold(0.05)     # fraction of steps with Ux > 0.05 mm
+      .gt(0.25)                 # at least 25 % of the window
+)
+```
+
+---
+
+## 9. Plot the survivors
+
+Plotting helpers carry over verbatim — `hot` behaves exactly like the
+original `nr`, just with fewer rows:
+
+```python
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(7, 4))
+for nid in hot.info.nodes_ids:
+    ts = hot.fetch("DISPLACEMENT", component=1, node_ids=[nid])
+    ax.plot(hot.time, ts.to_numpy(), lw=0.7, label=str(nid))
+ax.axhline(0.1, color="k", lw=0.7, ls="--")
+ax.set_xlabel("time (s)")
+ax.set_ylabel("$U_x$ (mm)")
+ax.set_title(f"{len(hot.info.nodes_ids)} roof nodes above the threshold")
+ax.legend(fontsize="x-small", ncol=2)
+plt.show()
+```
+
+---
+
+## 10. Complete worked example
+
+The recipe end-to-end on `QuadFrame_results`:
+
+```python
+from pathlib import Path
+import numpy as np
+from STKO_to_python import MPCODataSet
+
+ds = MPCODataSet(
+    str(Path("stko_results_examples/elasticFrame"
+             "/elasticFrame_mesh_displacementBased_results")),
+    "results",
+)
+
+# --- Layer A: pre-fetch selection -------------------------------------
+# Roof nodes inside a central plan band (skip the outermost columns).
+roof_band = (
+    ds.nodes.select()
+      .at_level("z", 3000.0, tol=1e-3)
+      .coord_in("x", lo=500.0, hi=4500.0)
+)
+print(f"{roof_band.count()} candidate nodes")
+
+# --- Read just those nodes -------------------------------------------
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",
+    selector=roof_band,
+    model_stage="MODEL_STAGE[2]",
+)
+
+# --- Layer B: value-driven trimming ----------------------------------
+# Adaptive threshold: top 25 % of the |U| peak distribution
+peaks = nr.where().magnitude("DISPLACEMENT").peak().values()
+threshold = float(peaks.quantile(0.75))
+
+# AND together: peak |U| above the adaptive threshold AND positive Ux peak
+mask = (
+    nr.where().magnitude("DISPLACEMENT").peak().gt(threshold)
+    & nr.where().component("DISPLACEMENT", 1).peak().gt(0.0)
+)
+
+hot = nr[mask]
+print(f"{len(hot.info.nodes_ids)} nodes match")
+
+# --- Persist the trimmed result --------------------------------------
+hot.save_pickle("hot_roof_nodes.pkl.gz")
+```
+
+---
+
+## Cheat sheet
+
+| Goal | One-liner |
+|---|---|
+| All nodes in the model | `ds.nodes.select().ids()` (no anchor needed) |
+| Story floor at `z` | `ds.nodes.select().at_level("z", value=3000.0).ids()` |
+| In a 3-D AABB | `ds.nodes.select().within_box(min=(0,0,0), max=(10,10,10)).ids()` |
+| Within radius of a point | `ds.nodes.select().within_distance((5,5,5), r=2.0).ids()` |
+| k nearest to a point | `ds.nodes.select().nearest_to((5,5,5), k=10).ids()` |
+| On a plane | `ds.nodes.select().on_plane(z=2.5).ids()` (or `point=, normal=`) |
+| Inside a slab | `ds.nodes.select().coord_in("z", lo=2.0, hi=4.0).ids()` |
+| Tube around a line | `ds.nodes.select().near_line((0,0,0),(0,0,3),radius=0.1).ids()` |
+| In named selection set | `ds.nodes.select().from_selection("Roof").ids()` |
+| Nodes attached to elements | `ds.nodes.select().attached_to(element_selector=esel).ids()` |
+| Custom predicate | `ds.nodes.select().where(lambda df: df["x"] > 5).ids()` |
+| Combine | `(a & b).ids()`, `(a | b).ids()`, `(~a).ids()` |
+| Threshold abs-peak component | `nr.where().component(rn, c).abs_peak().gt(v)` |
+| Threshold |vector| peak | `nr.where().magnitude(rn).peak().gt(v)` |
+| Planar magnitude | `nr.where().magnitude(rn, components=(1,2)).peak().gt(v)` |
+| At a step | `nr.where().component(rn, c).at_step(s).between(lo, hi)` |
+| Over a time window | `nr.where(time=(t0,t1)).component(rn, c).peak().gt(v)` |
+| Sustained excursion | `nr.where().component(rn, c).over_threshold(v).gt(0.25)` |
+| Composing masks | `m1 & m2`, `m1 | m2`, `~m1` |
+| Apply | `nr[mask]` → fresh `NodalResults` |
+
+For the full API reference and the time-spec grammar see
+[NodalResults — Node selectors](../api/nodal-results.md#node-selectors-pre-fetch)
+and [NodalResults — Result masks](../api/nodal-results.md#result-masks-post-fetch).

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -15,10 +15,12 @@ workflows the library is built around. Each tutorial:
 | 2 | [Stress contour on a shear wall](02-stress-contour-on-a-wall.md) | `elasticFrame/QuadFrame_results` | `203-ASDShellQ4` |
 | 3 | [Peak moment per beam over a pushover](03-peak-moment-per-beam.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | `64-DispBeamColumn3d` |
 | 4 | [Volume integral of σ_11 over a brick subdomain](04-volume-integral-on-bricks.md) | `solid_partition_example` (gitignored — skip-if-absent) | `56-Brick` |
-| 5 | [Selector + mask pipeline](05-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | `64-DispBeamColumn3d` |
+| 5 | [Element selector + mask pipeline](05-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | `64-DispBeamColumn3d` |
+| 6 | [Node selector + mask pipeline](06-node-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | (node-side; any element family) |
 
 For broader tours of the API on a single fixture see the
 [Examples](../examples/usage_tour.md) section. For the reference
 documentation behind the calls used here see
-[ElementResults](../ElementResults.md) and
+[ElementResults](../ElementResults.md),
+[NodalResults](../NodalResults.md), and
 [Canonical names](../api/canonical-names.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,17 @@ ds.plot.xy(
   for the element result container, including `physical_coords()`,
   `integrate_canonical()`, time-series statistics, and the new
   `plot.history()` / `plot.diagram()` / `plot.scatter()` plotters.
+- **[NodalResults reference](api/nodal-results.md)** — full API for
+  the nodal result container, including `ds.nodes.select()`
+  (chainable spatial picks, `attached_to(...)` element bridge) and
+  `nr.where(...)` (component / vector-magnitude masks with
+  `& / | / ~` composition).
+- **Cookbook —**
+  [Element selector + mask pipeline](cookbook/05-selector-and-mask-pipeline.md)
+  and
+  [Node selector + mask pipeline](cookbook/06-node-selector-and-mask-pipeline.md)
+  are the recipe-style introductions to the lazy-query / value-mask
+  workflow on each side.
 - **[Architecture](architecture.md)** — the layered design, what lives
   where, pickle compatibility, and the per-phase refactor history.
 - **[API reference](api/index.md)** — class-by-class docs generated

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,8 @@ nav:
       - Stress contour on a shear wall: cookbook/02-stress-contour-on-a-wall.md
       - Peak moment per beam over a pushover: cookbook/03-peak-moment-per-beam.md
       - Volume integral on bricks: cookbook/04-volume-integral-on-bricks.md
+      - Element selector + mask pipeline: cookbook/05-selector-and-mask-pipeline.md
+      - Node selector + mask pipeline: cookbook/06-node-selector-and-mask-pipeline.md
   - Examples:
       - Usage tour: examples/usage_tour.md
       - Elastic frame: examples/elastic_frame.md

--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -3,8 +3,12 @@ from .core.dataset import MPCODataSet
 from .io.hdf5_utils import HDF5Utils
 
 from .nodes.node_manager import NodeManager
+from .nodes.selector import NodeSelector
+from .nodes.result_mask import NodeResultMask
 from .elements.element_manager import ElementManager
 from .elements.element_results import ElementResults
+from .elements.selector import ElementSelector
+from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
 from .model.cdata_reader import CDataReader
 
@@ -39,6 +43,10 @@ __all__ = [
     "Nodes",
     "Elements",
     "ElementResults",
+    "ElementSelector",
+    "ResultMask",
+    "NodeSelector",
+    "NodeResultMask",
     "Plot",
     "Aggregator",
     "StrOp",

--- a/src/STKO_to_python/nodes/__init__.py
+++ b/src/STKO_to_python/nodes/__init__.py
@@ -1,4 +1,6 @@
 from .node_manager import NodeManager
+from .result_mask import NodeResultMask
+from .selector import NodeSelector
 
 # Back-compat alias preserved on the package surface (quiet); the deep
 # path ``STKO_to_python.nodes.nodes.Nodes`` emits a
@@ -7,5 +9,7 @@ Nodes = NodeManager
 
 __all__ = [
     'NodeManager',
+    'NodeResultMask',
+    'NodeSelector',
     'Nodes',
 ]

--- a/src/STKO_to_python/nodes/node_manager.py
+++ b/src/STKO_to_python/nodes/node_manager.py
@@ -11,6 +11,7 @@ import h5py
 if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
     from ..results.nodal_results_dataclass import NodalResults
+    from .selector import NodeSelector
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,33 @@ class NodeManager:
         self._get_all_nodes_ids()
         return self._node_index_df  # type: ignore
 
+    # ------------------------------------------------------------------
+    # Selector entry point
+    # ------------------------------------------------------------------
+
+    def select(self) -> "NodeSelector":
+        """Build a lazy, chainable node-id query.
+
+        Returns a fresh :class:`~STKO_to_python.nodes.selector.NodeSelector`
+        with no anchor; chain ``from_selection`` / ``with_ids`` to set
+        an explicit universe (required for ``~``), or apply spatial
+        primitives (``within_box``, ``nearest_to``, ``on_plane``,
+        ``near_line``, ``within_distance``, ``coord_in``, ``at_level``,
+        ``attached_to``) and a ``where(fn)`` predicate against the full
+        node set. Combine with ``&`` / ``|`` / ``~``.
+
+        Examples
+        --------
+        >>> ids = (dataset.nodes.select()
+        ...        .from_selection("Roof")
+        ...        .within_box(min=(0, 0, 28), max=(50, 50, 32))
+        ...        .nearest_to((25, 25, 30), k=8)
+        ...        .ids())
+        """
+        from .selector import NodeSelector
+
+        return NodeSelector(self)
+
     @staticmethod
     def _normalize_stages(stages, all_stages) -> Tuple[str, ...]:
         if stages is None:
@@ -270,11 +298,40 @@ class NodeManager:
         node_ids: Union[int, Sequence[int], Sequence[Sequence[int]], np.ndarray, None] = None,
         selection_set_id: Union[int, Sequence[int], None] = None,
         selection_set_name: Union[str, Sequence[str], None] = None,
+        selector: Optional["NodeSelector"] = None,
     ) -> "NodalResults":
         """Route through the dataset-owned query engine so every call
         benefits from the LRU cache. Thin wrapper; the actual read lives
         in :meth:`_fetch_nodal_results_uncached`.
+
+        Parameters
+        ----------
+        selector : NodeSelector, optional
+            Resolved id list from a chainable selector
+            (:meth:`NodeManager.select`). When provided, its ids are
+            merged with ``node_ids`` (union semantics).
         """
+        if selector is not None:
+            from .selector import NodeSelector
+
+            if not isinstance(selector, NodeSelector):
+                raise TypeError(
+                    "selector must be a NodeSelector instance "
+                    f"(got {type(selector).__name__})."
+                )
+            sel_ids = selector.ids()
+            if node_ids is None:
+                node_ids = sel_ids
+            else:
+                node_ids = np.unique(
+                    np.concatenate(
+                        [
+                            _flatten_node_ids(node_ids),
+                            sel_ids,
+                        ]
+                    )
+                )
+
         engine = getattr(self.dataset, "_nodal_query_engine", None)
         if engine is not None:
             return engine.fetch(

--- a/src/STKO_to_python/nodes/result_mask.py
+++ b/src/STKO_to_python/nodes/result_mask.py
@@ -1,0 +1,598 @@
+"""NodeResultMask — threshold / time-window filters on :class:`NodalResults`.
+
+Mirrors :class:`STKO_to_python.elements.result_mask.ResultMask` for the
+nodal side. The selector layer (:class:`NodeSelector`) decides *which
+nodes* before any HDF5 read; this layer decides *which of the fetched
+nodes satisfy a value condition*. Output is a per-node boolean mask
+that can be combined with ``&`` / ``|`` / ``~`` and applied to the
+parent ``NodalResults`` via ``nr[mask]``.
+
+Differences from the element side
+---------------------------------
+* :class:`NodalResults` uses a ``(result, component)`` :class:`MultiIndex`
+  on its columns. Pick a column with a single call:
+  ``nr.where(...).component("DISPLACEMENT", 1)``.
+* :meth:`_ResultQuery.magnitude` reduces a vector
+  (``sqrt(sum(comp_i**2))``) per ``(node_id, step)`` before time-axis
+  reductions — the most common pick for "filter nodes by ``|U|`` peak".
+
+The chain shape is::
+
+    nr.where(time=...)                      # default time window (optional)
+      .component("DISPLACEMENT", 1)         # or .magnitude("DISPLACEMENT")
+      .abs_peak(time=...)                   # reduction over time → scalar/node
+      .gt(0.05)                             # comparator → NodeResultMask
+"""
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import numpy as np
+import pandas as pd
+
+# Time-grammar resolver is shared with the element side. Importing
+# preserves a single source of truth for the spec semantics.
+from ..elements.result_mask import resolve_step_indices
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..results.nodal_results_dataclass import NodalResults
+
+
+TimeSpec = Union[
+    None,
+    int,
+    float,
+    slice,
+    Tuple[float, float],
+    Sequence[int],
+    Sequence[float],
+    np.ndarray,
+]
+
+
+# Sentinel for "no override; use the chain's default time window".
+_DEFAULT: Any = object()
+
+
+# ---------------------------------------------------------------------- #
+# NodeResultMask                                                          #
+# ---------------------------------------------------------------------- #
+
+class NodeResultMask:
+    """Per-node boolean mask, composable via ``& / | / ~``.
+
+    Created by the comparator step of a ``nr.where().<...>`` chain or
+    by the ``predicate(fn)`` escape hatch. Apply via ``nr[mask]`` (a
+    fresh :class:`NodalResults`) or extract the matching ids via
+    :meth:`ids`.
+    """
+
+    __slots__ = ("_nr", "_series")
+
+    def __init__(self, nr: "NodalResults", series: pd.Series) -> None:
+        if not isinstance(series, pd.Series):
+            raise TypeError("NodeResultMask: series must be a pandas Series.")
+        s = series.astype("boolean").fillna(False).astype(bool)
+        canonical_idx = pd.Index(
+            np.asarray(_node_ids_from_results(nr), dtype=np.int64)
+        )
+        s = s.reindex(canonical_idx, fill_value=False)
+        s.name = "mask"
+        s.index.name = "node_id"
+        self._nr = nr
+        self._series = s
+
+    # ------------------------------------------------------------------ #
+    # Outputs                                                            #
+    # ------------------------------------------------------------------ #
+    def mask(self) -> pd.Series:
+        """Boolean Series indexed by ``node_id``."""
+        return self._series.copy()
+
+    def ids(self) -> np.ndarray:
+        """``int64`` array of node IDs where the mask is ``True``."""
+        return self._series.index[self._series].to_numpy(dtype=np.int64)
+
+    def count(self) -> int:
+        """Number of nodes where the mask is ``True``."""
+        return int(self._series.sum())
+
+    def apply(self) -> "NodalResults":
+        """Return a fresh :class:`NodalResults` trimmed to matched ids."""
+        return _subset_nr(self._nr, self.ids())
+
+    # ------------------------------------------------------------------ #
+    # Boolean composition                                                 #
+    # ------------------------------------------------------------------ #
+    def __and__(self, other: "NodeResultMask") -> "NodeResultMask":
+        if not isinstance(other, NodeResultMask):
+            return NotImplemented  # type: ignore[return-value]
+        if self._nr is not other._nr:
+            raise ValueError(
+                "Cannot AND masks from different NodalResults instances."
+            )
+        return NodeResultMask(self._nr, self._series & other._series)
+
+    def __or__(self, other: "NodeResultMask") -> "NodeResultMask":
+        if not isinstance(other, NodeResultMask):
+            return NotImplemented  # type: ignore[return-value]
+        if self._nr is not other._nr:
+            raise ValueError(
+                "Cannot OR masks from different NodalResults instances."
+            )
+        return NodeResultMask(self._nr, self._series | other._series)
+
+    def __invert__(self) -> "NodeResultMask":
+        return NodeResultMask(self._nr, ~self._series)
+
+    def __repr__(self) -> str:
+        return (
+            f"NodeResultMask(n_true={self.count()}, "
+            f"n_total={len(self._series)})"
+        )
+
+    def __len__(self) -> int:
+        return int(self.count())
+
+
+# ---------------------------------------------------------------------- #
+# _ScalarPerNode — reduced values, exposes comparators                   #
+# ---------------------------------------------------------------------- #
+
+class _ScalarPerNode:
+    """One float per node, ready for a comparator step."""
+
+    __slots__ = ("_nr", "_values")
+
+    def __init__(self, nr: "NodalResults", values: pd.Series) -> None:
+        self._nr = nr
+        canonical_idx = pd.Index(
+            np.asarray(_node_ids_from_results(nr), dtype=np.int64)
+        )
+        self._values = values.reindex(canonical_idx)
+        self._values.index.name = "node_id"
+
+    def values(self) -> pd.Series:
+        """The underlying scalar Series (indexed by ``node_id``)."""
+        return self._values.copy()
+
+    def gt(self, value: float) -> NodeResultMask:
+        return NodeResultMask(self._nr, self._values > value)
+
+    def lt(self, value: float) -> NodeResultMask:
+        return NodeResultMask(self._nr, self._values < value)
+
+    def ge(self, value: float) -> NodeResultMask:
+        return NodeResultMask(self._nr, self._values >= value)
+
+    def le(self, value: float) -> NodeResultMask:
+        return NodeResultMask(self._nr, self._values <= value)
+
+    def between(self, lo: float, hi: float, *, inclusive: bool = True) -> NodeResultMask:
+        if inclusive:
+            s = (self._values >= lo) & (self._values <= hi)
+        else:
+            s = (self._values > lo) & (self._values < hi)
+        return NodeResultMask(self._nr, s)
+
+    def outside(self, lo: float, hi: float, *, inclusive: bool = False) -> NodeResultMask:
+        if inclusive:
+            s = (self._values <= lo) | (self._values >= hi)
+        else:
+            s = (self._values < lo) | (self._values > hi)
+        return NodeResultMask(self._nr, s)
+
+    def eq(self, value: float, *, atol: float = 0.0) -> NodeResultMask:
+        if atol == 0.0:
+            return NodeResultMask(self._nr, self._values == value)
+        return self.near(value, atol=atol)
+
+    def near(self, value: float, *, atol: float) -> NodeResultMask:
+        return NodeResultMask(self._nr, (self._values - value).abs() <= atol)
+
+    def __repr__(self) -> str:
+        return f"_ScalarPerNode(n={len(self._values)})"
+
+
+# ---------------------------------------------------------------------- #
+# _PerStepSeries — Series indexed by (node_id, step), exposes reductions #
+# ---------------------------------------------------------------------- #
+
+class _PerStepSeries:
+    """Backbone for both :class:`_ComponentQuery` and :class:`_MagnitudeQuery`.
+
+    Holds a ``(node_id, step)``-indexed Series of values plus the chain's
+    default time window, and implements the time-axis reductions and
+    ``over_threshold`` / ``predicate`` paths.
+    """
+
+    __slots__ = ("_nr", "_series", "_default_time", "_label")
+
+    def __init__(
+        self,
+        nr: "NodalResults",
+        series: pd.Series,
+        default_time: TimeSpec,
+        label: str,
+    ) -> None:
+        self._nr = nr
+        self._series = series
+        self._default_time = default_time
+        self._label = label
+
+    # ------------------------------------------------------------------ #
+    # Reductions                                                          #
+    # ------------------------------------------------------------------ #
+    def at_step(self, step: int) -> _ScalarPerNode:
+        s = self._slice_steps(np.asarray([int(step)], dtype=np.int64))
+        return _ScalarPerNode(self._nr, s.droplevel("step"))
+
+    def at_time(self, t: float) -> _ScalarPerNode:
+        idx = resolve_step_indices(float(t), self._time_arr())
+        if idx.size == 0:
+            raise ValueError(f"at_time({t}): no step found.")
+        s = self._slice_steps(np.asarray([int(idx[0])], dtype=np.int64))
+        return _ScalarPerNode(self._nr, s.droplevel("step"))
+
+    def peak(self, *, time: Any = _DEFAULT) -> _ScalarPerNode:
+        return self._reduce_over_time(time, "max")
+
+    def trough(self, *, time: Any = _DEFAULT) -> _ScalarPerNode:
+        return self._reduce_over_time(time, "min")
+
+    def abs_peak(self, *, time: Any = _DEFAULT) -> _ScalarPerNode:
+        return self._reduce_over_time(time, "abs_max")
+
+    def mean(self, *, time: Any = _DEFAULT) -> _ScalarPerNode:
+        return self._reduce_over_time(time, "mean")
+
+    def residual(self, *, time: Any = _DEFAULT) -> _ScalarPerNode:
+        return self._reduce_over_time(time, "last")
+
+    def over_threshold(
+        self,
+        value: float,
+        *,
+        time: Any = _DEFAULT,
+    ) -> _ScalarPerNode:
+        """Fraction of steps in the window where value > ``threshold``.
+
+        Chain a comparator (e.g. ``.gt(0.1)``) to mask nodes that
+        spend at least 10% of the window above the threshold.
+        """
+        eff = self._effective_time(time)
+        steps = resolve_step_indices(eff, self._time_arr())
+        if steps.size == 0:
+            raise ValueError("over_threshold: empty step window.")
+        sub = self._slice_steps(steps)
+        ser = (sub > value).groupby(level="node_id").mean()
+        return _ScalarPerNode(self._nr, ser)
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                          #
+    # ------------------------------------------------------------------ #
+    def _time_arr(self) -> np.ndarray:
+        t = self._nr.time
+        if not isinstance(t, np.ndarray):
+            t = np.asarray(t, dtype=np.float64)
+        return t
+
+    def _effective_time(self, time: Any) -> TimeSpec:
+        return self._default_time if time is _DEFAULT else time
+
+    def _slice_steps(self, steps: np.ndarray) -> pd.Series:
+        lvl = self._series.index.get_level_values("step")
+        return self._series.loc[lvl.isin(steps)]
+
+    def _reduce_over_time(self, time: TimeSpec, op: str) -> _ScalarPerNode:
+        eff = self._effective_time(time)
+        steps = resolve_step_indices(eff, self._time_arr())
+        if steps.size == 0:
+            raise ValueError(f"{op}: empty step window.")
+        sub = self._slice_steps(steps)
+        if op == "max":
+            ser = sub.groupby(level="node_id").max()
+        elif op == "min":
+            ser = sub.groupby(level="node_id").min()
+        elif op == "abs_max":
+            ser = sub.abs().groupby(level="node_id").max()
+        elif op == "mean":
+            ser = sub.groupby(level="node_id").mean()
+        elif op == "last":
+            sorted_ser = (
+                sub.reset_index()
+                .sort_values("step")
+                .set_index(["node_id", "step"])
+                .iloc[:, 0]
+            )
+            ser = sorted_ser.groupby(level="node_id").last()
+        else:
+            raise ValueError(f"unknown reduction {op!r}")
+        return _ScalarPerNode(self._nr, ser)
+
+    def __repr__(self) -> str:
+        return f"_PerStepSeries({self._label!r})"
+
+
+class _ComponentQuery(_PerStepSeries):
+    """One ``(result, component)`` column from a :class:`NodalResults`."""
+
+    @classmethod
+    def from_column(
+        cls,
+        nr: "NodalResults",
+        result_name: str,
+        component: Any,
+        default_time: TimeSpec,
+    ) -> "_ComponentQuery":
+        col = _resolve_component_column(nr, result_name, component)
+        ser = nr.df[col]
+        if isinstance(ser, pd.DataFrame):
+            # Defensive: should not happen since column tuple is exact.
+            ser = ser.iloc[:, 0]
+        ser.name = f"{result_name}|{component}"
+        label = f"{result_name}|{component}"
+        return cls(nr, ser, default_time, label)
+
+
+class _MagnitudeQuery(_PerStepSeries):
+    """Vector-magnitude reduction over a result's components.
+
+    Produces one scalar per ``(node_id, step)`` via
+    ``sqrt(sum(comp_i**2))``, which then flows through the same
+    time-axis reductions as :class:`_ComponentQuery`.
+    """
+
+    @classmethod
+    def from_components(
+        cls,
+        nr: "NodalResults",
+        result_name: str,
+        components: Sequence[Any],
+        default_time: TimeSpec,
+    ) -> "_MagnitudeQuery":
+        # Empty `components` means "use every component for this result"
+        # — the common 3-DOF |U| / |V| / |A| case.
+        if not components:
+            cols = _list_components_for_result(nr, result_name)
+            if not cols:
+                raise ValueError(
+                    f"magnitude: result {result_name!r} has no components."
+                )
+        else:
+            cols = [
+                _resolve_component_column(nr, result_name, c) for c in components
+            ]
+        sub = nr.df[cols]
+        # Square + sum across columns, then sqrt — preserves the
+        # (node_id, step) MultiIndex on the resulting Series.
+        sq = sub.pow(2).sum(axis=1)
+        mag = np.sqrt(sq)
+        mag.name = f"|{result_name}|"
+        label = f"|{result_name}|"
+        return cls(nr, mag, default_time, label)
+
+
+# ---------------------------------------------------------------------- #
+# _ResultQuery — nr.where() entry point                                   #
+# ---------------------------------------------------------------------- #
+
+class _ResultQuery:
+    """Entry point produced by :meth:`NodalResults.where`."""
+
+    __slots__ = ("_nr", "_default_time")
+
+    def __init__(self, nr: "NodalResults", default_time: TimeSpec) -> None:
+        self._nr = nr
+        self._default_time = default_time
+
+    def component(self, result_name: str, component: Any) -> _ComponentQuery:
+        """Pick one ``(result, component)`` column (e.g. ``("DISPLACEMENT", 1)``)."""
+        return _ComponentQuery.from_column(
+            self._nr, str(result_name), component, self._default_time
+        )
+
+    def magnitude(
+        self,
+        result_name: str,
+        *,
+        components: Sequence[Any] = (),
+    ) -> _MagnitudeQuery:
+        """Pick the vector magnitude of a result over given components.
+
+        With ``components=()`` (default) every component for the result
+        is used — the natural choice for 3-DOF nodal vectors like
+        ``DISPLACEMENT`` / ``VELOCITY`` / ``ACCELERATION``. Pass an
+        explicit list to restrict to a subset (e.g. ``components=(1, 2)``
+        for a planar magnitude).
+        """
+        return _MagnitudeQuery.from_components(
+            self._nr, str(result_name), tuple(components), self._default_time
+        )
+
+    def predicate(
+        self,
+        fn: Callable[[pd.DataFrame], Union[pd.Series, np.ndarray]],
+    ) -> NodeResultMask:
+        """Escape hatch — ``fn`` receives the parent ``df`` and must
+        return a bool mask aligned with ``node_id`` (length =
+        ``n_nodes``) or aligned with the full ``(node_id, step)``
+        index (in which case it is reduced via ``any``).
+        """
+        df = self._nr.df
+        node_ids = _node_ids_from_results(self._nr)
+        n_nodes = len(node_ids)
+        out = fn(df)
+        arr = np.asarray(out)
+        if arr.shape == (n_nodes,):
+            ser = pd.Series(
+                arr.astype(bool),
+                index=pd.Index(np.asarray(node_ids, dtype=np.int64), name="node_id"),
+            )
+        elif arr.shape == (len(df),):
+            tmp = pd.Series(arr.astype(bool), index=df.index)
+            ser = tmp.groupby(level="node_id").any()
+        else:
+            raise ValueError(
+                f"predicate(fn): returned shape {arr.shape}; expected "
+                f"({n_nodes},) or ({len(df)},)."
+            )
+        return NodeResultMask(self._nr, ser)
+
+    def __repr__(self) -> str:
+        return f"_ResultQuery(default_time={self._default_time!r})"
+
+
+# ---------------------------------------------------------------------- #
+# Helpers                                                                #
+# ---------------------------------------------------------------------- #
+
+def _node_ids_from_results(nr: "NodalResults") -> Tuple[int, ...]:
+    """Pull the canonical sorted node-id tuple from a ``NodalResults``."""
+    info = getattr(nr, "info", None)
+    nids = getattr(info, "nodes_ids", None) if info is not None else None
+    if nids:
+        return tuple(int(x) for x in nids)
+    # Fallback: derive from the dataframe index.
+    idx = nr.df.index
+    if isinstance(idx, pd.MultiIndex):
+        names = list(idx.names) if idx.names else []
+        if "node_id" in names:
+            level = names.index("node_id")
+        elif idx.nlevels == 2:
+            level = 0
+        elif idx.nlevels == 3:
+            level = 1
+        else:
+            raise ValueError(
+                "NodalResults.df index has unexpected nlevels "
+                f"{idx.nlevels}; cannot infer node_id level."
+            )
+        vals = idx.get_level_values(level).unique().to_numpy(dtype=np.int64)
+        vals.sort()
+        return tuple(int(x) for x in vals)
+    return ()
+
+
+def _resolve_component_column(
+    nr: "NodalResults",
+    result_name: str,
+    component: Any,
+) -> Tuple[str, Any]:
+    """Resolve ``(result_name, component)`` to an exact column tuple.
+
+    Accepts a ``component`` that is either an ``int`` (1-based index as
+    stored in the column MultiIndex) or any value comparing equal to
+    one of the stored component labels via ``str``-coercion.
+    """
+    cols = nr.df.columns
+    if not isinstance(cols, pd.MultiIndex):
+        raise TypeError(
+            "component(...): NodalResults has single-level columns; "
+            "the (result, component) two-arg form requires a MultiIndex. "
+            "Use predicate(fn) or build the mask from .ids() directly."
+        )
+    rname = str(result_name)
+    direct = (rname, component)
+    if direct in cols:
+        return direct
+    # Try str-coerced match
+    comp_str = str(component)
+    for c0, c1 in cols:
+        if str(c0) == rname and str(c1) == comp_str:
+            return (c0, c1)
+    available = sorted(
+        {str(c1) for (c0, c1) in cols if str(c0) == rname}
+    )
+    raise ValueError(
+        f"component {component!r} not found for result {result_name!r}. "
+        f"Available components: {available}"
+    )
+
+
+def _list_components_for_result(
+    nr: "NodalResults",
+    result_name: str,
+) -> list[Tuple[str, Any]]:
+    """Return every column tuple under a given result name."""
+    cols = nr.df.columns
+    if not isinstance(cols, pd.MultiIndex):
+        return []
+    rname = str(result_name)
+    return [(c0, c1) for (c0, c1) in cols if str(c0) == rname]
+
+
+# ---------------------------------------------------------------------- #
+# Subsetting helper — fresh NodalResults from a mask                      #
+# ---------------------------------------------------------------------- #
+
+def _subset_nr(nr: "NodalResults", ids: np.ndarray) -> "NodalResults":
+    """Build a fresh :class:`NodalResults` keeping only ``ids``.
+
+    Trims ``df``, ``info.nodes_ids``, and ``info.nodes_info`` while
+    preserving every other field (time, stage metadata, plot settings,
+    selection sets, analysis time, size).
+    """
+    from ..results.nodal_results_dataclass import NodalResults
+
+    keep = np.asarray(sorted(int(x) for x in ids), dtype=np.int64)
+
+    idx = nr.df.index
+    if not isinstance(idx, pd.MultiIndex):
+        raise TypeError(
+            "NodalResults.df must have a MultiIndex with a 'node_id' level."
+        )
+    names = list(idx.names) if idx.names else []
+    if "node_id" in names:
+        node_level = names.index("node_id")
+    elif idx.nlevels == 2:
+        node_level = 0
+    elif idx.nlevels == 3:
+        node_level = 1
+    else:
+        raise ValueError(
+            f"NodalResults.df index has unexpected nlevels {idx.nlevels}."
+        )
+
+    if keep.size == 0:
+        new_df = nr.df.iloc[0:0]
+    else:
+        lvl = idx.get_level_values(node_level)
+        new_df = nr.df.loc[lvl.isin(keep)]
+
+    info = nr.info
+    nodes_info_df = getattr(info, "nodes_info", None)
+    if isinstance(nodes_info_df, pd.DataFrame) and not nodes_info_df.empty:
+        # ``nodes_info`` is indexed by node_id (set up in
+        # ``_fetch_nodal_results_uncached``), so a label-based loc is
+        # safe; missing ids would raise but we filter to the kept set.
+        common = nodes_info_df.index.intersection(keep)
+        new_nodes_info = nodes_info_df.loc[common]
+    else:
+        new_nodes_info = nodes_info_df
+
+    return NodalResults(
+        df=new_df,
+        time=nr.time,
+        name=nr.name,
+        nodes_ids=tuple(int(x) for x in keep),
+        nodes_info=new_nodes_info,
+        results_components=tuple(info.results_components or ()),
+        model_stages=tuple(info.model_stages or ()),
+        stage_step_ranges=dict(info.stage_step_ranges or {}),
+        plot_settings=nr.plot_settings,
+        selection_set=info.selection_set,
+        analysis_time=info.analysis_time,
+        size=info.size,
+    )
+
+
+__all__ = ["NodeResultMask"]

--- a/src/STKO_to_python/nodes/selector.py
+++ b/src/STKO_to_python/nodes/selector.py
@@ -1,0 +1,778 @@
+"""NodeSelector — lazy, chainable, composable node-id queries.
+
+Mirrors :class:`STKO_to_python.elements.selector.ElementSelector` for
+nodes. Resolution to an id array is deferred until :meth:`ids` /
+:meth:`mask` / :meth:`df` / :meth:`count` is called.
+
+The composition primitives are:
+
+* **Chain** — ``sel.from_selection(...).within_box(...).nearest_to(...)`` —
+  each call AND-narrows the candidate set in source order.
+* **Boolean algebra** — ``a & b``, ``a | b``, ``~a`` — operate on the
+  resolved id sets via ``np.intersect1d`` / ``np.union1d`` /
+  ``np.setdiff1d`` against an anchor-bound universe.
+
+Universe rule
+-------------
+Without an anchor, the universe is *all* nodes in the model — spatial
+primitives still work fine. ``~sel`` requires an explicit anchor
+(``from_selection`` / ``with_ids``) so that "complement" has a
+well-defined meaning; otherwise it would silently negate against the
+whole model and produce a surprisingly large set.
+
+Combinators inherit a derived universe:
+
+* ``(a & b)._universe`` = ``a._universe ∩ b._universe``
+* ``(a | b)._universe`` = ``a._universe ∪ b._universe``
+* ``(~a)._universe``  = ``a._universe``  (idempotent)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import reduce
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .node_manager import NodeManager
+    from ..elements.selector import ElementSelector
+
+
+ArrayLike = Union[Sequence[float], np.ndarray]
+
+
+# ---------------------------------------------------------------------- #
+# Filter ops                                                             #
+# ---------------------------------------------------------------------- #
+
+class _FilterOp:
+    """Marker base. Each op narrows a DataFrame; ops compose by stacking."""
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class _WithinBoxOp(_FilterOp):
+    bbox_min: Tuple[float, float, float]
+    bbox_max: Tuple[float, float, float]
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        bmin = np.asarray(self.bbox_min, dtype=np.float64)
+        bmax = np.asarray(self.bbox_max, dtype=np.float64)
+        x = df["x"].to_numpy()
+        y = df["y"].to_numpy()
+        z = df["z"].to_numpy()
+        mask = (
+            (x >= bmin[0]) & (x <= bmax[0]) &
+            (y >= bmin[1]) & (y <= bmax[1]) &
+            (z >= bmin[2]) & (z <= bmax[2])
+        )
+        return df.loc[mask]
+
+
+@dataclass(frozen=True)
+class _WithinDistanceOp(_FilterOp):
+    point: Tuple[float, float, float]
+    radius: float
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        p = np.asarray(self.point, dtype=np.float64)
+        x = df["x"].to_numpy()
+        y = df["y"].to_numpy()
+        z = df["z"].to_numpy()
+        d = np.sqrt((x - p[0]) ** 2 + (y - p[1]) ** 2 + (z - p[2]) ** 2)
+        return df.loc[d <= self.radius]
+
+
+@dataclass(frozen=True)
+class _NearestToOp(_FilterOp):
+    point: Tuple[float, float, float]
+    k: int
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty or self.k <= 0:
+            return df.iloc[0:0]
+        p = np.asarray(self.point, dtype=np.float64)
+        x = df["x"].to_numpy()
+        y = df["y"].to_numpy()
+        z = df["z"].to_numpy()
+        d = np.sqrt((x - p[0]) ** 2 + (y - p[1]) ** 2 + (z - p[2]) ** 2)
+        if self.k >= len(df):
+            return df.iloc[np.argsort(d, kind="stable")]
+        idx = np.argpartition(d, self.k - 1)[: self.k]
+        idx = idx[np.argsort(d[idx], kind="stable")]
+        return df.iloc[idx]
+
+
+@dataclass(frozen=True)
+class _OnPlaneOp(_FilterOp):
+    point: Tuple[float, float, float]
+    normal: Tuple[float, float, float]
+    tol: float
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        p = np.asarray(self.point, dtype=np.float64)
+        n = np.asarray(self.normal, dtype=np.float64)
+        norm = np.linalg.norm(n)
+        if norm < 1e-15:
+            raise ValueError("on_plane: normal vector has zero length.")
+        n = n / norm
+        coords = df[["x", "y", "z"]].to_numpy(dtype=np.float64)
+        signed = (coords - p) @ n
+        return df.loc[np.abs(signed) <= self.tol]
+
+
+@dataclass(frozen=True)
+class _NearLineOp(_FilterOp):
+    p0: Tuple[float, float, float]
+    p1: Tuple[float, float, float]
+    radius: float
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        a = np.asarray(self.p0, dtype=np.float64)
+        b = np.asarray(self.p1, dtype=np.float64)
+        ab = b - a
+        ab2 = float(np.dot(ab, ab))
+        if ab2 < 1e-30:
+            raise ValueError("near_line: p0 and p1 coincide.")
+        c = df[["x", "y", "z"]].to_numpy(dtype=np.float64)
+        t = np.clip(((c - a) @ ab) / ab2, 0.0, 1.0)
+        proj = a + t[:, None] * ab
+        d = np.linalg.norm(c - proj, axis=1)
+        return df.loc[d <= self.radius]
+
+
+@dataclass(frozen=True)
+class _CoordInOp(_FilterOp):
+    axis: str
+    lo: Optional[float]
+    hi: Optional[float]
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        col = self.axis.lower()
+        if col not in {"x", "y", "z"}:
+            raise ValueError(f"coord_in: unknown axis {self.axis!r}.")
+        v = df[col].to_numpy()
+        mask = np.ones(len(v), dtype=bool)
+        if self.lo is not None:
+            mask &= v >= self.lo
+        if self.hi is not None:
+            mask &= v <= self.hi
+        return df.loc[mask]
+
+
+@dataclass(frozen=True)
+class _AtLevelOp(_FilterOp):
+    axis: str
+    value: float
+    tol: float
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        col = self.axis.lower()
+        if col not in {"x", "y", "z"}:
+            raise ValueError(f"at_level: unknown axis {self.axis!r}.")
+        v = df[col].to_numpy()
+        return df.loc[np.abs(v - self.value) <= self.tol]
+
+
+@dataclass(frozen=True)
+class _AttachedToOp(_FilterOp):
+    """Keep nodes that appear in the ``node_list`` of any of a given set
+    of element ids.
+
+    The element id list is captured at op-construction time. Resolution
+    against the elements_info table happens at :meth:`apply` so
+    selectors stay lazy.
+    """
+    element_ids: Tuple[int, ...]
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty or not self.element_ids:
+            return df.iloc[0:0]
+        elements_info = getattr(manager.dataset, "elements_info", None)
+        if not isinstance(elements_info, dict):
+            raise ValueError(
+                "attached_to: dataset has no elements_info table; "
+                "cannot resolve element connectivity."
+            )
+        df_elem = elements_info.get("dataframe")
+        if df_elem is None or df_elem.empty:
+            raise ValueError(
+                "attached_to: elements_info dataframe is empty."
+            )
+        eid_set = set(int(x) for x in self.element_ids)
+        sub = df_elem[df_elem["element_id"].isin(eid_set)]
+        if sub.empty:
+            return df.iloc[0:0]
+        attached: set[int] = set()
+        for nl in sub["node_list"]:
+            for n in nl:
+                attached.add(int(n))
+        if not attached:
+            return df.iloc[0:0]
+        return df.loc[df["node_id"].isin(attached)]
+
+
+@dataclass(frozen=True)
+class _PredicateOp(_FilterOp):
+    fn: Callable[[pd.DataFrame], np.ndarray]
+
+    def apply(self, df: pd.DataFrame, manager: "NodeManager") -> pd.DataFrame:
+        if df.empty:
+            return df
+        mask = self.fn(df)
+        mask_arr = np.asarray(mask, dtype=bool)
+        if mask_arr.shape != (len(df),):
+            raise ValueError(
+                f"where(fn): predicate returned shape {mask_arr.shape}, "
+                f"expected ({len(df)},)."
+            )
+        return df.loc[mask_arr]
+
+
+# ---------------------------------------------------------------------- #
+# Anchor                                                                 #
+# ---------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class _Anchor:
+    selection: Optional[Tuple[Any, ...]] = None  # names or set ids
+    explicit_ids: Optional[Tuple[int, ...]] = None
+
+    def is_set(self) -> bool:
+        return self.selection is not None or self.explicit_ids is not None
+
+    def with_(
+        self,
+        *,
+        selection: Optional[Tuple[Any, ...]] = None,
+        explicit_ids: Optional[Tuple[int, ...]] = None,
+    ) -> "_Anchor":
+        return _Anchor(
+            selection=selection if selection is not None else self.selection,
+            explicit_ids=(
+                explicit_ids
+                if explicit_ids is not None
+                else self.explicit_ids
+            ),
+        )
+
+
+# ---------------------------------------------------------------------- #
+# NodeSelector                                                           #
+# ---------------------------------------------------------------------- #
+
+class NodeSelector:
+    """Lazy, immutable node-id query.
+
+    Construct via :meth:`NodeManager.select` and chain primitives.
+    Resolution to ids is deferred until :meth:`ids`, :meth:`mask`,
+    :meth:`df`, or :meth:`count` is called.
+
+    Examples
+    --------
+    >>> sel = (dataset.nodes.select()
+    ...        .from_selection("Roof")
+    ...        .within_box(min=(0, 0, 0), max=(10, 10, 30))
+    ...        .nearest_to((5, 5, 30), k=4))
+    >>> ids = sel.ids()
+    >>> df  = sel.df()
+    >>> mask = sel.mask()
+    >>> n   = sel.count()
+
+    Composition
+    -----------
+    >>> a = dataset.nodes.select().from_selection("Core").at_level("z", 30.0)
+    >>> b = dataset.nodes.select().from_selection("Perimeter").at_level("z", 30.0)
+    >>> (a & b).ids()        # intersection
+    >>> (a | b).ids()        # union
+    >>> (~a).ids()           # complement within a's anchor universe
+    """
+
+    def __init__(
+        self,
+        manager: "NodeManager",
+        *,
+        anchor: Optional[_Anchor] = None,
+        ops: Tuple[_FilterOp, ...] = (),
+    ) -> None:
+        self._manager = manager
+        self._anchor = anchor or _Anchor()
+        self._ops = ops
+
+    # ------------------------------------------------------------------ #
+    # Anchor primitives                                                   #
+    # ------------------------------------------------------------------ #
+
+    def from_selection(
+        self,
+        name_or_id: Union[str, int, Sequence[Union[str, int]]],
+    ) -> "NodeSelector":
+        """Anchor universe to one or more selection sets (by name or id)."""
+        if isinstance(name_or_id, (str, int, np.integer)):
+            sel_tup: Tuple[Any, ...] = (name_or_id,)
+        else:
+            sel_tup = tuple(name_or_id)
+        existing = self._anchor.selection or ()
+        return NodeSelector(
+            self._manager,
+            anchor=self._anchor.with_(selection=existing + sel_tup),
+            ops=self._ops,
+        )
+
+    def with_ids(
+        self, ids: Union[int, Sequence[int], np.ndarray]
+    ) -> "NodeSelector":
+        """Anchor universe to an explicit set of node ids."""
+        if isinstance(ids, (int, np.integer)):
+            arr = (int(ids),)
+        else:
+            arr = tuple(int(x) for x in np.asarray(ids).ravel())
+        existing = self._anchor.explicit_ids or ()
+        return NodeSelector(
+            self._manager,
+            anchor=self._anchor.with_(explicit_ids=existing + arr),
+            ops=self._ops,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Spatial primitives                                                  #
+    # ------------------------------------------------------------------ #
+
+    def within_box(
+        self,
+        *,
+        min: ArrayLike,
+        max: ArrayLike,
+    ) -> "NodeSelector":
+        """Keep nodes whose coordinates lie inside an axis-aligned bounding box."""
+        op = _WithinBoxOp(
+            bbox_min=tuple(np.asarray(min, dtype=np.float64).tolist()),
+            bbox_max=tuple(np.asarray(max, dtype=np.float64).tolist()),
+        )
+        return self._with_op(op)
+
+    def within_distance(
+        self, point: ArrayLike, radius: float
+    ) -> "NodeSelector":
+        """Keep nodes within ``radius`` of ``point``."""
+        if radius < 0:
+            raise ValueError("within_distance: radius must be non-negative.")
+        op = _WithinDistanceOp(
+            point=tuple(np.asarray(point, dtype=np.float64).tolist()),
+            radius=float(radius),
+        )
+        return self._with_op(op)
+
+    def nearest_to(self, point: ArrayLike, k: int = 1) -> "NodeSelector":
+        """Keep the ``k`` nodes nearest to ``point``.
+
+        Result rows are sorted by ascending distance (deterministic, with
+        a stable tie-break on the original row order).
+        """
+        if k < 0:
+            raise ValueError("nearest_to: k must be non-negative.")
+        op = _NearestToOp(
+            point=tuple(np.asarray(point, dtype=np.float64).tolist()),
+            k=int(k),
+        )
+        return self._with_op(op)
+
+    def on_plane(
+        self,
+        *,
+        point: Optional[ArrayLike] = None,
+        normal: Optional[ArrayLike] = None,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        tol: float = 1e-6,
+    ) -> "NodeSelector":
+        """Keep nodes lying on a plane within ``tol`` (signed distance).
+
+        Either pass ``point`` + ``normal`` for a general plane, or one
+        of ``x=``, ``y=``, ``z=`` for an axis-aligned plane (equivalent
+        to :meth:`at_level` with the same axis).
+        """
+        axis_args = sum(arg is not None for arg in (x, y, z))
+        if axis_args > 1:
+            raise ValueError("on_plane: pass at most one of x=, y=, z=.")
+        if axis_args == 1 and (point is not None or normal is not None):
+            raise ValueError(
+                "on_plane: cannot mix x/y/z= with point/normal."
+            )
+        if axis_args == 1:
+            if x is not None:
+                p, n = (x, 0.0, 0.0), (1.0, 0.0, 0.0)
+            elif y is not None:
+                p, n = (0.0, y, 0.0), (0.0, 1.0, 0.0)
+            else:
+                p, n = (0.0, 0.0, z), (0.0, 0.0, 1.0)  # type: ignore[arg-type]
+        else:
+            if point is None or normal is None:
+                raise ValueError(
+                    "on_plane: pass point=+normal= or one of x=/y=/z=."
+                )
+            p = tuple(np.asarray(point, dtype=np.float64).tolist())  # type: ignore[assignment]
+            n = tuple(np.asarray(normal, dtype=np.float64).tolist())  # type: ignore[assignment]
+        op = _OnPlaneOp(point=p, normal=n, tol=float(tol))  # type: ignore[arg-type]
+        return self._with_op(op)
+
+    def near_line(
+        self,
+        p0: ArrayLike,
+        p1: ArrayLike,
+        radius: float,
+    ) -> "NodeSelector":
+        """Keep nodes within ``radius`` of the line segment from ``p0`` to ``p1``."""
+        if radius < 0:
+            raise ValueError("near_line: radius must be non-negative.")
+        op = _NearLineOp(
+            p0=tuple(np.asarray(p0, dtype=np.float64).tolist()),
+            p1=tuple(np.asarray(p1, dtype=np.float64).tolist()),
+            radius=float(radius),
+        )
+        return self._with_op(op)
+
+    def coord_in(
+        self,
+        axis: str,
+        *,
+        lo: Optional[float] = None,
+        hi: Optional[float] = None,
+    ) -> "NodeSelector":
+        """Keep nodes with ``<axis>`` coordinate in ``[lo, hi]``.
+
+        Either bound may be ``None`` for a one-sided constraint. ``axis``
+        is one of ``"x"``, ``"y"``, ``"z"``.
+        """
+        if lo is None and hi is None:
+            raise ValueError("coord_in: pass at least one of lo=, hi=.")
+        return self._with_op(_CoordInOp(axis=str(axis), lo=lo, hi=hi))
+
+    def at_level(
+        self,
+        axis: str = "z",
+        value: Optional[float] = None,
+        *,
+        tol: float = 1e-6,
+    ) -> "NodeSelector":
+        """Keep nodes with ``<axis>`` coordinate equal to ``value`` (within ``tol``).
+
+        Convenience wrapper for "story floor" / "support row" picks. Use
+        :meth:`coord_in` for ranges, :meth:`on_plane` for off-axis planes.
+        """
+        if value is None:
+            raise ValueError("at_level: ``value`` is required.")
+        return self._with_op(
+            _AtLevelOp(axis=str(axis), value=float(value), tol=float(tol))
+        )
+
+    def attached_to(
+        self,
+        *,
+        element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+        element_selector: Optional["ElementSelector"] = None,
+    ) -> "NodeSelector":
+        """Keep nodes that participate in the connectivity of the given elements.
+
+        Pass either ``element_ids=`` (explicit ids) or
+        ``element_selector=`` (resolved at chain time). Closes the loop
+        between node and element selectors — e.g. "all nodes attached to
+        the columns inside this story".
+        """
+        if (element_ids is None) == (element_selector is None):
+            raise ValueError(
+                "attached_to: pass exactly one of element_ids= or "
+                "element_selector=."
+            )
+        if element_selector is not None:
+            ids_arr = element_selector.ids()
+        else:
+            if isinstance(element_ids, (int, np.integer)):
+                ids_arr = np.asarray([int(element_ids)], dtype=np.int64)
+            else:
+                ids_arr = np.asarray(element_ids, dtype=np.int64).ravel()
+        eid_tup = tuple(int(x) for x in ids_arr)
+        return self._with_op(_AttachedToOp(element_ids=eid_tup))
+
+    def where(
+        self, fn: Callable[[pd.DataFrame], np.ndarray]
+    ) -> "NodeSelector":
+        """Predicate escape hatch.
+
+        ``fn`` receives the candidate node-index DataFrame (columns
+        ``node_id, file_id, index, x, y, z``) and must return a boolean
+        array of equal length.
+
+        Example
+        -------
+        >>> sel.where(lambda df: (df["x"]**2 + df["y"]**2) < 25.0)
+        """
+        return self._with_op(_PredicateOp(fn=fn))
+
+    # ------------------------------------------------------------------ #
+    # Resolution                                                          #
+    # ------------------------------------------------------------------ #
+
+    def df(self) -> pd.DataFrame:
+        """Return the node-index DataFrame matching this selector."""
+        df = self._resolve_universe_df()
+        for op in self._ops:
+            df = op.apply(df, self._manager)
+            if df.empty:
+                break
+        return df
+
+    def ids(self) -> np.ndarray:
+        """Return matched node ids as ``int64`` array.
+
+        Order matches the underlying op chain — for ``nearest_to`` this
+        is by ascending distance; otherwise by ascending node_id.
+        """
+        df = self.df()
+        if df.empty:
+            return np.empty(0, dtype=np.int64)
+        return df["node_id"].to_numpy(dtype=np.int64)
+
+    def mask(self) -> pd.Series:
+        """Boolean Series indexed by node_id over this selector's universe.
+
+        With no anchor the universe is *all* nodes in the model.
+        """
+        uni = self._universe_ids(allow_all=True)
+        matched = set(int(x) for x in self.ids().tolist())
+        values = np.fromiter(
+            (int(nid) in matched for nid in uni), dtype=bool, count=uni.size
+        )
+        return pd.Series(values, index=uni, name="mask")
+
+    def count(self) -> int:
+        """Number of matched nodes."""
+        return int(self.ids().size)
+
+    # ------------------------------------------------------------------ #
+    # Boolean composition                                                 #
+    # ------------------------------------------------------------------ #
+
+    def __and__(self, other: "NodeSelector") -> "NodeSelector":
+        if not isinstance(other, NodeSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="and", parts=(self, other))
+
+    def __or__(self, other: "NodeSelector") -> "NodeSelector":
+        if not isinstance(other, NodeSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="or", parts=(self, other))
+
+    def __invert__(self) -> "NodeSelector":
+        if not self._anchor.is_set():
+            raise ValueError(
+                "Cannot negate a selector without a from_selection/"
+                "with_ids anchor — call .from_selection(...) or "
+                ".with_ids(...) first to define the universe."
+            )
+        return _CombinedSelector(self._manager, kind="not", parts=(self,))
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _with_op(self, op: _FilterOp) -> "NodeSelector":
+        return NodeSelector(
+            self._manager, anchor=self._anchor, ops=self._ops + (op,)
+        )
+
+    def _resolve_universe_df(self) -> pd.DataFrame:
+        df = self._manager._ensure_node_index_df()
+        a = self._anchor
+        if a.selection is not None:
+            names: list[str] = []
+            ids: list[int] = []
+            for s in a.selection:
+                if isinstance(s, (int, np.integer)):
+                    ids.append(int(s))
+                else:
+                    names.append(str(s))
+            sel_ids = self._manager.dataset._selection_resolver.resolve_nodes(
+                names=names or None, ids=ids or None
+            )
+            df = df[df["node_id"].isin(sel_ids)]
+        if a.explicit_ids is not None:
+            df = df[df["node_id"].isin(a.explicit_ids)]
+        return df
+
+    def _universe_ids(self, *, allow_all: bool = False) -> np.ndarray:
+        """Return the node-id universe for this selector.
+
+        ``allow_all=True`` falls back to "all nodes in the model" when
+        no anchor is set (used by :meth:`mask`). Negation paths require
+        an explicit anchor and pass ``allow_all=False`` (the default).
+        """
+        if not self._anchor.is_set():
+            if not allow_all:
+                raise ValueError(
+                    "Selector has no anchor; cannot compute a universe."
+                )
+            return (
+                self._manager._ensure_node_index_df()["node_id"]
+                .to_numpy(dtype=np.int64)
+            )
+        return (
+            self._resolve_universe_df()["node_id"]
+            .to_numpy(dtype=np.int64)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Repr                                                                #
+    # ------------------------------------------------------------------ #
+
+    def __repr__(self) -> str:
+        bits: list[str] = []
+        if self._anchor.selection:
+            bits.append(f"from_selection={list(self._anchor.selection)!r}")
+        if self._anchor.explicit_ids:
+            bits.append(f"with_ids({len(self._anchor.explicit_ids)})")
+        for op in self._ops:
+            bits.append(type(op).__name__.strip("_"))
+        return f"NodeSelector({', '.join(bits)})"
+
+
+# ---------------------------------------------------------------------- #
+# Combined (AND/OR/NOT) selector                                         #
+# ---------------------------------------------------------------------- #
+
+class _CombinedSelector(NodeSelector):
+    """Boolean combinator over child selectors."""
+
+    def __init__(
+        self,
+        manager: "NodeManager",
+        *,
+        kind: str,
+        parts: Tuple[NodeSelector, ...],
+    ) -> None:
+        self._manager = manager
+        self._anchor = _Anchor()
+        self._ops = ()
+        if kind not in {"and", "or", "not"}:
+            raise ValueError(f"_CombinedSelector: unknown kind {kind!r}.")
+        if kind == "not" and len(parts) != 1:
+            raise ValueError("_CombinedSelector('not'): expects one part.")
+        if kind in {"and", "or"} and len(parts) < 2:
+            raise ValueError(f"_CombinedSelector({kind!r}): expects ≥2 parts.")
+        self._kind = kind
+        self._parts = parts
+
+    def ids(self) -> np.ndarray:
+        if self._kind == "and":
+            arrs = [p.ids() for p in self._parts]
+            return reduce(np.intersect1d, arrs) if arrs else np.empty(0, np.int64)
+        if self._kind == "or":
+            arrs = [p.ids() for p in self._parts]
+            return (
+                reduce(np.union1d, arrs) if arrs else np.empty(0, np.int64)
+            )
+        # not
+        inner = self._parts[0]
+        uni = inner._universe_ids(allow_all=False)
+        return np.setdiff1d(uni, inner.ids(), assume_unique=False)
+
+    def df(self) -> pd.DataFrame:
+        ids = self.ids()
+        if ids.size == 0:
+            return self._manager._ensure_node_index_df().iloc[0:0]
+        df_all = self._manager._ensure_node_index_df()
+        return df_all[df_all["node_id"].isin(ids)]
+
+    def mask(self) -> pd.Series:
+        uni = self._universe_ids(allow_all=True)
+        matched = set(int(x) for x in self.ids().tolist())
+        values = np.fromiter(
+            (int(nid) in matched for nid in uni), dtype=bool, count=uni.size
+        )
+        return pd.Series(values, index=uni, name="mask")
+
+    def count(self) -> int:
+        return int(self.ids().size)
+
+    def _universe_ids(self, *, allow_all: bool = False) -> np.ndarray:
+        unis = [p._universe_ids(allow_all=allow_all) for p in self._parts]
+        if self._kind == "and":
+            return reduce(np.intersect1d, unis) if unis else np.empty(0, np.int64)
+        if self._kind == "or":
+            return reduce(np.union1d, unis) if unis else np.empty(0, np.int64)
+        return unis[0]  # not
+
+    def __and__(self, other: "NodeSelector") -> "NodeSelector":
+        if not isinstance(other, NodeSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="and", parts=(self, other))
+
+    def __or__(self, other: "NodeSelector") -> "NodeSelector":
+        if not isinstance(other, NodeSelector):
+            return NotImplemented  # type: ignore[return-value]
+        return _CombinedSelector(self._manager, kind="or", parts=(self, other))
+
+    def __invert__(self) -> "NodeSelector":
+        for p in self._parts:
+            try:
+                p._universe_ids(allow_all=False)
+            except ValueError as e:
+                raise ValueError(
+                    "Cannot negate a combinator whose parts lack anchors. "
+                    f"Inner error: {e}"
+                ) from e
+        return _CombinedSelector(self._manager, kind="not", parts=(self,))
+
+    def from_selection(self, name_or_id):  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .from_selection() on a combined selector; "
+            "anchor each leaf selector before combining."
+        )
+
+    def with_ids(self, ids):  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .with_ids() on a combined selector; anchor "
+            "each leaf selector before combining."
+        )
+
+    def _with_op(self, op: _FilterOp) -> "NodeSelector":
+        raise TypeError(
+            "Cannot append filter ops directly to a combined selector. "
+            "Apply primitives to leaf selectors before combining, or "
+            "pass the combined result through .ids() and rebuild."
+        )
+
+    def __repr__(self) -> str:
+        op = {"and": " & ", "or": " | "}.get(self._kind)
+        if self._kind == "not":
+            return f"~({self._parts[0]!r})"
+        return "(" + op.join(repr(p) for p in self._parts) + ")"  # type: ignore[arg-type]
+
+
+__all__ = ["NodeSelector"]

--- a/src/STKO_to_python/results/nodal_results_dataclass.py
+++ b/src/STKO_to_python/results/nodal_results_dataclass.py
@@ -830,6 +830,46 @@ class NodalResults:
         )
 
     # ------------------------------------------------------------------ #
+    # Threshold / time-window query (parity with ElementResults.where)    #
+    # ------------------------------------------------------------------ #
+
+    def where(self, *, time: Any = None) -> Any:
+        """Start a threshold / time-window mask query.
+
+        Returns a ``_ResultQuery`` object; chain ``.component(result, comp)`` /
+        ``.magnitude(result)`` / ``.predicate(...)`` to build a
+        :class:`~STKO_to_python.nodes.result_mask.NodeResultMask`. The
+        ``time`` argument sets a default window for every reduction in
+        the chain (each reduction can override with its own ``time=``).
+
+        Examples
+        --------
+        >>> mask = (nr.where(time=(0.0, 10.0))
+        ...        .component("DISPLACEMENT", 1).abs_peak().gt(0.05))
+        >>> hot = nr[mask]                       # filtered NodalResults
+        >>> ids = mask.ids()                     # int64 array
+
+        >>> mask = (nr.where()
+        ...        .magnitude("DISPLACEMENT").peak().gt(0.05))
+        """
+        from ..nodes.result_mask import _ResultQuery
+
+        return _ResultQuery(self, default_time=time)
+
+    def __getitem__(self, key: Any) -> Any:
+        """Apply a :class:`NodeResultMask` (``nr[mask]``) to get a fresh
+        trimmed :class:`NodalResults`.
+        """
+        from ..nodes.result_mask import NodeResultMask
+
+        if isinstance(key, NodeResultMask):
+            return key.apply()
+        raise TypeError(
+            f"NodalResults[...] expects a NodeResultMask; got "
+            f"{type(key).__name__}."
+        )
+
+    # ------------------------------------------------------------------ #
     # Dynamic attribute access
     # ------------------------------------------------------------------ #
 

--- a/tests/unit/nodes/test_result_mask.py
+++ b/tests/unit/nodes/test_result_mask.py
@@ -1,0 +1,250 @@
+"""Unit tests for ``NodeResultMask`` and the ``nr.where(...)`` chain.
+
+Builds a small synthetic :class:`NodalResults` (3 nodes x 5 steps,
+3-component DISPLACEMENT) so each reduction's expected output is
+hand-checkable. No HDF5 fixture required.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.results.nodal_results_dataclass import NodalResults
+from STKO_to_python.nodes.result_mask import NodeResultMask
+
+
+# ---------------------------------------------------------------------- #
+# Fixture                                                                #
+# ---------------------------------------------------------------------- #
+
+@pytest.fixture
+def nr() -> NodalResults:
+    """3 nodes × 5 steps × 3 DISPLACEMENT components."""
+    nids = (1, 2, 3)
+    steps = list(range(5))
+    time = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+
+    # Per node, per step values for components 1, 2, 3.
+    # Designed so the |U|-magnitude peak is well-separated:
+    #   node 1 → mostly small, peak |U| = 5 at step 4 (3,4,0)
+    #   node 2 → biggest, peak |U| = 13 at step 2 (5,12,0)
+    #   node 3 → tiny, peak |U| = 1 at step 0 (1,0,0)
+    u1 = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [2.0, 0.0, 0.0],
+        [3.0, 0.0, 0.0],
+        [3.0, 4.0, 0.0],
+    ]
+    u2 = [
+        [0.0, 0.0, 0.0],
+        [3.0, 4.0, 0.0],
+        [5.0, 12.0, 0.0],
+        [3.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ]
+    u3 = [
+        [1.0, 0.0, 0.0],
+        [0.5, 0.0, 0.0],
+        [0.5, 0.0, 0.0],
+        [0.5, 0.0, 0.0],
+        [0.5, 0.0, 0.0],
+    ]
+    per_node = {1: u1, 2: u2, 3: u3}
+
+    rows: list[dict] = []
+    for n in nids:
+        for s in steps:
+            ux, uy, uz = per_node[n][s]
+            rows.append(
+                {
+                    "node_id": n,
+                    "step": s,
+                    ("DISPLACEMENT", 1): ux,
+                    ("DISPLACEMENT", 2): uy,
+                    ("DISPLACEMENT", 3): uz,
+                }
+            )
+    df = pd.DataFrame(rows).set_index(["node_id", "step"]).sort_index()
+    df.columns = pd.MultiIndex.from_tuples(
+        df.columns.tolist(), names=("result", "component")
+    )
+
+    coords = pd.DataFrame(
+        {"x": [0.0, 1.0, 2.0], "y": [0.0, 0.0, 0.0], "z": [0.0, 0.0, 0.0]},
+        index=pd.Index(nids, name="node_id"),
+    )
+
+    return NodalResults(
+        df=df,
+        time=time,
+        name="synthetic",
+        nodes_ids=nids,
+        nodes_info=coords,
+        results_components=("DISPLACEMENT|1", "DISPLACEMENT|2", "DISPLACEMENT|3"),
+        model_stages=("MODEL_STAGE[1]",),
+        stage_step_ranges={"MODEL_STAGE[1]": (0, 5)},
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Component path                                                          #
+# ---------------------------------------------------------------------- #
+
+def test_component_peak_threshold(nr: NodalResults):
+    mask = nr.where().component("DISPLACEMENT", 2).peak().gt(5.0)
+    ids = set(mask.ids().tolist())
+    # Component 2 peaks: node1=4, node2=12, node3=0. Only node 2 > 5.
+    assert ids == {2}
+
+
+def test_component_abs_peak(nr: NodalResults):
+    mask = nr.where().component("DISPLACEMENT", 1).abs_peak().ge(3.0)
+    ids = set(mask.ids().tolist())
+    # |comp1| peaks: node1=3, node2=5, node3=1. Threshold ≥3.
+    assert ids == {1, 2}
+
+
+def test_component_at_step(nr: NodalResults):
+    mask = nr.where().component("DISPLACEMENT", 1).at_step(2).gt(1.5)
+    ids = set(mask.ids().tolist())
+    # At step 2, comp 1: node1=2, node2=5, node3=0.5.
+    assert ids == {1, 2}
+
+
+def test_component_unknown_raises(nr: NodalResults):
+    with pytest.raises(ValueError, match="not found"):
+        nr.where().component("DISPLACEMENT", 99)
+
+
+# ---------------------------------------------------------------------- #
+# Magnitude path                                                          #
+# ---------------------------------------------------------------------- #
+
+def test_magnitude_default_uses_all_components(nr: NodalResults):
+    mask = nr.where().magnitude("DISPLACEMENT").peak().gt(10.0)
+    ids = set(mask.ids().tolist())
+    # |U| peaks: node1=5, node2=13, node3=1. Threshold > 10 → only node 2.
+    assert ids == {2}
+
+
+def test_magnitude_planar_components(nr: NodalResults):
+    mask = nr.where().magnitude("DISPLACEMENT", components=(1, 2)).peak().ge(5.0)
+    ids = set(mask.ids().tolist())
+    # Same since comp 3 is zero throughout — node 1 (5) and node 2 (13).
+    assert ids == {1, 2}
+
+
+def test_magnitude_unknown_result_raises(nr: NodalResults):
+    with pytest.raises(ValueError, match="no components"):
+        nr.where().magnitude("VELOCITY")
+
+
+# ---------------------------------------------------------------------- #
+# Time windowing                                                          #
+# ---------------------------------------------------------------------- #
+
+def test_default_time_window_propagates(nr: NodalResults):
+    # Window covers steps 0..2 (time half-open [0, 3) → steps 0,1,2).
+    mask = (
+        nr.where(time=(0.0, 3.0))
+        .component("DISPLACEMENT", 2)
+        .peak()
+        .gt(5.0)
+    )
+    ids = set(mask.ids().tolist())
+    # Comp 2 peaks in window: node1=0, node2=12, node3=0. Only node 2 > 5.
+    assert ids == {2}
+
+
+def test_explicit_time_overrides_default(nr: NodalResults):
+    # Default window of [0, 3); override with the full series.
+    mask = (
+        nr.where(time=(0.0, 3.0))
+        .component("DISPLACEMENT", 1)
+        .peak(time=None)
+        .gt(2.5)
+    )
+    ids = set(mask.ids().tolist())
+    # Full-window comp 1 peaks: node1=3, node2=5, node3=1.
+    assert ids == {1, 2}
+
+
+# ---------------------------------------------------------------------- #
+# Boolean composition + nr[mask]                                          #
+# ---------------------------------------------------------------------- #
+
+def test_mask_and(nr: NodalResults):
+    a = nr.where().magnitude("DISPLACEMENT").peak().gt(2.0)
+    b = nr.where().component("DISPLACEMENT", 1).peak().gt(2.5)
+    ids = set((a & b).ids().tolist())
+    # |U| > 2: nodes 1, 2; comp 1 > 2.5: nodes 1, 2 → AND = {1,2}.
+    assert ids == {1, 2}
+
+
+def test_mask_or(nr: NodalResults):
+    a = nr.where().component("DISPLACEMENT", 1).peak().gt(4.0)  # node 2
+    b = nr.where().component("DISPLACEMENT", 2).peak().ge(4.0)  # nodes 1 and 2
+    ids = set((a | b).ids().tolist())
+    assert ids == {1, 2}
+
+
+def test_mask_invert(nr: NodalResults):
+    a = nr.where().magnitude("DISPLACEMENT").peak().gt(10.0)
+    not_a = ~a
+    ids = set(not_a.ids().tolist())
+    # ~{2} → {1, 3}
+    assert ids == {1, 3}
+
+
+def test_apply_returns_trimmed_nodal_results(nr: NodalResults):
+    mask = nr.where().magnitude("DISPLACEMENT").peak().gt(10.0)
+    trimmed = nr[mask]
+    assert isinstance(trimmed, NodalResults)
+    assert tuple(trimmed.info.nodes_ids) == (2,)
+    # df should only contain rows for node 2.
+    nids = set(trimmed.df.index.get_level_values("node_id").unique().tolist())
+    assert nids == {2}
+
+
+def test_apply_empty_mask(nr: NodalResults):
+    mask = nr.where().magnitude("DISPLACEMENT").peak().gt(1e9)
+    trimmed = nr[mask]
+    assert isinstance(trimmed, NodalResults)
+    assert tuple(trimmed.info.nodes_ids) == ()
+    assert trimmed.df.empty
+
+
+# ---------------------------------------------------------------------- #
+# predicate escape hatch                                                  #
+# ---------------------------------------------------------------------- #
+
+def test_predicate_per_node_array(nr: NodalResults):
+    # Per-node bool array — same length as info.nodes_ids.
+    mask = nr.where().predicate(lambda df: np.array([True, False, True]))
+    ids = set(mask.ids().tolist())
+    assert ids == {1, 3}
+
+
+def test_predicate_per_row_array(nr: NodalResults):
+    # Per-row bool array — collapsed via any over (node_id, step).
+    arr = np.zeros(len(nr.df), dtype=bool)
+    arr[0] = True  # one row of node 1 — any() → node 1 included.
+    mask = nr.where().predicate(lambda df: arr)
+    ids = set(mask.ids().tolist())
+    assert ids == {1}
+
+
+def test_predicate_shape_mismatch_raises(nr: NodalResults):
+    with pytest.raises(ValueError, match="returned shape"):
+        nr.where().predicate(lambda df: np.ones(99, dtype=bool))
+
+
+# ---------------------------------------------------------------------- #
+# __getitem__ rejects non-mask                                            #
+# ---------------------------------------------------------------------- #
+
+def test_getitem_non_mask_raises(nr: NodalResults):
+    with pytest.raises(TypeError, match="NodeResultMask"):
+        nr[42]

--- a/tests/unit/nodes/test_selector.py
+++ b/tests/unit/nodes/test_selector.py
@@ -1,0 +1,338 @@
+"""Unit tests for ``NodeSelector``.
+
+Synthetic, self-contained ``NodeManager`` stand-in — no on-disk
+fixtures. Geometry is a uniform 4 x 4 x 4 lattice of nodes plus a
+12-element beam grid wiring adjacent x-neighbours along z=0, y=0 so
+that ``attached_to`` has a non-trivial connectivity to chase.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.nodes.selector import NodeSelector
+
+
+# ---------------------------------------------------------------------- #
+# Fixtures                                                                #
+# ---------------------------------------------------------------------- #
+
+def _build_index() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return (nodes_df, elements_df).
+
+    Nodes: 4 x 4 x 4 integer-coord lattice (64 nodes), node_id from 1.
+    Elements: 12 line elements wiring (ix, 0, 0) -> (ix+1, 0, 0) for
+    ix in 0..2, repeated for y in {0} and z in {0}, but here just one
+    row of 3 along z=0 for simplicity. Plus 3 elements at z=2 and 3 at
+    z=3 so attached_to spans more than one z-level.
+    """
+    nodes: list[dict] = []
+    nid = 1
+    coord_to_id: dict[tuple[int, int, int], int] = {}
+    for ix in range(4):
+        for iy in range(4):
+            for iz in range(4):
+                coord_to_id[(ix, iy, iz)] = nid
+                nodes.append(
+                    {
+                        "node_id": nid,
+                        "file_id": 0,
+                        "index": nid - 1,
+                        "x": float(ix),
+                        "y": float(iy),
+                        "z": float(iz),
+                    }
+                )
+                nid += 1
+    df_nodes = pd.DataFrame(nodes)
+
+    # Elements: a few line elements running along x at z=0, z=2, z=3.
+    elem_rows: list[dict] = []
+    eid = 1
+    for iz in (0, 2, 3):
+        for ix in range(3):
+            n1 = coord_to_id[(ix, 0, iz)]
+            n2 = coord_to_id[(ix + 1, 0, iz)]
+            elem_rows.append(
+                {
+                    "element_id": eid,
+                    "element_idx": eid - 1,
+                    "file_id": 0,
+                    "element_type": "64-DispBeamColumn3d",
+                    "decorated_type": "64-DispBeamColumn3d[1000:0]",
+                    "node_list": (n1, n2),
+                    "num_nodes": 2,
+                    "centroid_x": float(ix) + 0.5,
+                    "centroid_y": 0.0,
+                    "centroid_z": float(iz),
+                }
+            )
+            eid += 1
+    df_elems = pd.DataFrame(elem_rows)
+    return df_nodes, df_elems
+
+
+@dataclass
+class _MockSelResolver:
+    node_sets: dict  # case-folded name -> np.ndarray
+    id_sets: dict  # int -> np.ndarray
+
+    def resolve_nodes(
+        self,
+        *,
+        names: Optional[Sequence[str]] = None,
+        ids: Optional[Sequence[int]] = None,
+        explicit_ids: Optional[Sequence[int]] = None,
+    ) -> np.ndarray:
+        gathered: list[np.ndarray] = []
+        if names:
+            for n in names:
+                key = str(n).strip().lower()
+                if key not in self.node_sets:
+                    raise ValueError(f"unknown set: {n}")
+                gathered.append(self.node_sets[key])
+        if ids:
+            for sid in ids:
+                if int(sid) not in self.id_sets:
+                    raise ValueError(f"unknown set id: {sid}")
+                gathered.append(self.id_sets[int(sid)])
+        if explicit_ids is not None:
+            gathered.append(np.asarray(list(explicit_ids), dtype=np.int64))
+        if not gathered:
+            raise ValueError("no inputs")
+        return np.unique(np.concatenate(gathered))
+
+
+class _MockDataset:
+    def __init__(self, df_nodes, df_elems, resolver):
+        self.nodes_info = {"dataframe": df_nodes}
+        self.elements_info = {"dataframe": df_elems}
+        self._selection_resolver = resolver
+
+
+class _MockManager:
+    def __init__(self, df_nodes, df_elems, resolver):
+        self._df = df_nodes
+        self.dataset = _MockDataset(df_nodes, df_elems, resolver)
+
+    def _ensure_node_index_df(self) -> pd.DataFrame:
+        return self._df
+
+
+@pytest.fixture
+def mgr() -> _MockManager:
+    df_nodes, df_elems = _build_index()
+    # "Roof" → all nodes at z=3; "Base" → all nodes at z=0.
+    roof = df_nodes[df_nodes["z"] == 3.0]["node_id"].to_numpy(np.int64)
+    base = df_nodes[df_nodes["z"] == 0.0]["node_id"].to_numpy(np.int64)
+    resolver = _MockSelResolver(
+        node_sets={"roof": roof, "base": base},
+        id_sets={1: roof, 2: base},
+    )
+    return _MockManager(df_nodes, df_elems, resolver)
+
+
+# ---------------------------------------------------------------------- #
+# Anchors                                                                 #
+# ---------------------------------------------------------------------- #
+
+def test_select_with_no_anchor_universe_is_all_nodes(mgr: _MockManager):
+    sel = NodeSelector(mgr)
+    assert sel.count() == 64
+    # Mask still works without an anchor (universe = all nodes).
+    m = sel.mask()
+    assert m.size == 64
+    assert m.all()
+
+
+def test_from_selection_by_name(mgr: _MockManager):
+    sel = NodeSelector(mgr).from_selection("Roof")
+    assert sel.count() == 16
+    df = sel.df()
+    assert (df["z"].to_numpy() == 3.0).all()
+
+
+def test_from_selection_by_id(mgr: _MockManager):
+    sel = NodeSelector(mgr).from_selection(2)  # base
+    assert sel.count() == 16
+    assert (sel.df()["z"].to_numpy() == 0.0).all()
+
+
+def test_with_ids_anchor(mgr: _MockManager):
+    ids = [1, 2, 3, 4]
+    sel = NodeSelector(mgr).with_ids(ids)
+    out = sel.ids().tolist()
+    assert sorted(out) == sorted(ids)
+
+
+# ---------------------------------------------------------------------- #
+# Spatial primitives                                                      #
+# ---------------------------------------------------------------------- #
+
+def test_within_box(mgr: _MockManager):
+    sel = NodeSelector(mgr).within_box(min=(0, 0, 0), max=(1, 1, 1))
+    # 2*2*2 = 8 nodes
+    assert sel.count() == 8
+
+
+def test_within_distance(mgr: _MockManager):
+    sel = NodeSelector(mgr).within_distance((0, 0, 0), radius=1.0)
+    ids = set(sel.ids().tolist())
+    # Nodes at distance 0 (origin) and 1 (axis-aligned neighbours).
+    # Coords with sum of squares <= 1: (0,0,0), (1,0,0), (0,1,0), (0,0,1).
+    assert len(ids) == 4
+
+
+def test_nearest_to_k(mgr: _MockManager):
+    sel = NodeSelector(mgr).nearest_to((0.1, 0.1, 0.1), k=3)
+    ids = sel.ids().tolist()
+    # First should be (0,0,0); next two are axis-aligned neighbours.
+    assert len(ids) == 3
+    df = sel.df().reset_index(drop=True)
+    # Distance ordering preserved.
+    assert df.iloc[0]["x"] == 0.0
+    assert df.iloc[0]["y"] == 0.0
+    assert df.iloc[0]["z"] == 0.0
+
+
+def test_on_plane_axis_aligned(mgr: _MockManager):
+    sel = NodeSelector(mgr).on_plane(z=2.0)
+    df = sel.df()
+    assert (df["z"].to_numpy() == 2.0).all()
+    assert sel.count() == 16
+
+
+def test_at_level_z(mgr: _MockManager):
+    sel = NodeSelector(mgr).at_level("z", 2.0)
+    df = sel.df()
+    assert (df["z"].to_numpy() == 2.0).all()
+    assert sel.count() == 16
+
+
+def test_coord_in_axis(mgr: _MockManager):
+    sel = NodeSelector(mgr).coord_in("x", lo=1.0, hi=2.0)
+    df = sel.df()
+    xs = df["x"].to_numpy()
+    assert ((xs >= 1.0) & (xs <= 2.0)).all()
+
+
+def test_near_line(mgr: _MockManager):
+    # Line along the x-axis at y=0, z=0
+    sel = NodeSelector(mgr).near_line((0, 0, 0), (3, 0, 0), radius=0.0)
+    df = sel.df()
+    # Only nodes with y=0 and z=0 (the line itself) qualify.
+    assert (df["y"].to_numpy() == 0.0).all()
+    assert (df["z"].to_numpy() == 0.0).all()
+
+
+def test_where_predicate(mgr: _MockManager):
+    sel = NodeSelector(mgr).where(
+        lambda df: (df["x"].to_numpy() ** 2 + df["y"].to_numpy() ** 2) < 1.5
+    )
+    df = sel.df()
+    # x²+y² < 1.5 → (x,y) ∈ {(0,0), (1,0), (0,1)} = 3 combos × 4 z-levels.
+    assert sel.count() == 12
+    assert df["x"].max() <= 1.0
+
+
+def test_where_predicate_shape_mismatch_raises(mgr: _MockManager):
+    sel = NodeSelector(mgr).where(lambda df: np.ones(3, dtype=bool))
+    with pytest.raises(ValueError, match="predicate returned shape"):
+        sel.df()
+
+
+# ---------------------------------------------------------------------- #
+# attached_to                                                             #
+# ---------------------------------------------------------------------- #
+
+def test_attached_to_explicit_ids(mgr: _MockManager):
+    # Element 1 connects nodes (0,0,0) and (1,0,0).
+    sel = NodeSelector(mgr).attached_to(element_ids=[1])
+    ids = set(sel.ids().tolist())
+    df_nodes = mgr._df
+    n1 = int(df_nodes[
+        (df_nodes["x"] == 0) & (df_nodes["y"] == 0) & (df_nodes["z"] == 0)
+    ]["node_id"].iloc[0])
+    n2 = int(df_nodes[
+        (df_nodes["x"] == 1) & (df_nodes["y"] == 0) & (df_nodes["z"] == 0)
+    ]["node_id"].iloc[0])
+    assert ids == {n1, n2}
+
+
+def test_attached_to_requires_one_source(mgr: _MockManager):
+    with pytest.raises(ValueError, match="exactly one"):
+        NodeSelector(mgr).attached_to()
+
+
+# ---------------------------------------------------------------------- #
+# Boolean composition                                                     #
+# ---------------------------------------------------------------------- #
+
+def test_intersection(mgr: _MockManager):
+    a = NodeSelector(mgr).from_selection("Roof")
+    b = NodeSelector(mgr).at_level("x", 0.0)
+    ids = set((a & b).ids().tolist())
+    # roof (z=3) ∩ x=0 → 4 nodes (one per y).
+    assert len(ids) == 4
+
+
+def test_union(mgr: _MockManager):
+    a = NodeSelector(mgr).from_selection("Roof")
+    b = NodeSelector(mgr).from_selection("Base")
+    ids = set((a | b).ids().tolist())
+    # Roof + Base = 32 nodes total.
+    assert len(ids) == 32
+
+
+def test_negation_universe_is_anchor(mgr: _MockManager):
+    a = NodeSelector(mgr).from_selection("Roof").at_level("x", 0.0)
+    # The universe is the Roof set; negation gives the rest of the roof.
+    not_a = ~a
+    ids = set(not_a.ids().tolist())
+    # Roof has 16 nodes; 4 at x=0; complement has 12.
+    assert len(ids) == 12
+
+
+def test_negation_without_anchor_raises(mgr: _MockManager):
+    sel = NodeSelector(mgr).at_level("z", 0.0)
+    with pytest.raises(ValueError, match="anchor"):
+        ~sel
+
+
+def test_combinator_cannot_take_anchor_methods(mgr: _MockManager):
+    a = NodeSelector(mgr).from_selection("Roof")
+    b = NodeSelector(mgr).from_selection("Base")
+    with pytest.raises(TypeError, match="combined selector"):
+        (a & b).from_selection("Roof")
+
+
+def test_mask_indexed_by_universe(mgr: _MockManager):
+    sel = NodeSelector(mgr).from_selection("Roof").at_level("x", 0.0)
+    m = sel.mask()
+    # Mask indexed by the universe (Roof = 16 nodes).
+    assert m.size == 16
+    assert m.sum() == 4
+
+
+def test_repr_includes_anchor_and_ops(mgr: _MockManager):
+    sel = (
+        NodeSelector(mgr)
+        .from_selection("Roof")
+        .within_box(min=(0, 0, 0), max=(3, 3, 3))
+    )
+    r = repr(sel)
+    assert "NodeSelector" in r
+    assert "from_selection" in r
+    assert "WithinBoxOp" in r
+
+
+def test_selectors_are_immutable(mgr: _MockManager):
+    a = NodeSelector(mgr).from_selection("Roof")
+    b = a.at_level("x", 0.0)
+    # Adding the op did not mutate ``a``.
+    assert a.count() == 16
+    assert b.count() == 4


### PR DESCRIPTION
## Summary

Brings the node side to feature parity with the recently-added [`ElementSelector`/`ResultMask`](https://github.com/nmorabowen/STKO_to_python/commit/06df7af) pipeline.

- **`NodeSelector`** ([`nodes/selector.py`](src/STKO_to_python/nodes/selector.py)) — lazy, immutable, chainable node-id query. Anchors (`from_selection`, `with_ids`), spatial primitives (`within_box`, `within_distance`, `nearest_to`, `on_plane`, `near_line`, `coord_in`), and the node-only primitives **`at_level("z", value=, tol=…)`** (story-floor sugar) and **`attached_to(element_ids=… | element_selector=…)`** (the bridge to `ElementSelector`). `&` / `|` / `~` boolean composition with the same anchor-bound universe rules as the element side.
- **`NodeResultMask`** ([`nodes/result_mask.py`](src/STKO_to_python/nodes/result_mask.py)) — per-node mask from a value condition. Two pick shapes: single component (`.component(result_name, comp)`) or vector magnitude (`.magnitude(result_name, components=…)`, `sqrt(sum(c_i**2))` per `(node, step)` before time reduction). Same reduction set as the element side (`peak / trough / abs_peak / mean / residual / over_threshold / at_step / at_time`) and the same time-spec grammar. Results compose with `&` / `|` / `~`, applied via `nr[mask]` for a fresh trimmed `NodalResults`.
- **Wiring** — `ds.nodes.select()` returns a fresh selector. `get_nodal_results(..., selector=NodeSelector)` accepts a selector and unions its ids with anything else passed (`node_ids`, `selection_set_*`). `NodalResults.where(time=…)` opens the mask chain; `NodalResults[mask]` returns the trimmed view.
- **Docs** — new [Cookbook 06](docs/cookbook/06-node-selector-and-mask-pipeline.md) (verified end-to-end against the `elasticFrame_mesh_displacementBased_results` fixture, the same one cookbook 05 uses), new sections in [`NodalResults.md`](docs/NodalResults.md) and [`api/nodal-results.md`](docs/api/nodal-results.md), and an `mkdocs.yml` nav entry. Cross-links between the two cookbooks. Time grammar is shared with the element side via `from STKO_to_python.elements.result_mask import resolve_step_indices`, so a single source of truth.
- **Tests** — 41 new unit tests under `tests/unit/nodes/` (synthetic 4×4×4 lattice + 3-DOF DISPLACEMENT fixture, no on-disk dependency).

## Test plan

- [x] `pytest tests/unit/nodes` → 41/41 passing
- [x] `pytest tests/unit/elements` → 76/76 still passing (cross-imports OK)
- [x] Full unit suite → 556 passing / 1 skipped (skip is unrelated, fixture-missing)
- [x] End-to-end smoke: `ds.nodes.select().at_level('z', zmax) → get_nodal_results(selector=…) → nr.where().magnitude('DISPLACEMENT').peak().gt(0) → nr[mask]` against the `elasticFrame/results` fixture
- [x] `mkdocs build` clean (8.7s, no warnings about missing references)

## Notes

- No version bump in this PR; happy to roll into a `1.3.0` cut later (this batch + the element pipeline merged in #53 together would be the natural release).
- No public API removed or renamed — backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)