### PR TITLE
Parse *LOCAL_AXES, *SECTION_OFFSET, *ELEMENT_INFO from .cdata

### DIFF
--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -10,7 +10,7 @@ from .elements.element_results import ElementResults
 from .elements.selector import ElementSelector
 from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
-from .model.cdata_reader import CDataReader
+from .model.cdata_reader import CDataReader, ElementInfo
 
 from .plotting.plot import Plot
 from .plotting.plot_settings import PlotSettings
@@ -40,6 +40,7 @@ __all__ = [
     "HDF5Utils",
     "ModelInfo",
     "CData",
+    "ElementInfo",
     "Nodes",
     "Elements",
     "ElementResults",

--- a/src/STKO_to_python/model/__init__.py
+++ b/src/STKO_to_python/model/__init__.py
@@ -1,5 +1,5 @@
 from .model_info_reader import ModelInfoReader
-from .cdata_reader import CDataReader
+from .cdata_reader import CDataReader, ElementInfo
 
 # Back-compat aliases preserved on the package surface (quiet); the
 # deep paths ``STKO_to_python.model.model_info.ModelInfo`` and
@@ -13,4 +13,5 @@ __all__ = [
     "ModelInfoReader",
     "CData",
     "CDataReader",
+    "ElementInfo",
 ]

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -1,8 +1,31 @@
+"""Reader for MPCO ``.cdata`` sidecar files.
 
+The ``.cdata`` text file is STKO's companion to ``.mpco`` results. It
+carries model metadata that does not live in HDF5:
 
+- ``*SELECTION_SET`` — named groups of nodes / elements (also exposed
+  via :class:`SelectionSetResolver`).
+- ``*LOCAL_AXES`` — per-element rotation quaternion (element-local
+  frame relative to global).
+- ``*SECTION_OFFSET`` — per-element section-centroid offset in
+  element-local 2D coords.
+- ``*ELEMENT_INFO`` — parent geometry / sub-geometry / physical and
+  element property metadata per element. Enables "select by geometry"
+  workflows without pre-defined selection sets.
+- ``*BEAM_PROFILE`` and ``*BEAM_PROFILE_ASSIGNMENT`` — present in the
+  file but not yet parsed by this reader.
+
+``CDataReader`` does a single pass over every partition the first time
+any accessor is touched. ``MPCODataSet`` constructs the reader eagerly
+and queries ``_extract_selection_set_ids`` during ``__init__``, so in
+practice the parse happens at dataset-construction time and every
+accessor is then O(1).
+"""
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
@@ -14,160 +37,330 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-SelectionSetIdsArg = Union[int, "np.integer", list, None]
+SelectionSetIdsArg = Union[int, np.integer, list, None]
 
+
+# ---------------------------------------------------------------------- #
+# Structured records
+# ---------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class ElementInfo:
+    """Parent-geometry and property metadata for one element.
+
+    Mirrors a single ``*ELEMENT_INFO`` row. Names can contain spaces
+    (e.g. ``"New physical property"``); STKO emits them with explicit
+    length prefixes which the parser handles transparently.
+    """
+    element_id: int
+    geom_id: int
+    geom_name: str
+    sub_geom_idx: int
+    sub_geom_type: str           # "Edge" | "Face" | "Solid" | ...
+    physical_property_id: int
+    physical_property_name: str
+    element_property_id: int
+    element_property_name: str
+
+
+# ---------------------------------------------------------------------- #
+# Low-level parsing helpers (module-private; testable directly)
+# ---------------------------------------------------------------------- #
+
+def _read_length_prefixed(rest: str) -> tuple[str, str]:
+    """Consume a ``LENGTH NAME`` pair from the start of *rest*.
+
+    STKO encodes name fields as ``LENGTH NAME`` where ``LENGTH`` is the
+    character count of ``NAME`` (which may itself contain spaces, e.g.
+    ``"21 New physical property"``).
+
+    Returns ``(name, remainder)`` where ``remainder`` has the
+    name's trailing separator space stripped.
+    """
+    space_idx = rest.find(" ")
+    if space_idx == -1:
+        raise ValueError(f"Expected '<len> <name>' pair, got: {rest!r}")
+    length = int(rest[:space_idx])
+    name_start = space_idx + 1
+    name_end = name_start + length
+    name = rest[name_start:name_end]
+    remaining = rest[name_end:]
+    if remaining.startswith(" "):
+        remaining = remaining[1:]
+    return name, remaining
+
+
+def _read_section_lines(lines: list[str], start: int) -> tuple[list[str], int]:
+    """Return ``(data_lines, end_index)`` for the section beginning at *start*.
+
+    Sections terminate at the first blank line, ``*`` marker, or EOF.
+    Each data line is right-stripped of whitespace; the leading marker
+    line itself is the caller's responsibility (not included in *start*).
+    """
+    data: list[str] = []
+    i = start
+    n = len(lines)
+    while i < n:
+        s = lines[i].rstrip()
+        if not s:
+            break
+        if s.startswith("*"):
+            break
+        data.append(s)
+        i += 1
+    return data, i
+
+
+# ---------------------------------------------------------------------- #
+# CDataReader
+# ---------------------------------------------------------------------- #
 
 class CDataReader:
     """Canonical Layer 3 reader for MPCO ``.cdata`` sidecar files.
 
-    The legacy name ``CData`` is preserved as an alias at the bottom of
-    this module; new code should prefer ``CDataReader``.
+    Parsing happens lazily on first access to any accessor (or eagerly
+    when ``MPCODataSet`` calls ``_extract_selection_set_ids`` during
+    construction). All sections share one file pass per partition.
+
+    The legacy name ``CData`` is preserved as a quiet alias on the
+    package surface; the deep import path emits ``DeprecationWarning``.
     """
 
     def __init__(self, dataset: "MPCODataSet"):
         self.dataset = dataset
+        # Single-pass cache. None until first access; populated by
+        # `_parse_all_files`.
+        self._parsed: Optional[dict] = None
 
-    def _extract_selection_set_ids_for_file(
-        self,
-        file_path: str,
-        selection_set_ids: SelectionSetIdsArg = None,
-    ) -> list[dict]:
-        """Parse all ``*SELECTION_SET`` blocks from a single ``.cdata`` file.
+    # ------------------------------------------------------------------ #
+    # Public read-only views (lazy)
+    # ------------------------------------------------------------------ #
 
-        Args:
-            file_path: Path to the ``.cdata`` file.
-            selection_set_ids: Optional ID filter. If ``None``, every set is
-                parsed.
+    @cached_property
+    def local_axes(self) -> dict[int, np.ndarray]:
+        """``{elem_id -> [qw, qx, qy, qz]}`` per-element rotation quaternion.
 
-        Returns:
-            List of dicts, one per selection set, each with keys
-            ``SET_ID``, ``SET_NAME``, ``NODES`` (numpy ``int`` array),
-            ``ELEMENTS`` (numpy ``int`` array). ``NODES``/``ELEMENTS``
-            keys are absent when the count is zero.
-
-        Raises:
-            OSError: If the file cannot be opened.
-            ValueError, IndexError: If the file is malformed. The
-                original traceback is logged with file context.
+        The quaternion rotates from element-local to global coordinates.
+        Useful for interpreting beam force/moment results that STKO
+        emits in the local frame.
         """
-        if isinstance(selection_set_ids, (int, np.integer)):
-            selection_set_ids = [int(selection_set_ids)]
+        return self._parse_all_files()["local_axes"]
 
-        if selection_set_ids is not None and not isinstance(selection_set_ids, list):
-            raise ValueError("CData Error: selection_set_ids must be a list of integers or None.")
+    @cached_property
+    def section_offsets(self) -> dict[int, np.ndarray]:
+        """``{elem_id -> [yOffset, zOffset]}`` in element-local coords.
 
-        selection_sets: list[dict] = []
+        Distance from the integration axis to the section centroid;
+        relevant for moment computations about the geometric centerline.
+        """
+        return self._parse_all_files()["section_offsets"]
 
-        try:
-            # errors="replace" guards against non-UTF-8 bytes in the file
-            # (e.g. comments emitted by a legacy STKO build) without
-            # silently dropping legitimate UTF-8 selection-set names.
-            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
-                lines = f.readlines()
+    @cached_property
+    def element_info(self) -> dict[int, ElementInfo]:
+        """``{elem_id -> ElementInfo}`` parent geometry & property metadata.
 
-            for i, line in enumerate(lines):
-                if line.strip() != "*SELECTION_SET":
-                    continue
+        Lets callers select elements by STKO geometry/property names
+        rather than relying on pre-built selection sets.
+        """
+        return self._parse_all_files()["element_info"]
 
-                set_id = int(lines[i + 1].strip())
-                if selection_set_ids is not None and set_id not in selection_set_ids:
-                    continue
-
-                raw_set_name = lines[i + 2].strip()
-                name_length = int(raw_set_name.split()[0])
-                offset = len(str(name_length)) + 1
-                set_name = raw_set_name[offset : offset + name_length]
-
-                number_of_nodes = int(lines[i + 3].strip())
-                number_of_elements = int(lines[i + 4].strip())
-
-                selection_set: dict = {"SET_ID": set_id, "SET_NAME": set_name}
-
-                # Elements come right after the (possibly empty) nodes
-                # block. Initialize unconditionally so NNODES=0 with
-                # NELEMENTS>0 doesn't reference an unbound name.
-                elements_start_line = i + 5
-
-                if number_of_nodes > 0:
-                    nodes_end_line = elements_start_line + (number_of_nodes + 9) // 10
-                    node_lines = lines[elements_start_line:nodes_end_line]
-                    selection_set["NODES"] = np.fromstring(
-                        " ".join(node_lines).strip(), sep=" ", dtype=int
-                    )
-                    elements_start_line = nodes_end_line
-
-                if number_of_elements > 0:
-                    elements_end_line = elements_start_line + (number_of_elements + 9) // 10
-                    element_lines = lines[elements_start_line:elements_end_line]
-                    selection_set["ELEMENTS"] = np.fromstring(
-                        " ".join(element_lines).strip(), sep=" ", dtype=int
-                    )
-
-                selection_sets.append(selection_set)
-
-        except Exception:
-            # Re-raise so the dataset fails loudly at construction;
-            # silently returning [] used to mask broken cdata files
-            # until a downstream selection-set query crashed.
-            logger.exception("CData parse error in %s", file_path)
-            raise
-
-        return selection_sets
+    # ------------------------------------------------------------------ #
+    # Selection-set surface (eager from MPCODataSet.__init__)
+    # ------------------------------------------------------------------ #
 
     def _extract_selection_set_ids(
         self,
         selection_set_ids: SelectionSetIdsArg = None,
     ) -> dict[int, dict]:
-        """Aggregate selection sets across every ``.cdata`` partition.
+        """Aggregate ``*SELECTION_SET`` blocks across every partition.
 
         Args:
-            selection_set_ids: Optional ID filter. If ``None``, every set
-                from every partition is aggregated.
+            selection_set_ids: Optional ID filter. If ``None``, every
+                set from every partition is aggregated.
 
         Returns:
-            Dict mapping ``set_id -> {"SET_NAME": str, "NODES": list[int],
-            "ELEMENTS": list[int]}``. Member lists are sorted and
-            deduplicated across partitions.
+            A fresh dict mapping ``set_id -> {"SET_NAME": str,
+            "NODES": list[int], "ELEMENTS": list[int]}``. Member lists
+            are sorted and deduplicated across partitions. Safe to
+            mutate without disturbing the reader's cache.
         """
         if isinstance(selection_set_ids, (int, np.integer)):
             selection_set_ids = [int(selection_set_ids)]
-
         if selection_set_ids is not None and not isinstance(selection_set_ids, list):
             raise ValueError("selection_set_ids must be a list of integers or None.")
 
-        aggregated_data: dict[int, dict] = {}
-        file_mapping = self.dataset.cdata_partitions
-
-        for file_path in file_mapping.values():
-            selection_sets = self._extract_selection_set_ids_for_file(
-                file_path, selection_set_ids=selection_set_ids
-            )
-
-            for selection_set in selection_sets:
-                set_id = selection_set["SET_ID"]
-
-                if set_id not in aggregated_data:
-                    aggregated_data[set_id] = {
-                        "SET_NAME": selection_set["SET_NAME"],
-                        "NODES": set(selection_set.get("NODES", [])),
-                        "ELEMENTS": set(selection_set.get("ELEMENTS", [])),
-                    }
-                else:
-                    aggregated_data[set_id]["NODES"].update(selection_set.get("NODES", []))
-                    aggregated_data[set_id]["ELEMENTS"].update(selection_set.get("ELEMENTS", []))
-
-        for set_id in aggregated_data:
-            aggregated_data[set_id]["NODES"] = sorted(aggregated_data[set_id]["NODES"])
-            aggregated_data[set_id]["ELEMENTS"] = sorted(aggregated_data[set_id]["ELEMENTS"])
-
-        return aggregated_data
+        cached = self._parse_all_files()["selection_sets"]
+        if selection_set_ids is None:
+            wanted = cached.keys()
+        else:
+            wanted = set(selection_set_ids) & cached.keys()
+        return {
+            sid: {
+                "SET_NAME": cached[sid]["SET_NAME"],
+                "NODES": list(cached[sid]["NODES"]),
+                "ELEMENTS": list(cached[sid]["ELEMENTS"]),
+            }
+            for sid in wanted
+        }
 
     def print_selection_set_names(self) -> None:
         """Emit names of all available selection sets at INFO level."""
-        selection_sets = self.dataset.selection_set
+        sets = self.dataset.selection_set
         logger.info("Available selection sets:")
-        for key, payload in selection_sets.items():
+        for key, payload in sets.items():
             logger.info("  Set id: %s - Set name: %s", key, payload["SET_NAME"])
+
+    # ------------------------------------------------------------------ #
+    # Parsing internals
+    # ------------------------------------------------------------------ #
+
+    def _parse_all_files(self) -> dict:
+        """Single-pass parse across every partition; cached on ``self``."""
+        if self._parsed is not None:
+            return self._parsed
+
+        accum: dict = {
+            "selection_sets": {},      # int -> {"SET_NAME": str, "NODES": set, "ELEMENTS": set}
+            "local_axes": {},          # int -> ndarray(4,)
+            "section_offsets": {},     # int -> ndarray(2,)
+            "element_info": {},        # int -> ElementInfo
+        }
+        for file_path in self.dataset.cdata_partitions.values():
+            self._parse_file_into(file_path, accum)
+
+        # Finalize: convert member sets to sorted lists for the
+        # selection-set payload. Done once, post-aggregation.
+        for payload in accum["selection_sets"].values():
+            payload["NODES"] = sorted(payload["NODES"])
+            payload["ELEMENTS"] = sorted(payload["ELEMENTS"])
+
+        self._parsed = accum
+        return accum
+
+    def _parse_file_into(self, file_path: str, accum: dict) -> None:
+        """Single-pass parse of one ``.cdata`` file into *accum*.
+
+        Re-raises after logging on any failure so the dataset fails
+        loudly at construction; silent ``return``s used to mask broken
+        cdata files until a downstream selection-set query crashed.
+        """
+        try:
+            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()
+
+            i = 0
+            n = len(lines)
+            while i < n:
+                marker = lines[i].strip()
+                if marker == "*SELECTION_SET":
+                    i = self._parse_one_selection_set(lines, i, accum["selection_sets"])
+                elif marker == "*LOCAL_AXES":
+                    i = self._parse_local_axes(lines, i + 1, accum["local_axes"])
+                elif marker == "*SECTION_OFFSET":
+                    i = self._parse_section_offset(lines, i + 1, accum["section_offsets"])
+                elif marker == "*ELEMENT_INFO":
+                    i = self._parse_element_info(lines, i + 1, accum["element_info"])
+                else:
+                    i += 1
+        except Exception:
+            logger.exception("CData parse error in %s", file_path)
+            raise
+
+    # --- per-section parsers ----------------------------------------- #
+
+    @staticmethod
+    def _parse_one_selection_set(lines: list[str], i: int, out: dict) -> int:
+        """Parse one ``*SELECTION_SET`` block; return index after the block."""
+        set_id = int(lines[i + 1].strip())
+
+        raw_name = lines[i + 2].strip()
+        name_length = int(raw_name.split()[0])
+        offset = len(str(name_length)) + 1
+        set_name = raw_name[offset : offset + name_length]
+
+        n_nodes = int(lines[i + 3].strip())
+        n_elems = int(lines[i + 4].strip())
+
+        # Elements come right after the (possibly empty) nodes block.
+        # Initialize unconditionally so NNODES=0 + NELEMENTS>0 doesn't
+        # reference an unbound name.
+        cursor = i + 5
+
+        nodes: np.ndarray = np.empty(0, dtype=int)
+        if n_nodes > 0:
+            end = cursor + (n_nodes + 9) // 10
+            nodes = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
+            cursor = end
+
+        elements: np.ndarray = np.empty(0, dtype=int)
+        if n_elems > 0:
+            end = cursor + (n_elems + 9) // 10
+            elements = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
+            cursor = end
+
+        if set_id in out:
+            out[set_id]["NODES"].update(int(x) for x in nodes)
+            out[set_id]["ELEMENTS"].update(int(x) for x in elements)
+        else:
+            out[set_id] = {
+                "SET_NAME": set_name,
+                "NODES": set(int(x) for x in nodes),
+                "ELEMENTS": set(int(x) for x in elements),
+            }
+        return cursor
+
+    @staticmethod
+    def _parse_local_axes(lines: list[str], i: int, out: dict) -> int:
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            parts = line.split()
+            elem_id = int(parts[0])
+            out[elem_id] = np.array([float(x) for x in parts[1:5]], dtype=float)
+        return end
+
+    @staticmethod
+    def _parse_section_offset(lines: list[str], i: int, out: dict) -> int:
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            parts = line.split()
+            elem_id = int(parts[0])
+            out[elem_id] = np.array([float(x) for x in parts[1:3]], dtype=float)
+        return end
+
+    @staticmethod
+    def _parse_element_info(lines: list[str], i: int, out: dict) -> int:
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            tokens = line.split(" ", 2)
+            elem_id = int(tokens[0])
+            geom_id = int(tokens[1])
+            rest = tokens[2]
+
+            geom_name, rest = _read_length_prefixed(rest)
+
+            sub_idx_str, sub_type, rest = rest.split(" ", 2)
+            sub_geom_idx = int(sub_idx_str)
+
+            pp_id_str, rest = rest.split(" ", 1)
+            pp_id = int(pp_id_str)
+            pp_name, rest = _read_length_prefixed(rest)
+
+            ep_id_str, rest = rest.split(" ", 1)
+            ep_id = int(ep_id_str)
+            ep_name, _ = _read_length_prefixed(rest)
+
+            out[elem_id] = ElementInfo(
+                element_id=elem_id,
+                geom_id=geom_id,
+                geom_name=geom_name,
+                sub_geom_idx=sub_geom_idx,
+                sub_geom_type=sub_type,
+                physical_property_id=pp_id,
+                physical_property_name=pp_name,
+                element_property_id=ep_id,
+                element_property_name=ep_name,
+            )
+        return end
 
 
 # The legacy ``CData`` alias lives on the ``STKO_to_python.model``
@@ -175,6 +368,3 @@ class CDataReader:
 # ``STKO_to_python.model.cdata`` (DeprecationWarning via PEP 562
 # ``__getattr__`` shim). It is intentionally not declared on this
 # canonical module so that the library never trips its own warning.
-
-
-

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -11,7 +11,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from STKO_to_python.model.cdata_reader import CDataReader
+import numpy as np
+
+from STKO_to_python.model.cdata_reader import (
+    CDataReader,
+    ElementInfo,
+    _read_length_prefixed,
+)
 
 
 def _ids_block(ids: list[int]) -> str:
@@ -207,3 +213,197 @@ def test_parse_errors_logged_not_printed(tmp_path, caplog) -> None:
         rec.name == "STKO_to_python.model.cdata_reader" and rec.levelno >= logging.ERROR
         for rec in caplog.records
     )
+
+
+# ---------------------------------------------------------------------- #
+# *LOCAL_AXES
+# ---------------------------------------------------------------------- #
+
+def test_local_axes_parses(tmp_path) -> None:
+    text = (
+        "*LOCAL_AXES\n"
+        "1 0 0.707107 0 0.707107\n"
+        "2 1 0 0 0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    axes = reader.local_axes
+    assert set(axes.keys()) == {1, 2}
+    np.testing.assert_allclose(axes[1], [0, 0.707107, 0, 0.707107])
+    np.testing.assert_allclose(axes[2], [1, 0, 0, 0])
+
+
+def test_local_axes_multi_partition_merge(tmp_path) -> None:
+    """Each partition owns disjoint elements; the merged dict covers both."""
+    part0 = "*LOCAL_AXES\n1 1 0 0 0\n"
+    part1 = "*LOCAL_AXES\n2 0 1 0 0\n"
+    reader = _make_reader(tmp_path, part0, part1)
+    axes = reader.local_axes
+    assert set(axes.keys()) == {1, 2}
+
+
+def test_local_axes_terminator_blank_line(tmp_path) -> None:
+    """The blank line that separates sections must end the LOCAL_AXES block."""
+    text = (
+        "*LOCAL_AXES\n"
+        "1 1 0 0 0\n"
+        "\n"
+        "#Begin SECTION OFFSET definitions.\n"
+        "*SECTION_OFFSET\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert set(reader.local_axes.keys()) == {1}
+
+
+# ---------------------------------------------------------------------- #
+# *SECTION_OFFSET
+# ---------------------------------------------------------------------- #
+
+def test_section_offset_parses(tmp_path) -> None:
+    text = (
+        "*SECTION_OFFSET\n"
+        "5 1.5 -2.0\n"
+        "6 0 0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    offsets = reader.section_offsets
+    np.testing.assert_allclose(offsets[5], [1.5, -2.0])
+    np.testing.assert_allclose(offsets[6], [0, 0])
+
+
+def test_section_offset_empty_section(tmp_path) -> None:
+    """STKO emits *SECTION_OFFSET with no data when nothing is offset
+    (matches the elasticFrame and QuadFrame examples).
+    """
+    text = (
+        "*SECTION_OFFSET\n"
+        "\n"
+        "#Begin BEAM PROFILE definitions.\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert reader.section_offsets == {}
+
+
+# ---------------------------------------------------------------------- #
+# *ELEMENT_INFO + length-prefixed name helper
+# ---------------------------------------------------------------------- #
+
+def test_read_length_prefixed_simple() -> None:
+    name, rest = _read_length_prefixed("5 Merge 0 Edge")
+    assert name == "Merge"
+    assert rest == "0 Edge"
+
+
+def test_read_length_prefixed_name_with_spaces() -> None:
+    """STKO encodes 'LENGTH NAME' with LENGTH = char count of NAME,
+    so embedded spaces in the name are preserved.
+    """
+    name, rest = _read_length_prefixed("21 New physical property 4 2 Q4")
+    assert name == "New physical property"
+    assert rest == "4 2 Q4"
+
+
+def test_read_length_prefixed_at_end_of_string() -> None:
+    name, rest = _read_length_prefixed("4 None")
+    assert name == "None"
+    assert rest == ""
+
+
+def test_element_info_parses(tmp_path) -> None:
+    """Mirrors the elasticFrame example row format."""
+    text = (
+        "*ELEMENT_INFO\n"
+        "1 7 5 Merge 0 Edge 1 7 elastic 2 14 elasticBeamCol\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    info = reader.element_info
+    assert set(info.keys()) == {1}
+    ei = info[1]
+    assert ei.element_id == 1
+    assert ei.geom_id == 7
+    assert ei.geom_name == "Merge"
+    assert ei.sub_geom_idx == 0
+    assert ei.sub_geom_type == "Edge"
+    assert ei.physical_property_id == 1
+    assert ei.physical_property_name == "elastic"
+    assert ei.element_property_id == 2
+    assert ei.element_property_name == "elasticBeamCol"
+
+
+def test_element_info_property_name_with_spaces(tmp_path) -> None:
+    """Property names can contain spaces (e.g. 'New physical property')."""
+    text = (
+        "*ELEMENT_INFO\n"
+        "498 9 5 Merge 0 Face 4 21 New physical property 4 2 Q4\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    ei = reader.element_info[498]
+    assert ei.geom_name == "Merge"
+    assert ei.sub_geom_type == "Face"
+    assert ei.physical_property_id == 4
+    assert ei.physical_property_name == "New physical property"
+    assert ei.element_property_id == 4
+    assert ei.element_property_name == "Q4"
+
+
+def test_element_info_returns_dataclass(tmp_path) -> None:
+    text = (
+        "*ELEMENT_INFO\n"
+        "1 7 5 Merge 0 Edge 0 4 None 0 4 None\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert isinstance(reader.element_info[1], ElementInfo)
+
+
+# ---------------------------------------------------------------------- #
+# Multi-section single-pass
+# ---------------------------------------------------------------------- #
+
+def test_single_pass_parses_all_sections_one_file(tmp_path) -> None:
+    """The driver dispatches markers in a single pass over the file."""
+    text = (
+        "#Begin LOCAL AXES.\n"
+        "*LOCAL_AXES\n"
+        "1 1 0 0 0\n"
+        "\n"
+        "*SECTION_OFFSET\n"
+        "1 10 20\n"
+        "\n"
+        "*ELEMENT_INFO\n"
+        "1 7 5 Merge 0 Edge 0 4 None 0 4 None\n"
+        "\n"
+        "*SELECTION_SET\n"
+        "1\n"
+        "4 Roof\n"
+        "2\n"
+        "0\n"
+        "10 20\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()  # triggers eager parse
+    assert sets[1]["NODES"] == [10, 20]
+    np.testing.assert_allclose(reader.local_axes[1], [1, 0, 0, 0])
+    np.testing.assert_allclose(reader.section_offsets[1], [10, 20])
+    assert reader.element_info[1].geom_name == "Merge"
+
+
+def test_real_quadframe_partitions(tmp_path) -> None:
+    """Smoke test against the committed multi-partition example: every
+    section that exists in the file must populate without error.
+    """
+    import os.path
+    here = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    base = os.path.join(here, "stko_results_examples", "elasticFrame", "QuadFrame_results")
+    p0 = os.path.join(base, "results.part-0.mpco.cdata")
+    p1 = os.path.join(base, "results.part-1.mpco.cdata")
+    if not (os.path.exists(p0) and os.path.exists(p1)):
+        pytest.skip("QuadFrame example not present in this checkout")
+
+    reader = CDataReader(SimpleNamespace(cdata_partitions={0: p0, 1: p1}))
+    # Each row in *LOCAL_AXES is one element; partitions should not
+    # overlap, so the merged dict has at least as many entries as either.
+    assert len(reader.local_axes) > 0
+    assert all(arr.shape == (4,) for arr in reader.local_axes.values())
+    # SECTION_OFFSET is empty in the example.
+    assert reader.section_offsets == {}
+    # ELEMENT_INFO covers every element with *LOCAL_AXES.
+    assert len(reader.element_info) >= len(reader.local_axes)


### PR DESCRIPTION
> Stacked on top of #57. Once #57 merges, this PR auto-retargets to `main` — or I can manually retarget if preferred.

## Summary

The `.cdata` sidecar carries five rich metadata sections; until now the reader only parsed `*SELECTION_SET`. This PR adds parsing for three more sections via a single-pass file scanner, with lazy `cached_property` accessors:

```python
reader.local_axes       # {elem_id: ndarray([qw, qx, qy, qz])}
reader.section_offsets  # {elem_id: ndarray([yOff, zOff])}
reader.element_info     # {elem_id: ElementInfo(geom_name=..., sub_geom_type=...,
                        #                       physical_property_name=..., element_property_name=..., ...)}
```

`element_info` in particular unlocks "select by STKO geometry / property name" workflows without requiring users to pre-define selection sets.

### Verified on the bundled 95k-line example

- 69,551 elements indexed across `local_axes` and `element_info`
- Distinct geometry names recovered: `'Merge'`, `'Sweep'`, `'soil_field_foundation'`, `'soil_field_walls'`, `'structure_soil_foundation'`, `'structure_soil_walls'`
- Distinct physical-property names recovered: `'BasementsWalls_Elastic'`, `'C70x70_Elastic'`, `'Foundation_Elastic'`, `'ShearWalls_Elastic'`, `'Slab_Elastic'`, `'SoilElastic'`, ...

## Design notes

- `ElementInfo` is a frozen dataclass re-exported at the package surface (`STKO_to_python.ElementInfo`).
- Property and geometry names can contain spaces (e.g. `"New physical property"`); STKO encodes them as `LENGTH NAME` pairs where `LENGTH` is the character count. A `_read_length_prefixed` helper handles this and is unit-tested directly.
- Sections terminate at the first blank line or `*` marker. A `_read_section_lines` helper centralizes that contract.
- The selection-set parser is now part of the same single-pass scan, so dataset construction parses every section in one read instead of multiple. `_extract_selection_set_ids` preserves its dict-shape contract (verified — all 10 existing tests still pass).

## Scope

In:
- `*LOCAL_AXES`, `*SECTION_OFFSET`, `*ELEMENT_INFO`
- `ElementInfo` dataclass + re-exports
- Single-pass parser scaffold

Out (deferred):
- `*BEAM_PROFILE` and `*BEAM_PROFILE_ASSIGNMENT` — structured sub-blocks (NPOINTS / NTRIANGLES / NEDGES / NSWEEPS with variable-length per-edge data), warrants its own design pass for the `BeamProfile` dataclass shape.
- Making the selection-set parse lazy. Today it's still eagerly triggered by `MPCODataSet.__init__`, which is also why the new accessors end up being eagerly populated. Decoupling that needs `SelectionSetResolver` to take the reader directly (per the refactor proposal §6) and is a bigger change.

## Test plan

- [x] `python -m pytest tests/unit/test_cdata_reader.py -v` — 23 tests pass:
  - 10 existing tests continue to pass (selection-set contract preserved through the single-pass refactor)
  - 13 new tests: local-axes parse + multi-partition merge + blank-line terminator; section-offset parse + empty-section; `_read_length_prefixed` in 3 shapes; element_info simple parse + name-with-spaces parse + dataclass return type; single-pass multi-section parse; real-file smoke test against the bundled `QuadFrame_results` partitions
- [x] `python -m pytest tests/unit -q` — 579 passed, 1 skipped (pre-existing skip)
- [x] Smoke test against `examples/New/results_nodes.mpco.cdata` (95k lines, 34 selection sets, 69,551 elements) — all accessors populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)