### PR TITLE
Add ElementSelector anchors backed by *ELEMENT_INFO

### DIFF
--- a/src/STKO_to_python/elements/selector.py
+++ b/src/STKO_to_python/elements/selector.py
@@ -307,6 +307,45 @@ def _node_coord_lookup(manager: "ElementManager") -> Optional[_NodeCoordLookup]:
     return cache
 
 
+def _resolve_element_info_filter(
+    manager: "ElementManager", anchor: "_Anchor"
+) -> set[int]:
+    """Intersect every active *ELEMENT_INFO anchor in a single pass.
+
+    Returns the set of element ids whose ``ElementInfo`` matches every
+    anchor field that is set. One pass over ``element_info`` regardless
+    of how many anchor fields are active.
+    """
+    cdata = getattr(manager.dataset, "cdata", None)
+    if cdata is None:
+        raise AttributeError(
+            "Selector uses an element_info anchor but "
+            "dataset.cdata is not available."
+        )
+    element_info = cdata.element_info
+    if not element_info:
+        # Selector resolves to empty rather than raising; consistent
+        # with .of_type() against a class that has no rows.
+        return set()
+
+    matched: set[int] = set()
+    want_geom = anchor.geom_name
+    want_pp = anchor.physical_property_name
+    want_ep = anchor.element_property_name
+    want_sub = anchor.sub_geom_type
+    for eid, ei in element_info.items():
+        if want_geom is not None and ei.geom_name != want_geom:
+            continue
+        if want_pp is not None and ei.physical_property_name != want_pp:
+            continue
+        if want_ep is not None and ei.element_property_name != want_ep:
+            continue
+        if want_sub is not None and ei.sub_geom_type != want_sub:
+            continue
+        matched.add(int(eid))
+    return matched
+
+
 # ---------------------------------------------------------------------- #
 # Anchor — defines the type-bound universe for a selector                #
 # ---------------------------------------------------------------------- #
@@ -316,12 +355,30 @@ class _Anchor:
     of_type: Optional[str] = None
     selection: Optional[Tuple[Any, ...]] = None  # names or set ids
     explicit_ids: Optional[Tuple[int, ...]] = None
+    # .cdata *ELEMENT_INFO anchors (resolved against
+    # ``dataset.cdata.element_info``):
+    geom_name: Optional[str] = None
+    physical_property_name: Optional[str] = None
+    element_property_name: Optional[str] = None
+    sub_geom_type: Optional[str] = None
 
     def is_set(self) -> bool:
         return (
             self.of_type is not None
             or self.selection is not None
             or self.explicit_ids is not None
+            or self.geom_name is not None
+            or self.physical_property_name is not None
+            or self.element_property_name is not None
+            or self.sub_geom_type is not None
+        )
+
+    def has_element_info_filter(self) -> bool:
+        return (
+            self.geom_name is not None
+            or self.physical_property_name is not None
+            or self.element_property_name is not None
+            or self.sub_geom_type is not None
         )
 
     def with_(
@@ -330,6 +387,10 @@ class _Anchor:
         of_type: Optional[str] = None,
         selection: Optional[Tuple[Any, ...]] = None,
         explicit_ids: Optional[Tuple[int, ...]] = None,
+        geom_name: Optional[str] = None,
+        physical_property_name: Optional[str] = None,
+        element_property_name: Optional[str] = None,
+        sub_geom_type: Optional[str] = None,
     ) -> "_Anchor":
         return _Anchor(
             of_type=of_type if of_type is not None else self.of_type,
@@ -338,6 +399,24 @@ class _Anchor:
                 explicit_ids
                 if explicit_ids is not None
                 else self.explicit_ids
+            ),
+            geom_name=(
+                geom_name if geom_name is not None else self.geom_name
+            ),
+            physical_property_name=(
+                physical_property_name
+                if physical_property_name is not None
+                else self.physical_property_name
+            ),
+            element_property_name=(
+                element_property_name
+                if element_property_name is not None
+                else self.element_property_name
+            ),
+            sub_geom_type=(
+                sub_geom_type
+                if sub_geom_type is not None
+                else self.sub_geom_type
             ),
         )
 
@@ -427,6 +506,55 @@ class ElementSelector:
         return ElementSelector(
             self._manager,
             anchor=self._anchor.with_(explicit_ids=existing + arr),
+            ops=self._ops,
+        )
+
+    def of_geometry(self, name: str) -> "ElementSelector":
+        """Anchor universe to elements whose STKO parent geometry has *name*.
+
+        Resolves against ``dataset.cdata.element_info[*].geom_name``.
+        Example: ``select().of_geometry("Slab")``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(geom_name=str(name)),
+            ops=self._ops,
+        )
+
+    def of_physical_property(self, name: str) -> "ElementSelector":
+        """Anchor universe to elements with the named physical (material/section) property.
+
+        Resolves against ``dataset.cdata.element_info[*].physical_property_name``.
+        Example: ``select().of_physical_property("ShearWalls_Elastic")``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(physical_property_name=str(name)),
+            ops=self._ops,
+        )
+
+    def of_element_property(self, name: str) -> "ElementSelector":
+        """Anchor universe to elements with the named element property.
+
+        Resolves against ``dataset.cdata.element_info[*].element_property_name``.
+        Example: ``select().of_element_property("elasticBeamCol")``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(element_property_name=str(name)),
+            ops=self._ops,
+        )
+
+    def of_sub_geom_type(self, geom_type: str) -> "ElementSelector":
+        """Anchor universe to elements whose parent sub-geometry has the given type.
+
+        ``geom_type`` is one of ``"Edge"``, ``"Face"``, ``"Solid"`` (and
+        whatever else STKO emits). Resolves against
+        ``dataset.cdata.element_info[*].sub_geom_type``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(sub_geom_type=str(geom_type)),
             ops=self._ops,
         )
 
@@ -662,6 +790,9 @@ class ElementSelector:
             df = df[df["element_id"].isin(sel_ids)]
         if a.explicit_ids is not None:
             df = df[df["element_id"].isin(a.explicit_ids)]
+        if a.has_element_info_filter():
+            matched = _resolve_element_info_filter(self._manager, a)
+            df = df[df["element_id"].isin(matched)]
         return df
 
     def _universe_ids(self) -> np.ndarray:
@@ -686,6 +817,18 @@ class ElementSelector:
             bits.append(f"from_selection={list(self._anchor.selection)!r}")
         if self._anchor.explicit_ids:
             bits.append(f"with_ids({len(self._anchor.explicit_ids)})")
+        if self._anchor.geom_name:
+            bits.append(f"of_geometry={self._anchor.geom_name!r}")
+        if self._anchor.physical_property_name:
+            bits.append(
+                f"of_physical_property={self._anchor.physical_property_name!r}"
+            )
+        if self._anchor.element_property_name:
+            bits.append(
+                f"of_element_property={self._anchor.element_property_name!r}"
+            )
+        if self._anchor.sub_geom_type:
+            bits.append(f"of_sub_geom_type={self._anchor.sub_geom_type!r}")
         for op in self._ops:
             bits.append(type(op).__name__.strip("_"))
         return f"ElementSelector({', '.join(bits)})"
@@ -806,6 +949,30 @@ class _CombinedSelector(ElementSelector):
         raise TypeError(
             "Cannot call .with_ids() on a combined selector; anchor "
             "each leaf selector before combining."
+        )
+
+    def of_geometry(self, name: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_geometry() on a combined selector; anchor "
+            "each leaf selector before combining."
+        )
+
+    def of_physical_property(self, name: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_physical_property() on a combined selector; "
+            "anchor each leaf selector before combining."
+        )
+
+    def of_element_property(self, name: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_element_property() on a combined selector; "
+            "anchor each leaf selector before combining."
+        )
+
+    def of_sub_geom_type(self, geom_type: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_sub_geom_type() on a combined selector; "
+            "anchor each leaf selector before combining."
         )
 
     def _with_op(self, op: _FilterOp) -> "ElementSelector":

--- a/tests/unit/elements/test_selector.py
+++ b/tests/unit/elements/test_selector.py
@@ -24,6 +24,7 @@ import pandas as pd
 import pytest
 
 from STKO_to_python.elements.selector import ElementSelector
+from STKO_to_python.model.cdata_reader import ElementInfo
 
 
 # ---------------------------------------------------------------------- #
@@ -162,19 +163,39 @@ class _MockSelResolver:
         return np.unique(np.concatenate(gathered))
 
 
+class _MockCData:
+    """Stand-in for ``CDataReader`` exposing just the .element_info dict
+    that the selector touches."""
+
+    def __init__(self, element_info: dict):
+        self.element_info = element_info
+
+
 class _MockDataset:
-    def __init__(self, df_nodes: pd.DataFrame, resolver: _MockSelResolver):
+    def __init__(
+        self,
+        df_nodes: pd.DataFrame,
+        resolver: _MockSelResolver,
+        element_info: Optional[dict] = None,
+    ):
         self.nodes_info = {"dataframe": df_nodes}
         self._selection_resolver = resolver
+        self.cdata = _MockCData(element_info or {})
 
 
 class _MockManager:
     """Stand-in for :class:`ElementManager` exposing only the surface
     that :class:`ElementSelector` touches."""
 
-    def __init__(self, df_elems: pd.DataFrame, df_nodes: pd.DataFrame, resolver):
+    def __init__(
+        self,
+        df_elems: pd.DataFrame,
+        df_nodes: pd.DataFrame,
+        resolver,
+        element_info: Optional[dict] = None,
+    ):
         self._df = df_elems
-        self.dataset = _MockDataset(df_nodes, resolver)
+        self.dataset = _MockDataset(df_nodes, resolver, element_info)
 
     def _ensure_elem_index_df(self) -> pd.DataFrame:
         return self._df
@@ -581,3 +602,197 @@ def test_selectors_are_immutable(mgr: _MockManager):
     assert base.count() == 9
     # a and b cover disjoint x-ranges so produce disjoint id sets.
     assert set(a.ids().tolist()).isdisjoint(set(b.ids().tolist()))
+
+
+# ---------------------------------------------------------------------- #
+# Tests — *ELEMENT_INFO anchors (.of_geometry / .of_physical_property etc) #
+# ---------------------------------------------------------------------- #
+
+
+def _build_element_info() -> dict[int, ElementInfo]:
+    """Annotate every element with parent-geometry + property metadata.
+
+    Beams (ids 1..9):
+      ids 1..3   -> geom "Frame",   physical "Steel_Elastic",    element_prop "elasticBeamCol", Edge
+      ids 4..9   -> geom "Frame",   physical "Concrete_Elastic", element_prop "elasticBeamCol", Edge
+
+    Shells (ids 10..18):
+                  -> geom "Slab",   physical "Slab_Elastic",     element_prop "Q4",            Face
+    """
+    info: dict[int, ElementInfo] = {}
+    for eid in range(1, 10):
+        pp = "Steel_Elastic" if eid <= 3 else "Concrete_Elastic"
+        info[eid] = ElementInfo(
+            element_id=eid,
+            geom_id=1,
+            geom_name="Frame",
+            sub_geom_idx=0,
+            sub_geom_type="Edge",
+            physical_property_id=1,
+            physical_property_name=pp,
+            element_property_id=1,
+            element_property_name="elasticBeamCol",
+        )
+    for eid in range(10, 19):
+        info[eid] = ElementInfo(
+            element_id=eid,
+            geom_id=2,
+            geom_name="Slab",
+            sub_geom_idx=0,
+            sub_geom_type="Face",
+            physical_property_id=2,
+            physical_property_name="Slab_Elastic",
+            element_property_id=2,
+            element_property_name="Q4",
+        )
+    return info
+
+
+@pytest.fixture
+def mgr_with_info() -> _MockManager:
+    """Same geometry as ``mgr`` plus a populated ``cdata.element_info``."""
+    df_elems, df_nodes = _build_index()
+    # Reuse the same two named sets as the main fixture.
+    beam_first = (
+        df_elems[
+            (df_elems["element_type"] == BEAM_TYPE)
+            & (df_elems["centroid_x"] <= 1.0)
+        ]["element_id"]
+        .to_numpy(np.int64)
+    )
+    shell_outer = (
+        df_elems[
+            (df_elems["element_type"] == SHELL_TYPE)
+            & (
+                (df_elems["centroid_x"] < 1.0)
+                | (df_elems["centroid_x"] > 2.0)
+                | (df_elems["centroid_y"] < 11.0)
+                | (df_elems["centroid_y"] > 12.0)
+            )
+        ]["element_id"]
+        .to_numpy(np.int64)
+    )
+    resolver = _MockSelResolver(
+        element_sets={"firstcolumn": beam_first, "outer": shell_outer},
+        id_sets={1: beam_first, 2: shell_outer},
+    )
+    return _MockManager(df_elems, df_nodes, resolver, _build_element_info())
+
+
+def test_of_geometry_filters_to_named_geometry(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_geometry("Slab")
+    ids = set(sel.ids().tolist())
+    assert ids == set(range(10, 19))  # all shells
+
+
+def test_of_physical_property_filters_by_material(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_physical_property("Steel_Elastic")
+    assert sorted(sel.ids().tolist()) == [1, 2, 3]
+
+
+def test_of_element_property_filters_by_element_class_name(
+    mgr_with_info: _MockManager,
+):
+    sel = ElementSelector(mgr_with_info).of_element_property("Q4")
+    assert sorted(sel.ids().tolist()) == list(range(10, 19))
+
+
+def test_of_sub_geom_type_filters_to_topology(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_sub_geom_type("Edge")
+    assert sorted(sel.ids().tolist()) == list(range(1, 10))
+
+
+def test_element_info_anchors_compose_AND(mgr_with_info: _MockManager):
+    """Multiple element_info anchors AND-narrow within a single call chain."""
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_geometry("Frame")
+        .of_physical_property("Concrete_Elastic")
+    )
+    assert sorted(sel.ids().tolist()) == [4, 5, 6, 7, 8, 9]
+
+
+def test_element_info_anchor_composes_with_of_type(mgr_with_info: _MockManager):
+    """``of_type`` and ``of_geometry`` AND-narrow as expected."""
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_type("DispBeamColumn3d")
+        .of_physical_property("Steel_Elastic")
+    )
+    assert sorted(sel.ids().tolist()) == [1, 2, 3]
+
+
+def test_element_info_anchor_composes_with_filter_op(mgr_with_info: _MockManager):
+    """Filter ops apply after the anchor universe is resolved."""
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_geometry("Frame")
+        .within_box(min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 0.5))
+    )
+    # Frame elements within the box: beam ids with centroid_x ∈ {0.5, 1.5}
+    # and centroid_z = 0 → exactly 2 beams (ids 1 and 4 in the fixture).
+    assert sel.count() == 2
+
+
+def test_unknown_geom_name_returns_empty(mgr_with_info: _MockManager):
+    """Unknown names produce empty results (consistent with ``of_type``)."""
+    sel = ElementSelector(mgr_with_info).of_geometry("DoesNotExist")
+    assert sel.count() == 0
+
+
+def test_empty_element_info_returns_empty(mgr: _MockManager):
+    """When dataset.cdata.element_info is empty, anchor resolves to empty."""
+    # The default `mgr` fixture has element_info={}.
+    sel = ElementSelector(mgr).of_geometry("anything")
+    assert sel.count() == 0
+
+
+def test_missing_cdata_attribute_raises(mgr_with_info: _MockManager):
+    """A dataset without ``cdata`` errors with a clear message."""
+    # Drop cdata to simulate an old/exotic dataset shape.
+    del mgr_with_info.dataset.cdata
+    sel = ElementSelector(mgr_with_info).of_geometry("Slab")
+    with pytest.raises(AttributeError, match="cdata"):
+        sel.ids()
+
+
+def test_element_info_anchor_negation_uses_anchor_universe(
+    mgr_with_info: _MockManager,
+):
+    """``~sel`` for an element_info anchor is well-defined: the complement
+    is everything else in the same universe (here, the anchor universe is
+    everything matching the anchor filters, so ``~`` returns everything
+    NOT matching them — which is an empty set if the universe is itself
+    just the match. We use the type universe for clarity).
+    """
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_type("DispBeamColumn3d")
+        .of_physical_property("Steel_Elastic")
+    )
+    # sel: beams 1..3
+    inv = ~sel
+    # Universe is "beams that are Steel_Elastic" = {1,2,3}; complement
+    # within that universe is empty.
+    assert inv.count() == 0
+
+
+def test_element_info_anchor_repr(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_geometry("Slab").of_physical_property(
+        "Slab_Elastic"
+    )
+    r = repr(sel)
+    assert "of_geometry='Slab'" in r
+    assert "of_physical_property='Slab_Elastic'" in r
+
+
+def test_element_info_anchor_blocked_on_combined_selector(
+    mgr_with_info: _MockManager,
+):
+    a = ElementSelector(mgr_with_info).of_type("DispBeamColumn3d")
+    b = ElementSelector(mgr_with_info).of_geometry("Slab")
+    combined = a | b
+    with pytest.raises(TypeError, match="of_geometry"):
+        combined.of_geometry("Frame")
+    with pytest.raises(TypeError, match="of_physical_property"):
+        combined.of_physical_property("Steel_Elastic")


### PR DESCRIPTION
> Stacked on top of #59 (which stacks on #58/#57). Will auto-retarget as the lower PRs merge.

## Summary

This PR is the user-visible payoff for the `.cdata` parsing work in #57–#59. It adds four anchor primitives to `ElementSelector` that resolve against `CDataReader.element_info`:

```python
sel.of_geometry("Slab")
sel.of_physical_property("Slab_Elastic")
sel.of_element_property("elasticBeamCol")
sel.of_sub_geom_type("Face")
```

So callers can now write the "select by STKO geometry / property name" workflow that was the original motivation for parsing `*ELEMENT_INFO`:

```python
sel = (dataset.elements
                .select()
                .of_geometry("Slab")
                .within_box(min=(0, 0, 0), max=(50, 50, 10)))
ids = sel.ids()
```

Multiple element_info anchors AND-narrow within one chain (same semantics as `of_type` / `from_selection`). They compose freely with existing filter ops and the `&` / `|` / `~` combinators.

## Design

- `_Anchor` gets four optional string fields. `is_set()` and `with_(...)` updated accordingly. The dataclass stays frozen, the selector stays immutable.
- A single private helper, `_resolve_element_info_filter`, intersects every active element_info anchor in **one pass** over `element_info` and returns a `set[int]` for the universe DF to filter against. No per-name caching — straight equality on a 70k-entry dict is sub-millisecond.
- Unknown names produce empty results (consistent with `of_type` against an absent class). Missing `dataset.cdata` raises `AttributeError` with a clear message.
- `_CombinedSelector` blocks all four new methods — same rule as `of_type` / `from_selection` / `with_ids`: anchor each leaf before combining.

## Test plan

- [x] `python -m pytest tests/unit/elements/test_selector.py -v` — 45 tests pass:
  - 32 existing tests continue to pass (the existing `_MockDataset` was extended to carry a `.cdata` namespace with `element_info={}`, transparent to current tests)
  - 13 new tests covering: single-field filter for each anchor; AND composition across anchors; composition with `of_type`; composition with `within_box`; unknown name → empty; empty `element_info` → empty; missing `cdata` → `AttributeError`; negation against anchor universe; repr format; combinator-blocking
- [x] `python -m pytest tests/unit -q` — 599 passed, 1 skipped (pre-existing skip)

## What's next

Option B from the plan (lazy `selection_set`, `CDataFormatPolicy`) is up next — internal cleanups, no user-visible behavior. Will open as a separate stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)