### PR TITLE
Harden CDataReader: fail-fast on parse errors, fix NNODES=0 bug

### DIFF
--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -1,7 +1,10 @@
 
 
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
+
 import numpy as np
 
 
@@ -11,6 +14,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+SelectionSetIdsArg = Union[int, "np.integer", list, None]
+
+
 class CDataReader:
     """Canonical Layer 3 reader for MPCO ``.cdata`` sidecar files.
 
@@ -18,148 +24,150 @@ class CDataReader:
     this module; new code should prefer ``CDataReader``.
     """
 
-    def __init__(self, dataset:'MPCODataSet'):
+    def __init__(self, dataset: "MPCODataSet"):
         self.dataset = dataset
-    
-    def _extract_selection_set_ids_for_file(self, file_path:str, selection_set_ids=None):
-        """
-        Extracts selection set IDs and associated data (nodes and elements) from the given file using NumPy for optimization.
+
+    def _extract_selection_set_ids_for_file(
+        self,
+        file_path: str,
+        selection_set_ids: SelectionSetIdsArg = None,
+    ) -> list[dict]:
+        """Parse all ``*SELECTION_SET`` blocks from a single ``.cdata`` file.
 
         Args:
-            file_path (str): Path to the .cdata file.
-            selection_set_ids (list, optional): List of selection set IDs to extract. If None, process all.
+            file_path: Path to the ``.cdata`` file.
+            selection_set_ids: Optional ID filter. If ``None``, every set is
+                parsed.
 
         Returns:
-            list: A list of dictionaries containing selection set data.
+            List of dicts, one per selection set, each with keys
+            ``SET_ID``, ``SET_NAME``, ``NODES`` (numpy ``int`` array),
+            ``ELEMENTS`` (numpy ``int`` array). ``NODES``/``ELEMENTS``
+            keys are absent when the count is zero.
+
+        Raises:
+            OSError: If the file cannot be opened.
+            ValueError, IndexError: If the file is malformed. The
+                original traceback is logged with file context.
         """
-        
-        if isinstance(selection_set_ids, (int, float)):
-            selection_set_ids = [selection_set_ids]
-        
+        if isinstance(selection_set_ids, (int, np.integer)):
+            selection_set_ids = [int(selection_set_ids)]
+
         if selection_set_ids is not None and not isinstance(selection_set_ids, list):
             raise ValueError("CData Error: selection_set_ids must be a list of integers or None.")
-        
-        selection_sets = []  # Store extracted data
+
+        selection_sets: list[dict] = []
 
         try:
-            with open(file_path, 'r') as file:
-                lines = file.readlines()
+            # errors="replace" guards against non-UTF-8 bytes in the file
+            # (e.g. comments emitted by a legacy STKO build) without
+            # silently dropping legitimate UTF-8 selection-set names.
+            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()
 
-                # Convert lines to a NumPy array for efficient slicing
-                lines_array = np.array(lines, dtype=str)
+            for i, line in enumerate(lines):
+                if line.strip() != "*SELECTION_SET":
+                    continue
 
-                # Iterate through lines to find *SELECTION_SET
-                for i, line in enumerate(lines_array):
-                    if line.strip() == "*SELECTION_SET":
-                        # Get SET_ID info
-                        set_id = int(lines_array[i + 1].strip())
-
-                        # Skip if this selection set ID is not in the provided list
-                        if selection_set_ids is not None and set_id not in selection_set_ids:
-                            continue
-
-                        # Extract the SET_NAME, keeping only the name
-                        raw_set_name = lines_array[i + 2].strip()
-                        name_length = int(raw_set_name.split()[0])  # Extract the length of the name
-                        set_name = raw_set_name[len(str(name_length)) + 1 : len(str(name_length)) + 1 + name_length]  # Extract the actual name
-                        
-                        number_of_nodes = int(lines_array[i + 3].strip())
-                        number_of_elements = int(lines_array[i + 4].strip())
-
-                        # Initialize selection set data
-                        selection_set = {
-                            "SET_ID": set_id,
-                            "SET_NAME": set_name,
-                        }
-
-                        # Extract nodes if number_of_nodes > 0
-                        if number_of_nodes > 0:
-                            nodes_start_line = i + 5
-                            nodes_end_line = nodes_start_line + (number_of_nodes + 9) // 10
-                            node_lines = lines_array[nodes_start_line:nodes_end_line]
-                            # Combine and convert to a NumPy array
-                            selection_set["NODES"] = np.fromstring(" ".join(node_lines).strip(), sep=" ", dtype=int)
-
-                        # Extract elements if number_of_elements > 0
-                        if number_of_elements > 0:
-                            elements_start_line = nodes_end_line
-                            elements_end_line = elements_start_line + (number_of_elements + 9) // 10
-                            element_lines = lines_array[elements_start_line:elements_end_line]
-                            # Combine and convert to a NumPy array
-                            selection_set["ELEMENTS"] = np.fromstring(" ".join(element_lines).strip(), sep=" ", dtype=int)
-
-                        # Add the parsed selection set to the list
-                        selection_sets.append(selection_set)
-
-        except Exception as e:
-            print(f"CData Error processing file {file_path}: {e}")
-            return []
-
-        return selection_sets
-    
-    def _extract_selection_set_ids(self, selection_set_ids=None):
-        """
-        
-        Aggregates nodes and elements while maintaining the structure of each selection set.
-
-        Args:
-            fileName (str): Name of the `.cdata` file to process.
-            selection_set_ids (list, optional): List of selection set IDs to extract. If None, all sets are included.
-
-        Returns:
-            dict: A dictionary where each key is a selection set ID, and the value is another dictionary
-                containing 'SET_NAME', 'NODES', and 'ELEMENTS'.
-        """
-        if isinstance(selection_set_ids, (int, float)):
-            selection_set_ids = [selection_set_ids]
-        
-        if selection_set_ids is not None and not isinstance(selection_set_ids, list):
-            raise ValueError("selection_set_ids must be a list of integers or None.")
-
-        aggregated_data = {}
-
-        # Get the list of `.cdata` files
-        file_mapping = self.dataset.cdata_partitions
-
-        for id, file_path in file_mapping.items():
-            # Extract selection sets for the current file
-            selection_sets = self._extract_selection_set_ids_for_file(file_path, selection_set_ids=selection_set_ids)
-
-            # Aggregate each selection set by its SET_ID
-            for selection_set in selection_sets:
-                set_id = selection_set["SET_ID"]
-
-                # Skip if the set ID is not in the provided list
+                set_id = int(lines[i + 1].strip())
                 if selection_set_ids is not None and set_id not in selection_set_ids:
                     continue
 
+                raw_set_name = lines[i + 2].strip()
+                name_length = int(raw_set_name.split()[0])
+                offset = len(str(name_length)) + 1
+                set_name = raw_set_name[offset : offset + name_length]
+
+                number_of_nodes = int(lines[i + 3].strip())
+                number_of_elements = int(lines[i + 4].strip())
+
+                selection_set: dict = {"SET_ID": set_id, "SET_NAME": set_name}
+
+                # Elements come right after the (possibly empty) nodes
+                # block. Initialize unconditionally so NNODES=0 with
+                # NELEMENTS>0 doesn't reference an unbound name.
+                elements_start_line = i + 5
+
+                if number_of_nodes > 0:
+                    nodes_end_line = elements_start_line + (number_of_nodes + 9) // 10
+                    node_lines = lines[elements_start_line:nodes_end_line]
+                    selection_set["NODES"] = np.fromstring(
+                        " ".join(node_lines).strip(), sep=" ", dtype=int
+                    )
+                    elements_start_line = nodes_end_line
+
+                if number_of_elements > 0:
+                    elements_end_line = elements_start_line + (number_of_elements + 9) // 10
+                    element_lines = lines[elements_start_line:elements_end_line]
+                    selection_set["ELEMENTS"] = np.fromstring(
+                        " ".join(element_lines).strip(), sep=" ", dtype=int
+                    )
+
+                selection_sets.append(selection_set)
+
+        except Exception:
+            # Re-raise so the dataset fails loudly at construction;
+            # silently returning [] used to mask broken cdata files
+            # until a downstream selection-set query crashed.
+            logger.exception("CData parse error in %s", file_path)
+            raise
+
+        return selection_sets
+
+    def _extract_selection_set_ids(
+        self,
+        selection_set_ids: SelectionSetIdsArg = None,
+    ) -> dict[int, dict]:
+        """Aggregate selection sets across every ``.cdata`` partition.
+
+        Args:
+            selection_set_ids: Optional ID filter. If ``None``, every set
+                from every partition is aggregated.
+
+        Returns:
+            Dict mapping ``set_id -> {"SET_NAME": str, "NODES": list[int],
+            "ELEMENTS": list[int]}``. Member lists are sorted and
+            deduplicated across partitions.
+        """
+        if isinstance(selection_set_ids, (int, np.integer)):
+            selection_set_ids = [int(selection_set_ids)]
+
+        if selection_set_ids is not None and not isinstance(selection_set_ids, list):
+            raise ValueError("selection_set_ids must be a list of integers or None.")
+
+        aggregated_data: dict[int, dict] = {}
+        file_mapping = self.dataset.cdata_partitions
+
+        for file_path in file_mapping.values():
+            selection_sets = self._extract_selection_set_ids_for_file(
+                file_path, selection_set_ids=selection_set_ids
+            )
+
+            for selection_set in selection_sets:
+                set_id = selection_set["SET_ID"]
+
                 if set_id not in aggregated_data:
-                    # Initialize a new entry for this selection set
                     aggregated_data[set_id] = {
                         "SET_NAME": selection_set["SET_NAME"],
                         "NODES": set(selection_set.get("NODES", [])),
                         "ELEMENTS": set(selection_set.get("ELEMENTS", [])),
                     }
                 else:
-                    # Update existing entry by merging nodes and elements
                     aggregated_data[set_id]["NODES"].update(selection_set.get("NODES", []))
                     aggregated_data[set_id]["ELEMENTS"].update(selection_set.get("ELEMENTS", []))
 
-        # Convert sets to sorted lists for final output
         for set_id in aggregated_data:
             aggregated_data[set_id]["NODES"] = sorted(aggregated_data[set_id]["NODES"])
             aggregated_data[set_id]["ELEMENTS"] = sorted(aggregated_data[set_id]["ELEMENTS"])
 
         return aggregated_data
-    
-    def print_selection_set_names(self):
-        """
-        Prints the names of all available selection sets.
-        """
+
+    def print_selection_set_names(self) -> None:
+        """Emit names of all available selection sets at INFO level."""
         selection_sets = self.dataset.selection_set
-        print('Available selection sets:')
-        for key in selection_sets.keys():
-            print(f'Set id:{key} - Set name: {selection_sets[key]["SET_NAME"]}')
+        logger.info("Available selection sets:")
+        for key, payload in selection_sets.items():
+            logger.info("  Set id: %s - Set name: %s", key, payload["SET_NAME"])
 
 
 # The legacy ``CData`` alias lives on the ``STKO_to_python.model``

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -1,0 +1,209 @@
+"""Unit tests for the CDataReader text parser.
+
+The parser is exercised directly against synthetic .cdata files on disk;
+``MPCODataSet`` is bypassed because the reader only needs
+``dataset.cdata_partitions``.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from STKO_to_python.model.cdata_reader import CDataReader
+
+
+def _ids_block(ids: list[int]) -> str:
+    """Render an id list as the cdata wraps it: ten ids per line."""
+    chunks = [
+        " ".join(str(x) for x in ids[start : start + 10])
+        for start in range(0, len(ids), 10)
+    ]
+    body = "\n".join(chunks)
+    return body + "\n" if ids else ""
+
+
+def _make_reader(tmp_path, *cdata_texts: str) -> CDataReader:
+    partitions = {}
+    for idx, text in enumerate(cdata_texts):
+        path = tmp_path / f"results.part-{idx}.mpco.cdata"
+        path.write_text(text, encoding="utf-8")
+        partitions[idx] = str(path)
+    return CDataReader(SimpleNamespace(cdata_partitions=partitions))
+
+
+def test_single_partition_simple_set(tmp_path) -> None:
+    text = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "12 ControlPoint\n"
+        "1\n"
+        "0\n"
+        "624\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert set(sets.keys()) == {1}
+    assert sets[1]["SET_NAME"] == "ControlPoint"
+    assert sets[1]["NODES"] == [624]
+    assert sets[1]["ELEMENTS"] == []
+
+
+def test_wrapped_multiline_node_list(tmp_path) -> None:
+    """25 nodes wrap to 3 lines (10/10/5) — pins the (n+9)//10 math."""
+    nodes = list(range(1, 26))
+    text = (
+        "*SELECTION_SET\n"
+        "7\n"
+        "10 Many_Nodes\n"
+        f"{len(nodes)}\n"
+        "0\n"
+        f"{_ids_block(nodes)}"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[7]["NODES"] == nodes
+
+
+def test_nodes_and_elements(tmp_path) -> None:
+    nodes = [10, 20, 30]
+    elements = list(range(100, 115))  # 15 elements -> 2 lines
+    text = (
+        "*SELECTION_SET\n"
+        "9\n"
+        "4 Both\n"
+        f"{len(nodes)}\n"
+        f"{len(elements)}\n"
+        f"{_ids_block(nodes)}"
+        f"{_ids_block(elements)}"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[9]["NODES"] == nodes
+    assert sets[9]["ELEMENTS"] == elements
+
+
+def test_zero_nodes_zero_elements(tmp_path) -> None:
+    """A set with no members keeps its name (matches real AbsorbingBoundary)."""
+    text = (
+        "*SELECTION_SET\n"
+        "21\n"
+        "17 AbsorbingBoundary\n"
+        "0\n"
+        "0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[21]["SET_NAME"] == "AbsorbingBoundary"
+    assert sets[21]["NODES"] == []
+    assert sets[21]["ELEMENTS"] == []
+
+
+def test_zero_nodes_with_elements(tmp_path) -> None:
+    """Regression: NNODES=0 + NELEMENTS>0 previously referenced an
+    unbound ``nodes_end_line`` and raised UnboundLocalError.
+    """
+    elements = [100, 200, 300]
+    text = (
+        "*SELECTION_SET\n"
+        "11\n"
+        "8 ElemOnly\n"
+        "0\n"
+        f"{len(elements)}\n"
+        f"{_ids_block(elements)}"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[11]["NODES"] == []
+    assert sets[11]["ELEMENTS"] == elements
+
+
+def test_no_selection_set_section(tmp_path) -> None:
+    """A .cdata file without any *SELECTION_SET (matches elasticFrame example)
+    yields an empty dict, not an error.
+    """
+    text = (
+        "#Begin LOCAL AXES definitions.\n"
+        "*LOCAL_AXES\n"
+        "1 0 0.707107 0 0.707107\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert reader._extract_selection_set_ids() == {}
+
+
+def test_multi_partition_aggregation(tmp_path) -> None:
+    """Same SET_ID across partitions merges members and dedupes."""
+    part0 = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "4 Roof\n"
+        "3\n"
+        "0\n"
+        "1 2 3\n"
+    )
+    part1 = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "4 Roof\n"
+        "2\n"
+        "0\n"
+        "3 4\n"  # 3 is a duplicate across partitions
+    )
+    reader = _make_reader(tmp_path, part0, part1)
+    sets = reader._extract_selection_set_ids()
+    assert sets[1]["NODES"] == [1, 2, 3, 4]
+    assert sets[1]["SET_NAME"] == "Roof"
+
+
+def test_filter_by_selection_set_ids(tmp_path) -> None:
+    text = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "1 A\n"
+        "1\n"
+        "0\n"
+        "100\n"
+        "*SELECTION_SET\n"
+        "2\n"
+        "1 B\n"
+        "1\n"
+        "0\n"
+        "200\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids(selection_set_ids=[2])
+    assert set(sets.keys()) == {2}
+
+
+def test_malformed_file_raises_not_silent(tmp_path) -> None:
+    """Truncated SELECTION_SET block bubbles up instead of silently
+    returning {}; otherwise downstream queries fail far from the cause.
+    """
+    text = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "1 A\n"
+        # missing NNODES, NELEMENTS, and data
+    )
+    reader = _make_reader(tmp_path, text)
+    with pytest.raises(Exception):
+        reader._extract_selection_set_ids()
+
+
+def test_parse_errors_logged_not_printed(tmp_path, caplog) -> None:
+    """Error path uses ``logger.exception``, not ``print``."""
+    text = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "1 A\n"
+        # truncated
+    )
+    reader = _make_reader(tmp_path, text)
+    with caplog.at_level(logging.ERROR, logger="STKO_to_python.model.cdata_reader"):
+        with pytest.raises(Exception):
+            reader._extract_selection_set_ids()
+    assert any(
+        rec.name == "STKO_to_python.model.cdata_reader" and rec.levelno >= logging.ERROR
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary

The `.cdata` selection-set parser silently returned `[]` on any exception, printed errors via stdout instead of the module logger, and crashed with `UnboundLocalError` when a set had zero nodes but non-zero elements. This PR hardens the reader without changing the public dict shape.

- Re-raise parse errors (after `logger.exception` with file context) so a malformed cdata file fails dataset construction instead of producing a half-populated `selection_set` dict that breaks downstream queries far from the cause.
- Initialize `elements_start_line` unconditionally — fixes the NNODES=0 + NELEMENTS>0 latent crash.
- Open files with `encoding="utf-8", errors="replace"` to avoid cp1252 decode failures on Windows when cdata files contain non-ASCII bytes.
- Drop the `np.array(lines)` wrapping. A fixed-width `U`-array allocation that didn't speed up any operation in the function; iterate the list directly.
- Use `logger.info` in `print_selection_set_names` for consistency with sibling readers.
- Remove the redundant `selection_set_ids` filter in the aggregator (the per-file helper already filters).
- Fix stale docstring referencing a `fileName` arg that does not exist on `_extract_selection_set_ids`.

## Scope

Public API and dict shape are unchanged: `MPCODataSet.selection_set` is still `{set_id -> {"SET_NAME", "NODES" (sorted list), "ELEMENTS" (sorted list)}}`. `CDataReader.__init__` still takes a dataset. The friend-method names (`_extract_selection_set_ids`, `_extract_selection_set_ids_for_file`) are unchanged.

Not in this PR (intentionally — separate work):
- Parsing the other `.cdata` sections (`*LOCAL_AXES`, `*ELEMENT_INFO`, `*BEAM_PROFILE*`, `*SECTION_OFFSET`).
- Making `selection_set` a `cached_property` instead of an eager field.
- A `CDataFormatPolicy` to abstract section tokens and the 10-ids-per-line wrap width.

## Test plan

- [x] `python -m pytest tests/unit/test_cdata_reader.py -v` — 10 new tests pass:
  - simple single-set, wrapped multi-line ids, nodes+elements
  - zero-nodes+zero-elements (degenerate set)
  - zero-nodes + non-zero-elements (regression)
  - no `*SELECTION_SET` section (matches `elasticFrame` example)
  - multi-partition aggregation with dedup
  - id filter
  - malformed file raises (not silent)
  - logger-not-print contract
- [x] `python -m pytest tests/unit -q` — 566 passed, 1 skipped (the skip is a missing fixture, unrelated).
- [x] Real-file smoke check against `examples/New/results_nodes.mpco.cdata` produces identical output to pre-patch (34 sets, same names and counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)