### PR TITLE
Parse *BEAM_PROFILE and *BEAM_PROFILE_ASSIGNMENT from .cdata

### DIFF
--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -10,7 +10,7 @@ from .elements.element_results import ElementResults
 from .elements.selector import ElementSelector
 from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
-from .model.cdata_reader import CDataReader, ElementInfo
+from .model.cdata_reader import BeamProfile, CDataReader, ElementInfo
 
 from .plotting.plot import Plot
 from .plotting.plot_settings import PlotSettings
@@ -41,6 +41,7 @@ __all__ = [
     "ModelInfo",
     "CData",
     "ElementInfo",
+    "BeamProfile",
     "Nodes",
     "Elements",
     "ElementResults",

--- a/src/STKO_to_python/model/__init__.py
+++ b/src/STKO_to_python/model/__init__.py
@@ -1,5 +1,5 @@
 from .model_info_reader import ModelInfoReader
-from .cdata_reader import CDataReader, ElementInfo
+from .cdata_reader import BeamProfile, CDataReader, ElementInfo
 
 # Back-compat aliases preserved on the package surface (quiet); the
 # deep paths ``STKO_to_python.model.model_info.ModelInfo`` and
@@ -14,4 +14,5 @@ __all__ = [
     "CData",
     "CDataReader",
     "ElementInfo",
+    "BeamProfile",
 ]

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -12,8 +12,11 @@ carries model metadata that does not live in HDF5:
 - ``*ELEMENT_INFO`` — parent geometry / sub-geometry / physical and
   element property metadata per element. Enables "select by geometry"
   workflows without pre-defined selection sets.
-- ``*BEAM_PROFILE`` and ``*BEAM_PROFILE_ASSIGNMENT`` — present in the
-  file but not yet parsed by this reader.
+- ``*BEAM_PROFILE`` — 2D cross-section geometry (points, triangles,
+  edges, sweeps) per profile id. Useful for plotting beam elements
+  as extruded solids.
+- ``*BEAM_PROFILE_ASSIGNMENT`` — element-id to profile-id mapping
+  with weights, expressing variable cross-section along an element.
 
 ``CDataReader`` does a single pass over every partition the first time
 any accessor is touched. ``MPCODataSet`` constructs the reader eagerly
@@ -61,6 +64,28 @@ class ElementInfo:
     physical_property_name: str
     element_property_id: int
     element_property_name: str
+
+
+@dataclass(frozen=True)
+class BeamProfile:
+    """2D cross-section geometry for a beam element profile.
+
+    Mirrors one block inside a ``*BEAM_PROFILE`` section.
+
+    - ``points`` are vertices in the section's local 2D frame.
+    - ``triangles`` is a triangulation of the section (for filled
+      rendering); each row is three 0-based point indices.
+    - ``edges`` is the outline as a list of polyline edges; each
+      edge is a 0-based ``ndarray`` of point indices, length varies
+      per edge (STKO supports curved/multi-point edges).
+    - ``sweeps`` indexes the points to sweep along the beam (for
+      generating an extruded 3D mesh).
+    """
+    profile_id: int
+    points: np.ndarray           # (npoints, 2) — x, y in section frame
+    triangles: np.ndarray        # (ntriangles, 3) — 0-based point indices
+    edges: list[np.ndarray]      # one (n_i,) array per edge, n_i varies
+    sweeps: np.ndarray           # (nsweeps,) — 0-based point indices
 
 
 # ---------------------------------------------------------------------- #
@@ -164,6 +189,28 @@ class CDataReader:
         """
         return self._parse_all_files()["element_info"]
 
+    @cached_property
+    def beam_profiles(self) -> dict[int, BeamProfile]:
+        """``{profile_id -> BeamProfile}`` 2D cross-section definitions.
+
+        Each entry holds the section's points, triangulation, edge
+        outline, and sweep indices. Profile definitions are typically
+        repeated identically across MP partitions; only the first
+        occurrence is kept.
+        """
+        return self._parse_all_files()["beam_profiles"]
+
+    @cached_property
+    def beam_profile_assignments(self) -> dict[int, list[tuple[int, float]]]:
+        """``{elem_id -> [(profile_id, weight), ...]}`` element → profile map.
+
+        Each tuple is one profile assigned to the element with a
+        weight in ``[0, 1]`` expressing relative span along the
+        element. The ``beam_profiles`` accessor resolves ``profile_id``
+        to the underlying cross-section geometry.
+        """
+        return self._parse_all_files()["beam_profile_assignments"]
+
     # ------------------------------------------------------------------ #
     # Selection-set surface (eager from MPCODataSet.__init__)
     # ------------------------------------------------------------------ #
@@ -220,10 +267,12 @@ class CDataReader:
             return self._parsed
 
         accum: dict = {
-            "selection_sets": {},      # int -> {"SET_NAME": str, "NODES": set, "ELEMENTS": set}
-            "local_axes": {},          # int -> ndarray(4,)
-            "section_offsets": {},     # int -> ndarray(2,)
-            "element_info": {},        # int -> ElementInfo
+            "selection_sets": {},              # int -> {"SET_NAME": str, "NODES": set, "ELEMENTS": set}
+            "local_axes": {},                  # int -> ndarray(4,)
+            "section_offsets": {},             # int -> ndarray(2,)
+            "element_info": {},                # int -> ElementInfo
+            "beam_profiles": {},               # int -> BeamProfile
+            "beam_profile_assignments": {},    # int -> list[tuple[int, float]]
         }
         for file_path in self.dataset.cdata_partitions.values():
             self._parse_file_into(file_path, accum)
@@ -258,6 +307,12 @@ class CDataReader:
                     i = self._parse_local_axes(lines, i + 1, accum["local_axes"])
                 elif marker == "*SECTION_OFFSET":
                     i = self._parse_section_offset(lines, i + 1, accum["section_offsets"])
+                elif marker == "*BEAM_PROFILE":
+                    i = self._parse_beam_profiles(lines, i + 1, accum["beam_profiles"])
+                elif marker == "*BEAM_PROFILE_ASSIGNMENT":
+                    i = self._parse_beam_profile_assignments(
+                        lines, i + 1, accum["beam_profile_assignments"]
+                    )
                 elif marker == "*ELEMENT_INFO":
                     i = self._parse_element_info(lines, i + 1, accum["element_info"])
                 else:
@@ -325,6 +380,84 @@ class CDataReader:
             parts = line.split()
             elem_id = int(parts[0])
             out[elem_id] = np.array([float(x) for x in parts[1:3]], dtype=float)
+        return end
+
+    @staticmethod
+    def _parse_beam_profiles(lines: list[str], i: int, out: dict) -> int:
+        """Parse one ``*BEAM_PROFILE`` section (may contain N profiles back-to-back).
+
+        Per-profile layout:
+            PROFILE_ID
+            NPOINTS NTRIANGLES NEDGES NSWEEPS
+            <NPOINTS rows of (x y)>
+            <NTRIANGLES rows of (p1 p2 p3)>
+            <NEDGES rows of (N p1 p2 ... pN)>     # variable length
+            <NSWEEPS rows of (p1)>
+        """
+        data, end = _read_section_lines(lines, i)
+        cursor = 0
+        n = len(data)
+        while cursor < n:
+            profile_id = int(data[cursor].strip())
+            cursor += 1
+            counts = [int(x) for x in data[cursor].split()]
+            n_pts, n_tris, n_edges, n_sweeps = counts[:4]
+            cursor += 1
+
+            points = np.array(
+                [[float(v) for v in data[cursor + k].split()] for k in range(n_pts)],
+                dtype=float,
+            )
+            cursor += n_pts
+
+            triangles = np.array(
+                [[int(v) for v in data[cursor + k].split()] for k in range(n_tris)],
+                dtype=int,
+            )
+            cursor += n_tris
+
+            edges: list[np.ndarray] = []
+            for _ in range(n_edges):
+                parts = [int(x) for x in data[cursor].split()]
+                # parts[0] is N (count of points in this edge), parts[1:N+1] are the indices.
+                edges.append(np.array(parts[1 : 1 + parts[0]], dtype=int))
+                cursor += 1
+
+            sweeps = np.array(
+                [int(data[cursor + k].strip()) for k in range(n_sweeps)],
+                dtype=int,
+            )
+            cursor += n_sweeps
+
+            # Profile definitions are duplicated identically across MP
+            # partitions; keep the first occurrence and drop later ones.
+            if profile_id not in out:
+                out[profile_id] = BeamProfile(
+                    profile_id=profile_id,
+                    points=points,
+                    triangles=triangles,
+                    edges=edges,
+                    sweeps=sweeps,
+                )
+        return end
+
+    @staticmethod
+    def _parse_beam_profile_assignments(lines: list[str], i: int, out: dict) -> int:
+        """Parse a ``*BEAM_PROFILE_ASSIGNMENT`` section.
+
+        Each row is ``ELEM_ID N_PROFILES PID_1 WEIGHT_1 ... PID_N WEIGHT_N``.
+        """
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            parts = line.split()
+            elem_id = int(parts[0])
+            n_prof = int(parts[1])
+            assignments: list[tuple[int, float]] = []
+            for k in range(n_prof):
+                pid = int(parts[2 + 2 * k])
+                weight = float(parts[3 + 2 * k])
+                assignments.append((pid, weight))
+            out[elem_id] = assignments
         return end
 
     @staticmethod

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -14,6 +14,7 @@ import pytest
 import numpy as np
 
 from STKO_to_python.model.cdata_reader import (
+    BeamProfile,
     CDataReader,
     ElementInfo,
     _read_length_prefixed,
@@ -407,3 +408,145 @@ def test_real_quadframe_partitions(tmp_path) -> None:
     assert reader.section_offsets == {}
     # ELEMENT_INFO covers every element with *LOCAL_AXES.
     assert len(reader.element_info) >= len(reader.local_axes)
+    # Beam profile 1 (the rectangular section) exists in both partitions
+    # — dedup should produce exactly one entry.
+    assert 1 in reader.beam_profiles
+    p1 = reader.beam_profiles[1]
+    assert p1.points.shape == (4, 2)
+    # Every beam element in the file has a profile assignment.
+    assert len(reader.beam_profile_assignments) > 0
+
+
+# ---------------------------------------------------------------------- #
+# *BEAM_PROFILE
+# ---------------------------------------------------------------------- #
+
+# Rectangular 4-point profile with 2 triangles, 4 straight edges, 4 sweep
+# points. Mirrors the bundled elasticFrame example exactly.
+_RECT_PROFILE = (
+    "*BEAM_PROFILE\n"
+    "1\n"
+    "4 2 4 4\n"
+    "-150 -200\n"
+    "150 -200\n"
+    "150 200\n"
+    "-150 200\n"
+    "0 1 2\n"
+    "0 2 3\n"
+    "2 0 1\n"
+    "2 1 2\n"
+    "2 2 3\n"
+    "2 3 0\n"
+    "0\n"
+    "1\n"
+    "2\n"
+    "3\n"
+)
+
+
+def test_beam_profile_rectangle_parses(tmp_path) -> None:
+    reader = _make_reader(tmp_path, _RECT_PROFILE)
+    profiles = reader.beam_profiles
+    assert set(profiles.keys()) == {1}
+
+    p = profiles[1]
+    assert isinstance(p, BeamProfile)
+    assert p.profile_id == 1
+    np.testing.assert_allclose(
+        p.points, [[-150, -200], [150, -200], [150, 200], [-150, 200]]
+    )
+    np.testing.assert_array_equal(p.triangles, [[0, 1, 2], [0, 2, 3]])
+    # All 4 edges are 2-point edges around the rectangle outline.
+    assert len(p.edges) == 4
+    np.testing.assert_array_equal(p.edges[0], [0, 1])
+    np.testing.assert_array_equal(p.edges[3], [3, 0])
+    np.testing.assert_array_equal(p.sweeps, [0, 1, 2, 3])
+
+
+def test_beam_profile_variable_length_edges(tmp_path) -> None:
+    """An edge with more than 2 points (curved outline)."""
+    text = (
+        "*BEAM_PROFILE\n"
+        "5\n"
+        "3 1 2 1\n"
+        "0 0\n"
+        "1 0\n"
+        "0 1\n"
+        "0 1 2\n"        # 1 triangle
+        "3 0 1 2\n"      # edge with 3 points
+        "2 2 0\n"        # edge with 2 points
+        "0\n"            # 1 sweep
+    )
+    reader = _make_reader(tmp_path, text)
+    p = reader.beam_profiles[5]
+    assert len(p.edges) == 2
+    np.testing.assert_array_equal(p.edges[0], [0, 1, 2])
+    np.testing.assert_array_equal(p.edges[1], [2, 0])
+
+
+def test_beam_profile_multiple_profiles_in_one_section(tmp_path) -> None:
+    """A *BEAM_PROFILE section can carry several profile blocks back-to-back."""
+    text = (
+        "*BEAM_PROFILE\n"
+        # profile 1: 2 points, 0 tris, 1 edge (2-point), 0 sweeps
+        "1\n"
+        "2 0 1 0\n"
+        "0 0\n"
+        "1 0\n"
+        "2 0 1\n"
+        # profile 2: 3 points, 1 tri, 0 edges, 1 sweep
+        "2\n"
+        "3 1 0 1\n"
+        "0 0\n"
+        "1 0\n"
+        "0 1\n"
+        "0 1 2\n"
+        "0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert set(reader.beam_profiles.keys()) == {1, 2}
+    assert reader.beam_profiles[1].points.shape == (2, 2)
+    assert reader.beam_profiles[2].triangles.shape == (1, 3)
+
+
+def test_beam_profile_multi_partition_dedup_first_wins(tmp_path) -> None:
+    """Profile defs are duplicated identically across MP partitions; keep one."""
+    reader = _make_reader(tmp_path, _RECT_PROFILE, _RECT_PROFILE)
+    assert set(reader.beam_profiles.keys()) == {1}
+
+
+# ---------------------------------------------------------------------- #
+# *BEAM_PROFILE_ASSIGNMENT
+# ---------------------------------------------------------------------- #
+
+def test_beam_profile_assignment_simple(tmp_path) -> None:
+    text = (
+        "*BEAM_PROFILE_ASSIGNMENT\n"
+        "1 1 1 1\n"
+        "2 1 1 1\n"
+        "3 1 2 0.5\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    a = reader.beam_profile_assignments
+    assert a[1] == [(1, 1.0)]
+    assert a[2] == [(1, 1.0)]
+    assert a[3] == [(2, 0.5)]
+
+
+def test_beam_profile_assignment_multiple_profiles_per_element(tmp_path) -> None:
+    """An element can carry multiple profiles, modelling a tapered section."""
+    text = (
+        "*BEAM_PROFILE_ASSIGNMENT\n"
+        "1 2 1 0.3 2 0.7\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert reader.beam_profile_assignments[1] == [(1, 0.3), (2, 0.7)]
+
+
+def test_beam_profile_assignment_multi_partition(tmp_path) -> None:
+    """Each element is owned by exactly one partition; merging is dict-union."""
+    part0 = "*BEAM_PROFILE_ASSIGNMENT\n1 1 1 1\n2 1 1 1\n"
+    part1 = "*BEAM_PROFILE_ASSIGNMENT\n3 1 1 1\n4 1 1 1\n"
+    reader = _make_reader(tmp_path, part0, part1)
+    a = reader.beam_profile_assignments
+    assert set(a.keys()) == {1, 2, 3, 4}


### PR DESCRIPTION
> Stacked on top of #58 (which stacks on #57). Will auto-retarget as the lower PRs merge.

## Summary

Adds the remaining two `.cdata` sections to the single-pass parser, completing the metadata coverage started in #58:

```python
reader.beam_profiles               # {profile_id: BeamProfile}
reader.beam_profile_assignments    # {elem_id: [(profile_id, weight), ...]}
```

### `BeamProfile` dataclass

Frozen dataclass holding the cross-section geometry:

| Field | Shape | Meaning |
|---|---|---|
| `points` | `(npoints, 2)` | 2D vertex coords in the section's local frame |
| `triangles` | `(ntriangles, 3)` | 0-based point-index triangulation for filled rendering |
| `edges` | `list[ndarray]` | outline polylines, **variable length per edge** |
| `sweeps` | `(nsweeps,)` | 0-based point indices to sweep along the beam |

Variable-length edges (e.g. a 3-point curved edge) are honestly modeled as `list[np.ndarray]` rather than padded into a fixed-shape 2D array.

### Cross-partition handling

Profile definitions are repeated identically across MP partitions (verified on `QuadFrame_results`). The parser keeps the first occurrence and silently drops later ones. Assignments are owned per-element by one partition, so merging is a straightforward dict union.

### Verified on the bundled 95k-line example

- 1 rectangular profile: 4 points (`[±150, ±200]`), 2 triangles, 4 outline edges, 4 sweep points
- 192 elements with profile assignments
- All consistent with STKO's typical column section emission

## Test plan

- [x] `python -m pytest tests/unit/test_cdata_reader.py -v` — 30 tests pass:
  - 23 existing tests continue to pass (no regressions)
  - 7 new tests: rectangle profile parse (mirrors the elasticFrame example exactly); variable-length curved edges; multiple profiles in a single `*BEAM_PROFILE` section; multi-partition dedup; assignment single-profile + multi-profile-per-element + multi-partition merge
  - The `test_real_quadframe_partitions` smoke test now also asserts beam profiles + assignments populate
- [x] `python -m pytest tests/unit -q` — 586 passed, 1 skipped (pre-existing skip)
- [x] Smoke test against `examples/New/results_nodes.mpco.cdata` confirms 1 profile / 192 assignments end-to-end

## What's left after this PR

With #57 + #58 + #59 merged, every section the `.cdata` file emits is parsed and exposed via lazy `cached_property` accessors. The natural follow-ups (separate PRs, separate review focus):

1. **Lazy selection-set loading.** Today `MPCODataSet.__init__` calls `_extract_selection_set_ids()` eagerly, which triggers the full parse at construction. Decoupling needs `SelectionSetResolver` to take the reader directly (per the refactor proposal §6).
2. **`CDataFormatPolicy`** mirroring `MpcoFormatPolicy` to abstract the section tokens and the 10-ids-per-line wrap width.

Neither is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)