### PR TITLE
Add CDataFormatPolicy and make id-list parsing width-agnostic

### DIFF
--- a/src/STKO_to_python/model/cdata_format.py
+++ b/src/STKO_to_python/model/cdata_format.py
@@ -1,0 +1,81 @@
+"""Centralized ``.cdata`` text-format policy.
+
+The ``.cdata`` sidecar (companion to ``.mpco``) is a line-oriented text
+format with a handful of section markers and a few encoding
+conventions (e.g. ``LENGTH NAME`` for names that may contain spaces).
+This module is the single place that owns those format facts.
+
+It mirrors :class:`STKO_to_python.io.format_policy.MpcoFormatPolicy`:
+pure-functional, stateless, safe to share across threads.
+
+See ``docs/architecture-refactor-proposal.md`` §3.1 for the design
+intent shared with the MPCO policy.
+"""
+from __future__ import annotations
+
+
+class CDataFormatPolicy:
+    """Pure-functional knowledge of the ``.cdata`` text-file layout.
+
+    The policy is stateless: section markers and conventions are class
+    attributes; helper queries are ``@staticmethod`` / ``@classmethod``.
+    One instance can be shared across every reader and parser.
+
+    Thread-safety
+    -------------
+    Safe for concurrent access. No mutable state.
+    """
+
+    __slots__ = ()
+
+    # ------------------------------------------------------------------ #
+    # Section marker tokens (the line that opens each section)            #
+    # ------------------------------------------------------------------ #
+
+    MARKER_SELECTION_SET = "*SELECTION_SET"
+    MARKER_LOCAL_AXES = "*LOCAL_AXES"
+    MARKER_SECTION_OFFSET = "*SECTION_OFFSET"
+    MARKER_BEAM_PROFILE = "*BEAM_PROFILE"
+    MARKER_BEAM_PROFILE_ASSIGNMENT = "*BEAM_PROFILE_ASSIGNMENT"
+    MARKER_ELEMENT_INFO = "*ELEMENT_INFO"
+
+    def __repr__(self) -> str:
+        return "CDataFormatPolicy()"
+
+    # ------------------------------------------------------------------ #
+    # Marker queries                                                      #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def known_markers(cls) -> frozenset[str]:
+        """Every section-opening marker this parser recognizes."""
+        return frozenset(
+            {
+                cls.MARKER_SELECTION_SET,
+                cls.MARKER_LOCAL_AXES,
+                cls.MARKER_SECTION_OFFSET,
+                cls.MARKER_BEAM_PROFILE,
+                cls.MARKER_BEAM_PROFILE_ASSIGNMENT,
+                cls.MARKER_ELEMENT_INFO,
+            }
+        )
+
+    @staticmethod
+    def is_section_marker(line: str) -> bool:
+        """True iff *line* (after strip) is a section-opening ``*MARKER`` line.
+
+        Any unrecognized ``*`` line is still treated as a section
+        boundary by the reader; this helper checks for the *known* set.
+        """
+        return line.strip() in CDataFormatPolicy.known_markers()
+
+    @staticmethod
+    def is_any_marker(line: str) -> bool:
+        """True iff *line* (after strip) starts with ``*`` — a section boundary.
+
+        The reader uses this when walking data lines inside a section
+        to detect the start of the next section, even if the marker is
+        one this policy version does not recognize.
+        """
+        s = line.strip()
+        return bool(s) and s.startswith("*")

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -33,6 +33,8 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 
+from .cdata_format import CDataFormatPolicy
+
 
 if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
@@ -136,6 +138,50 @@ def _read_section_lines(lines: list[str], start: int) -> tuple[list[str], int]:
     return data, i
 
 
+def _consume_ids(
+    lines: list[str], start: int, count: int
+) -> tuple[np.ndarray, int]:
+    """Consume exactly *count* integers starting at ``lines[start]``.
+
+    Walks forward across as many lines as needed, regardless of how
+    STKO chose to wrap the list. The current emitter uses 10 ids per
+    line, but this helper is width-agnostic so a hand-edited file
+    (or a future format variant) still parses correctly.
+
+    Returns ``(ndarray, next_index)`` where ``next_index`` is the
+    index of the first line *not* consumed.
+
+    Raises ``ValueError`` if EOF or a section boundary (``*``)
+    is reached before *count* ids have been gathered.
+    """
+    if count == 0:
+        return np.empty(0, dtype=int), start
+
+    collected: list[int] = []
+    i = start
+    n = len(lines)
+    while len(collected) < count:
+        if i >= n:
+            raise ValueError(
+                f"cdata: expected {count} ids, got only {len(collected)} "
+                f"before EOF (started at line {start + 1})."
+            )
+        s = lines[i].strip()
+        if not s or s.startswith("*"):
+            raise ValueError(
+                f"cdata: id list truncated at line {i + 1}; expected "
+                f"{count} ids, got {len(collected)}."
+            )
+        collected.extend(int(x) for x in s.split())
+        i += 1
+
+    # If the last consumed line happened to have more ids than we
+    # needed, trim. STKO doesn't currently emit this shape (its wrap
+    # is exact), but the trim makes us safe against hand-edits.
+    arr = np.array(collected[:count], dtype=int)
+    return arr, i
+
+
 # ---------------------------------------------------------------------- #
 # CDataReader
 # ---------------------------------------------------------------------- #
@@ -150,6 +196,10 @@ class CDataReader:
     The legacy name ``CData`` is preserved as a quiet alias on the
     package surface; the deep import path emits ``DeprecationWarning``.
     """
+
+    # Format policy is stateless and identical for every reader; share
+    # one class-level instance rather than allocating per dataset.
+    _format_policy: CDataFormatPolicy = CDataFormatPolicy()
 
     def __init__(self, dataset: "MPCODataSet"):
         self.dataset = dataset
@@ -297,23 +347,24 @@ class CDataReader:
             with open(file_path, "r", encoding="utf-8", errors="replace") as f:
                 lines = f.readlines()
 
+            policy = self._format_policy
             i = 0
             n = len(lines)
             while i < n:
                 marker = lines[i].strip()
-                if marker == "*SELECTION_SET":
+                if marker == policy.MARKER_SELECTION_SET:
                     i = self._parse_one_selection_set(lines, i, accum["selection_sets"])
-                elif marker == "*LOCAL_AXES":
+                elif marker == policy.MARKER_LOCAL_AXES:
                     i = self._parse_local_axes(lines, i + 1, accum["local_axes"])
-                elif marker == "*SECTION_OFFSET":
+                elif marker == policy.MARKER_SECTION_OFFSET:
                     i = self._parse_section_offset(lines, i + 1, accum["section_offsets"])
-                elif marker == "*BEAM_PROFILE":
+                elif marker == policy.MARKER_BEAM_PROFILE:
                     i = self._parse_beam_profiles(lines, i + 1, accum["beam_profiles"])
-                elif marker == "*BEAM_PROFILE_ASSIGNMENT":
+                elif marker == policy.MARKER_BEAM_PROFILE_ASSIGNMENT:
                     i = self._parse_beam_profile_assignments(
                         lines, i + 1, accum["beam_profile_assignments"]
                     )
-                elif marker == "*ELEMENT_INFO":
+                elif marker == policy.MARKER_ELEMENT_INFO:
                     i = self._parse_element_info(lines, i + 1, accum["element_info"])
                 else:
                     i += 1
@@ -325,7 +376,13 @@ class CDataReader:
 
     @staticmethod
     def _parse_one_selection_set(lines: list[str], i: int, out: dict) -> int:
-        """Parse one ``*SELECTION_SET`` block; return index after the block."""
+        """Parse one ``*SELECTION_SET`` block; return index after the block.
+
+        Node and element id lists are read via ``_consume_ids`` which is
+        width-agnostic — STKO currently wraps at 10 ids per line, but
+        this parser also accepts 1-per-line, all-on-one-line, or any
+        consistent variant.
+        """
         set_id = int(lines[i + 1].strip())
 
         raw_name = lines[i + 2].strip()
@@ -336,22 +393,12 @@ class CDataReader:
         n_nodes = int(lines[i + 3].strip())
         n_elems = int(lines[i + 4].strip())
 
-        # Elements come right after the (possibly empty) nodes block.
-        # Initialize unconditionally so NNODES=0 + NELEMENTS>0 doesn't
-        # reference an unbound name.
+        # Both lists live right after the header; nodes first, elements
+        # second. _consume_ids advances the cursor past whichever lines
+        # the wrap width happened to use.
         cursor = i + 5
-
-        nodes: np.ndarray = np.empty(0, dtype=int)
-        if n_nodes > 0:
-            end = cursor + (n_nodes + 9) // 10
-            nodes = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
-            cursor = end
-
-        elements: np.ndarray = np.empty(0, dtype=int)
-        if n_elems > 0:
-            end = cursor + (n_elems + 9) // 10
-            elements = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
-            cursor = end
+        nodes, cursor = _consume_ids(lines, cursor, n_nodes)
+        elements, cursor = _consume_ids(lines, cursor, n_elems)
 
         if set_id in out:
             out[set_id]["NODES"].update(int(x) for x in nodes)

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -13,10 +13,12 @@ import pytest
 
 import numpy as np
 
+from STKO_to_python.model.cdata_format import CDataFormatPolicy
 from STKO_to_python.model.cdata_reader import (
     BeamProfile,
     CDataReader,
     ElementInfo,
+    _consume_ids,
     _read_length_prefixed,
 )
 
@@ -550,3 +552,147 @@ def test_beam_profile_assignment_multi_partition(tmp_path) -> None:
     reader = _make_reader(tmp_path, part0, part1)
     a = reader.beam_profile_assignments
     assert set(a.keys()) == {1, 2, 3, 4}
+
+
+# ---------------------------------------------------------------------- #
+# CDataFormatPolicy — section marker constants and queries
+# ---------------------------------------------------------------------- #
+
+def test_format_policy_known_markers_covers_every_section() -> None:
+    """Every section the parser dispatches on must be in known_markers().
+
+    Pins the contract: if a new *MARKER is added to the parser, it must
+    also be added to CDataFormatPolicy.
+    """
+    expected = {
+        "*SELECTION_SET",
+        "*LOCAL_AXES",
+        "*SECTION_OFFSET",
+        "*BEAM_PROFILE",
+        "*BEAM_PROFILE_ASSIGNMENT",
+        "*ELEMENT_INFO",
+    }
+    assert CDataFormatPolicy.known_markers() == expected
+
+
+def test_format_policy_is_section_marker_recognizes_known() -> None:
+    assert CDataFormatPolicy.is_section_marker("*SELECTION_SET")
+    assert CDataFormatPolicy.is_section_marker("  *LOCAL_AXES  ")
+    assert not CDataFormatPolicy.is_section_marker("*UNKNOWN")
+    assert not CDataFormatPolicy.is_section_marker("# comment")
+    assert not CDataFormatPolicy.is_section_marker("")
+
+
+def test_format_policy_is_any_marker_flags_arbitrary_star_lines() -> None:
+    """Boundary detection: any '*' line ends a section, recognized or not."""
+    assert CDataFormatPolicy.is_any_marker("*UNKNOWN")
+    assert CDataFormatPolicy.is_any_marker("*ELEMENT_INFO")
+    assert not CDataFormatPolicy.is_any_marker("# comment")
+    assert not CDataFormatPolicy.is_any_marker("")
+
+
+def test_format_policy_is_stateless_and_hashable() -> None:
+    """The policy uses __slots__ = () so instances are interchangeable."""
+    a = CDataFormatPolicy()
+    b = CDataFormatPolicy()
+    assert repr(a) == repr(b) == "CDataFormatPolicy()"
+
+
+# ---------------------------------------------------------------------- #
+# _consume_ids — width-agnostic id list reader
+# ---------------------------------------------------------------------- #
+
+def test_consume_ids_zero_count_is_noop() -> None:
+    lines = ["10 20 30\n"]
+    arr, end = _consume_ids(lines, 0, 0)
+    assert arr.shape == (0,)
+    assert end == 0
+
+
+def test_consume_ids_single_line_default_wrap() -> None:
+    lines = ["1 2 3 4 5 6 7 8 9 10\n", "11 12\n"]
+    arr, end = _consume_ids(lines, 0, 12)
+    assert arr.tolist() == list(range(1, 13))
+    assert end == 2
+
+
+def test_consume_ids_one_per_line() -> None:
+    """Width-agnostic: a file wrapped at 1 id per line still parses."""
+    lines = [f"{x}\n" for x in range(1, 11)]
+    arr, end = _consume_ids(lines, 0, 10)
+    assert arr.tolist() == list(range(1, 11))
+    assert end == 10
+
+
+def test_consume_ids_all_on_one_line() -> None:
+    """Width-agnostic: a file with no wrap (all on one line) still parses."""
+    lines = ["1 2 3 4 5 6 7 8 9 10 11 12 13 14 15\n"]
+    arr, end = _consume_ids(lines, 0, 15)
+    assert arr.tolist() == list(range(1, 16))
+    assert end == 1
+
+
+def test_consume_ids_stops_when_count_reached_in_middle_of_line() -> None:
+    """If the wrap width over-emits on the last line, take only what's needed."""
+    lines = ["1 2 3 4 5\n"]
+    arr, end = _consume_ids(lines, 0, 3)
+    assert arr.tolist() == [1, 2, 3]
+    assert end == 1
+
+
+def test_consume_ids_raises_on_truncation_by_marker() -> None:
+    lines = ["1 2 3\n", "*SELECTION_SET\n"]
+    with pytest.raises(ValueError, match="truncated"):
+        _consume_ids(lines, 0, 10)
+
+
+def test_consume_ids_raises_on_truncation_by_blank() -> None:
+    lines = ["1 2 3\n", "\n", "next section\n"]
+    with pytest.raises(ValueError, match="truncated"):
+        _consume_ids(lines, 0, 10)
+
+
+def test_consume_ids_raises_on_eof() -> None:
+    lines = ["1 2 3\n"]
+    with pytest.raises(ValueError, match="EOF"):
+        _consume_ids(lines, 0, 10)
+
+
+# ---------------------------------------------------------------------- #
+# Selection-set parser is now width-agnostic end-to-end
+# ---------------------------------------------------------------------- #
+
+def test_selection_set_parses_with_one_id_per_line_wrap(tmp_path) -> None:
+    """A file wrapping ids at width=1 should parse identically to width=10."""
+    text = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "4 Test\n"
+        "5\n"           # NNODES = 5
+        "0\n"           # NELEMENTS = 0
+        # 5 nodes, one per line — atypical but legal under the new parser
+        "100\n"
+        "200\n"
+        "300\n"
+        "400\n"
+        "500\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[1]["NODES"] == [100, 200, 300, 400, 500]
+
+
+def test_selection_set_parses_with_all_ids_on_one_line(tmp_path) -> None:
+    """A file with no wrap at all should still parse."""
+    text = (
+        "*SELECTION_SET\n"
+        "2\n"
+        "3 Big\n"
+        "15\n"
+        "0\n"
+        # 15 nodes all on one line — outside the conventional wrap
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[2]["NODES"] == list(range(1, 16))


### PR DESCRIPTION
> Stacked on top of #60 (which stacks on #59/#58/#57). Will auto-retarget as the lower PRs merge.

## Summary

Two related internal improvements to the `.cdata` reader. **No public API or behavior change** — verified against the bundled 95k-line example: 34 sets, 69551 local_axes / element_info entries, 1 beam profile, 192 assignments, all identical to pre-refactor.

### 1. `CDataFormatPolicy` (mirrors `MpcoFormatPolicy`)

Stateless class at [`src/STKO_to_python/model/cdata_format.py`](src/STKO_to_python/model/cdata_format.py) owning the six section marker tokens:

```python
class CDataFormatPolicy:
    MARKER_SELECTION_SET = "*SELECTION_SET"
    MARKER_LOCAL_AXES = "*LOCAL_AXES"
    MARKER_SECTION_OFFSET = "*SECTION_OFFSET"
    MARKER_BEAM_PROFILE = "*BEAM_PROFILE"
    MARKER_BEAM_PROFILE_ASSIGNMENT = "*BEAM_PROFILE_ASSIGNMENT"
    MARKER_ELEMENT_INFO = "*ELEMENT_INFO"
    # plus known_markers(), is_section_marker(), is_any_marker()
```

`CDataReader` holds one class-level instance and uses the policy constants for marker dispatch instead of string literals. When STKO adds a new section, only the policy changes (plus the new parser case).

### 2. Width-agnostic id-list parsing

The selection-set parser previously assumed exactly 10 ids per line via `(n + 9) // 10` line counting (called out as a robustness concern in the original review). A future STKO format change or a hand-edited file with a different wrap would silently produce wrong-sliced data.

Replaced with `_consume_ids(lines, start, count)` which scans forward across as many lines as needed to gather exactly `count` integers, regardless of wrap width. Tested at width 1, width 10, and "all on one line".

Raises `ValueError` on EOF or section-boundary truncation, with a clear "expected N, got M" message — fail-fast consistent with the broader hardening in #57.

## What's deferred

Making `MPCODataSet.selection_set` lazy via `cached_property` was the other half of the original "Option B". Implementing it cleanly requires threading laziness through the query engine constructors (which take the resolver as a positional arg today). That's a bigger refactor that belongs with the architecture-refactor-proposal §6 work rather than alongside contained polish. Noted in the commit message.

## Test plan

- [x] `python -m pytest tests/unit/test_cdata_reader.py -v` — 44 tests pass:
  - 30 existing tests continue to pass (no regressions through the refactor)
  - 14 new tests: 4 for the policy (`known_markers` coverage, `is_section_marker` / `is_any_marker`, `repr`), 8 for `_consume_ids` (zero count, normal wrap, width-1 wrap, no wrap, over-emit trim, 3 error paths), 2 end-to-end (width-1 selection set, no-wrap selection set)
- [x] `python -m pytest tests/unit -q` — 613 passed, 1 skipped (pre-existing skip)
- [x] Smoke test against `examples/New/results_nodes.mpco.cdata` confirms identical output to pre-refactor (34/69551/69551/1/192 counts unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)