### PR TITLE
Land cdata stack on main (PRs #58–#61 content)

### DIFF
--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -10,7 +10,7 @@ from .elements.element_results import ElementResults
 from .elements.selector import ElementSelector
 from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
-from .model.cdata_reader import CDataReader, ElementInfo
+from .model.cdata_reader import BeamProfile, CDataReader, ElementInfo
 
 from .plotting.plot import Plot
 from .plotting.plot_settings import PlotSettings
@@ -41,6 +41,7 @@ __all__ = [
     "ModelInfo",
     "CData",
     "ElementInfo",
+    "BeamProfile",
     "Nodes",
     "Elements",
     "ElementResults",

--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -10,7 +10,7 @@ from .elements.element_results import ElementResults
 from .elements.selector import ElementSelector
 from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
-from .model.cdata_reader import CDataReader
+from .model.cdata_reader import CDataReader, ElementInfo
 
 from .plotting.plot import Plot
 from .plotting.plot_settings import PlotSettings
@@ -40,6 +40,7 @@ __all__ = [
     "HDF5Utils",
     "ModelInfo",
     "CData",
+    "ElementInfo",
     "Nodes",
     "Elements",
     "ElementResults",

--- a/src/STKO_to_python/elements/selector.py
+++ b/src/STKO_to_python/elements/selector.py
@@ -307,6 +307,45 @@ def _node_coord_lookup(manager: "ElementManager") -> Optional[_NodeCoordLookup]:
     return cache
 
 
+def _resolve_element_info_filter(
+    manager: "ElementManager", anchor: "_Anchor"
+) -> set[int]:
+    """Intersect every active *ELEMENT_INFO anchor in a single pass.
+
+    Returns the set of element ids whose ``ElementInfo`` matches every
+    anchor field that is set. One pass over ``element_info`` regardless
+    of how many anchor fields are active.
+    """
+    cdata = getattr(manager.dataset, "cdata", None)
+    if cdata is None:
+        raise AttributeError(
+            "Selector uses an element_info anchor but "
+            "dataset.cdata is not available."
+        )
+    element_info = cdata.element_info
+    if not element_info:
+        # Selector resolves to empty rather than raising; consistent
+        # with .of_type() against a class that has no rows.
+        return set()
+
+    matched: set[int] = set()
+    want_geom = anchor.geom_name
+    want_pp = anchor.physical_property_name
+    want_ep = anchor.element_property_name
+    want_sub = anchor.sub_geom_type
+    for eid, ei in element_info.items():
+        if want_geom is not None and ei.geom_name != want_geom:
+            continue
+        if want_pp is not None and ei.physical_property_name != want_pp:
+            continue
+        if want_ep is not None and ei.element_property_name != want_ep:
+            continue
+        if want_sub is not None and ei.sub_geom_type != want_sub:
+            continue
+        matched.add(int(eid))
+    return matched
+
+
 # ---------------------------------------------------------------------- #
 # Anchor — defines the type-bound universe for a selector                #
 # ---------------------------------------------------------------------- #
@@ -316,12 +355,30 @@ class _Anchor:
     of_type: Optional[str] = None
     selection: Optional[Tuple[Any, ...]] = None  # names or set ids
     explicit_ids: Optional[Tuple[int, ...]] = None
+    # .cdata *ELEMENT_INFO anchors (resolved against
+    # ``dataset.cdata.element_info``):
+    geom_name: Optional[str] = None
+    physical_property_name: Optional[str] = None
+    element_property_name: Optional[str] = None
+    sub_geom_type: Optional[str] = None
 
     def is_set(self) -> bool:
         return (
             self.of_type is not None
             or self.selection is not None
             or self.explicit_ids is not None
+            or self.geom_name is not None
+            or self.physical_property_name is not None
+            or self.element_property_name is not None
+            or self.sub_geom_type is not None
+        )
+
+    def has_element_info_filter(self) -> bool:
+        return (
+            self.geom_name is not None
+            or self.physical_property_name is not None
+            or self.element_property_name is not None
+            or self.sub_geom_type is not None
         )
 
     def with_(
@@ -330,6 +387,10 @@ class _Anchor:
         of_type: Optional[str] = None,
         selection: Optional[Tuple[Any, ...]] = None,
         explicit_ids: Optional[Tuple[int, ...]] = None,
+        geom_name: Optional[str] = None,
+        physical_property_name: Optional[str] = None,
+        element_property_name: Optional[str] = None,
+        sub_geom_type: Optional[str] = None,
     ) -> "_Anchor":
         return _Anchor(
             of_type=of_type if of_type is not None else self.of_type,
@@ -338,6 +399,24 @@ class _Anchor:
                 explicit_ids
                 if explicit_ids is not None
                 else self.explicit_ids
+            ),
+            geom_name=(
+                geom_name if geom_name is not None else self.geom_name
+            ),
+            physical_property_name=(
+                physical_property_name
+                if physical_property_name is not None
+                else self.physical_property_name
+            ),
+            element_property_name=(
+                element_property_name
+                if element_property_name is not None
+                else self.element_property_name
+            ),
+            sub_geom_type=(
+                sub_geom_type
+                if sub_geom_type is not None
+                else self.sub_geom_type
             ),
         )
 
@@ -427,6 +506,55 @@ class ElementSelector:
         return ElementSelector(
             self._manager,
             anchor=self._anchor.with_(explicit_ids=existing + arr),
+            ops=self._ops,
+        )
+
+    def of_geometry(self, name: str) -> "ElementSelector":
+        """Anchor universe to elements whose STKO parent geometry has *name*.
+
+        Resolves against ``dataset.cdata.element_info[*].geom_name``.
+        Example: ``select().of_geometry("Slab")``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(geom_name=str(name)),
+            ops=self._ops,
+        )
+
+    def of_physical_property(self, name: str) -> "ElementSelector":
+        """Anchor universe to elements with the named physical (material/section) property.
+
+        Resolves against ``dataset.cdata.element_info[*].physical_property_name``.
+        Example: ``select().of_physical_property("ShearWalls_Elastic")``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(physical_property_name=str(name)),
+            ops=self._ops,
+        )
+
+    def of_element_property(self, name: str) -> "ElementSelector":
+        """Anchor universe to elements with the named element property.
+
+        Resolves against ``dataset.cdata.element_info[*].element_property_name``.
+        Example: ``select().of_element_property("elasticBeamCol")``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(element_property_name=str(name)),
+            ops=self._ops,
+        )
+
+    def of_sub_geom_type(self, geom_type: str) -> "ElementSelector":
+        """Anchor universe to elements whose parent sub-geometry has the given type.
+
+        ``geom_type`` is one of ``"Edge"``, ``"Face"``, ``"Solid"`` (and
+        whatever else STKO emits). Resolves against
+        ``dataset.cdata.element_info[*].sub_geom_type``.
+        """
+        return ElementSelector(
+            self._manager,
+            anchor=self._anchor.with_(sub_geom_type=str(geom_type)),
             ops=self._ops,
         )
 
@@ -662,6 +790,9 @@ class ElementSelector:
             df = df[df["element_id"].isin(sel_ids)]
         if a.explicit_ids is not None:
             df = df[df["element_id"].isin(a.explicit_ids)]
+        if a.has_element_info_filter():
+            matched = _resolve_element_info_filter(self._manager, a)
+            df = df[df["element_id"].isin(matched)]
         return df
 
     def _universe_ids(self) -> np.ndarray:
@@ -686,6 +817,18 @@ class ElementSelector:
             bits.append(f"from_selection={list(self._anchor.selection)!r}")
         if self._anchor.explicit_ids:
             bits.append(f"with_ids({len(self._anchor.explicit_ids)})")
+        if self._anchor.geom_name:
+            bits.append(f"of_geometry={self._anchor.geom_name!r}")
+        if self._anchor.physical_property_name:
+            bits.append(
+                f"of_physical_property={self._anchor.physical_property_name!r}"
+            )
+        if self._anchor.element_property_name:
+            bits.append(
+                f"of_element_property={self._anchor.element_property_name!r}"
+            )
+        if self._anchor.sub_geom_type:
+            bits.append(f"of_sub_geom_type={self._anchor.sub_geom_type!r}")
         for op in self._ops:
             bits.append(type(op).__name__.strip("_"))
         return f"ElementSelector({', '.join(bits)})"
@@ -806,6 +949,30 @@ class _CombinedSelector(ElementSelector):
         raise TypeError(
             "Cannot call .with_ids() on a combined selector; anchor "
             "each leaf selector before combining."
+        )
+
+    def of_geometry(self, name: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_geometry() on a combined selector; anchor "
+            "each leaf selector before combining."
+        )
+
+    def of_physical_property(self, name: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_physical_property() on a combined selector; "
+            "anchor each leaf selector before combining."
+        )
+
+    def of_element_property(self, name: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_element_property() on a combined selector; "
+            "anchor each leaf selector before combining."
+        )
+
+    def of_sub_geom_type(self, geom_type: str) -> "ElementSelector":  # type: ignore[override]
+        raise TypeError(
+            "Cannot call .of_sub_geom_type() on a combined selector; "
+            "anchor each leaf selector before combining."
         )
 
     def _with_op(self, op: _FilterOp) -> "ElementSelector":

--- a/src/STKO_to_python/model/__init__.py
+++ b/src/STKO_to_python/model/__init__.py
@@ -1,5 +1,5 @@
 from .model_info_reader import ModelInfoReader
-from .cdata_reader import CDataReader, ElementInfo
+from .cdata_reader import BeamProfile, CDataReader, ElementInfo
 
 # Back-compat aliases preserved on the package surface (quiet); the
 # deep paths ``STKO_to_python.model.model_info.ModelInfo`` and
@@ -14,4 +14,5 @@ __all__ = [
     "CData",
     "CDataReader",
     "ElementInfo",
+    "BeamProfile",
 ]

--- a/src/STKO_to_python/model/__init__.py
+++ b/src/STKO_to_python/model/__init__.py
@@ -1,5 +1,5 @@
 from .model_info_reader import ModelInfoReader
-from .cdata_reader import CDataReader
+from .cdata_reader import CDataReader, ElementInfo
 
 # Back-compat aliases preserved on the package surface (quiet); the
 # deep paths ``STKO_to_python.model.model_info.ModelInfo`` and
@@ -13,4 +13,5 @@ __all__ = [
     "ModelInfoReader",
     "CData",
     "CDataReader",
+    "ElementInfo",
 ]

--- a/src/STKO_to_python/model/cdata_format.py
+++ b/src/STKO_to_python/model/cdata_format.py
@@ -1,0 +1,81 @@
+"""Centralized ``.cdata`` text-format policy.
+
+The ``.cdata`` sidecar (companion to ``.mpco``) is a line-oriented text
+format with a handful of section markers and a few encoding
+conventions (e.g. ``LENGTH NAME`` for names that may contain spaces).
+This module is the single place that owns those format facts.
+
+It mirrors :class:`STKO_to_python.io.format_policy.MpcoFormatPolicy`:
+pure-functional, stateless, safe to share across threads.
+
+See ``docs/architecture-refactor-proposal.md`` §3.1 for the design
+intent shared with the MPCO policy.
+"""
+from __future__ import annotations
+
+
+class CDataFormatPolicy:
+    """Pure-functional knowledge of the ``.cdata`` text-file layout.
+
+    The policy is stateless: section markers and conventions are class
+    attributes; helper queries are ``@staticmethod`` / ``@classmethod``.
+    One instance can be shared across every reader and parser.
+
+    Thread-safety
+    -------------
+    Safe for concurrent access. No mutable state.
+    """
+
+    __slots__ = ()
+
+    # ------------------------------------------------------------------ #
+    # Section marker tokens (the line that opens each section)            #
+    # ------------------------------------------------------------------ #
+
+    MARKER_SELECTION_SET = "*SELECTION_SET"
+    MARKER_LOCAL_AXES = "*LOCAL_AXES"
+    MARKER_SECTION_OFFSET = "*SECTION_OFFSET"
+    MARKER_BEAM_PROFILE = "*BEAM_PROFILE"
+    MARKER_BEAM_PROFILE_ASSIGNMENT = "*BEAM_PROFILE_ASSIGNMENT"
+    MARKER_ELEMENT_INFO = "*ELEMENT_INFO"
+
+    def __repr__(self) -> str:
+        return "CDataFormatPolicy()"
+
+    # ------------------------------------------------------------------ #
+    # Marker queries                                                      #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def known_markers(cls) -> frozenset[str]:
+        """Every section-opening marker this parser recognizes."""
+        return frozenset(
+            {
+                cls.MARKER_SELECTION_SET,
+                cls.MARKER_LOCAL_AXES,
+                cls.MARKER_SECTION_OFFSET,
+                cls.MARKER_BEAM_PROFILE,
+                cls.MARKER_BEAM_PROFILE_ASSIGNMENT,
+                cls.MARKER_ELEMENT_INFO,
+            }
+        )
+
+    @staticmethod
+    def is_section_marker(line: str) -> bool:
+        """True iff *line* (after strip) is a section-opening ``*MARKER`` line.
+
+        Any unrecognized ``*`` line is still treated as a section
+        boundary by the reader; this helper checks for the *known* set.
+        """
+        return line.strip() in CDataFormatPolicy.known_markers()
+
+    @staticmethod
+    def is_any_marker(line: str) -> bool:
+        """True iff *line* (after strip) starts with ``*`` — a section boundary.
+
+        The reader uses this when walking data lines inside a section
+        to detect the start of the next section, even if the marker is
+        one this policy version does not recognize.
+        """
+        s = line.strip()
+        return bool(s) and s.startswith("*")

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -1,8 +1,31 @@
+"""Reader for MPCO ``.cdata`` sidecar files.
 
+The ``.cdata`` text file is STKO's companion to ``.mpco`` results. It
+carries model metadata that does not live in HDF5:
 
+- ``*SELECTION_SET`` — named groups of nodes / elements (also exposed
+  via :class:`SelectionSetResolver`).
+- ``*LOCAL_AXES`` — per-element rotation quaternion (element-local
+  frame relative to global).
+- ``*SECTION_OFFSET`` — per-element section-centroid offset in
+  element-local 2D coords.
+- ``*ELEMENT_INFO`` — parent geometry / sub-geometry / physical and
+  element property metadata per element. Enables "select by geometry"
+  workflows without pre-defined selection sets.
+- ``*BEAM_PROFILE`` and ``*BEAM_PROFILE_ASSIGNMENT`` — present in the
+  file but not yet parsed by this reader.
+
+``CDataReader`` does a single pass over every partition the first time
+any accessor is touched. ``MPCODataSet`` constructs the reader eagerly
+and queries ``_extract_selection_set_ids`` during ``__init__``, so in
+practice the parse happens at dataset-construction time and every
+accessor is then O(1).
+"""
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
@@ -14,160 +37,330 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-SelectionSetIdsArg = Union[int, "np.integer", list, None]
+SelectionSetIdsArg = Union[int, np.integer, list, None]
 
+
+# ---------------------------------------------------------------------- #
+# Structured records
+# ---------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class ElementInfo:
+    """Parent-geometry and property metadata for one element.
+
+    Mirrors a single ``*ELEMENT_INFO`` row. Names can contain spaces
+    (e.g. ``"New physical property"``); STKO emits them with explicit
+    length prefixes which the parser handles transparently.
+    """
+    element_id: int
+    geom_id: int
+    geom_name: str
+    sub_geom_idx: int
+    sub_geom_type: str           # "Edge" | "Face" | "Solid" | ...
+    physical_property_id: int
+    physical_property_name: str
+    element_property_id: int
+    element_property_name: str
+
+
+# ---------------------------------------------------------------------- #
+# Low-level parsing helpers (module-private; testable directly)
+# ---------------------------------------------------------------------- #
+
+def _read_length_prefixed(rest: str) -> tuple[str, str]:
+    """Consume a ``LENGTH NAME`` pair from the start of *rest*.
+
+    STKO encodes name fields as ``LENGTH NAME`` where ``LENGTH`` is the
+    character count of ``NAME`` (which may itself contain spaces, e.g.
+    ``"21 New physical property"``).
+
+    Returns ``(name, remainder)`` where ``remainder`` has the
+    name's trailing separator space stripped.
+    """
+    space_idx = rest.find(" ")
+    if space_idx == -1:
+        raise ValueError(f"Expected '<len> <name>' pair, got: {rest!r}")
+    length = int(rest[:space_idx])
+    name_start = space_idx + 1
+    name_end = name_start + length
+    name = rest[name_start:name_end]
+    remaining = rest[name_end:]
+    if remaining.startswith(" "):
+        remaining = remaining[1:]
+    return name, remaining
+
+
+def _read_section_lines(lines: list[str], start: int) -> tuple[list[str], int]:
+    """Return ``(data_lines, end_index)`` for the section beginning at *start*.
+
+    Sections terminate at the first blank line, ``*`` marker, or EOF.
+    Each data line is right-stripped of whitespace; the leading marker
+    line itself is the caller's responsibility (not included in *start*).
+    """
+    data: list[str] = []
+    i = start
+    n = len(lines)
+    while i < n:
+        s = lines[i].rstrip()
+        if not s:
+            break
+        if s.startswith("*"):
+            break
+        data.append(s)
+        i += 1
+    return data, i
+
+
+# ---------------------------------------------------------------------- #
+# CDataReader
+# ---------------------------------------------------------------------- #
 
 class CDataReader:
     """Canonical Layer 3 reader for MPCO ``.cdata`` sidecar files.
 
-    The legacy name ``CData`` is preserved as an alias at the bottom of
-    this module; new code should prefer ``CDataReader``.
+    Parsing happens lazily on first access to any accessor (or eagerly
+    when ``MPCODataSet`` calls ``_extract_selection_set_ids`` during
+    construction). All sections share one file pass per partition.
+
+    The legacy name ``CData`` is preserved as a quiet alias on the
+    package surface; the deep import path emits ``DeprecationWarning``.
     """
 
     def __init__(self, dataset: "MPCODataSet"):
         self.dataset = dataset
+        # Single-pass cache. None until first access; populated by
+        # `_parse_all_files`.
+        self._parsed: Optional[dict] = None
 
-    def _extract_selection_set_ids_for_file(
-        self,
-        file_path: str,
-        selection_set_ids: SelectionSetIdsArg = None,
-    ) -> list[dict]:
-        """Parse all ``*SELECTION_SET`` blocks from a single ``.cdata`` file.
+    # ------------------------------------------------------------------ #
+    # Public read-only views (lazy)
+    # ------------------------------------------------------------------ #
 
-        Args:
-            file_path: Path to the ``.cdata`` file.
-            selection_set_ids: Optional ID filter. If ``None``, every set is
-                parsed.
+    @cached_property
+    def local_axes(self) -> dict[int, np.ndarray]:
+        """``{elem_id -> [qw, qx, qy, qz]}`` per-element rotation quaternion.
 
-        Returns:
-            List of dicts, one per selection set, each with keys
-            ``SET_ID``, ``SET_NAME``, ``NODES`` (numpy ``int`` array),
-            ``ELEMENTS`` (numpy ``int`` array). ``NODES``/``ELEMENTS``
-            keys are absent when the count is zero.
-
-        Raises:
-            OSError: If the file cannot be opened.
-            ValueError, IndexError: If the file is malformed. The
-                original traceback is logged with file context.
+        The quaternion rotates from element-local to global coordinates.
+        Useful for interpreting beam force/moment results that STKO
+        emits in the local frame.
         """
-        if isinstance(selection_set_ids, (int, np.integer)):
-            selection_set_ids = [int(selection_set_ids)]
+        return self._parse_all_files()["local_axes"]
 
-        if selection_set_ids is not None and not isinstance(selection_set_ids, list):
-            raise ValueError("CData Error: selection_set_ids must be a list of integers or None.")
+    @cached_property
+    def section_offsets(self) -> dict[int, np.ndarray]:
+        """``{elem_id -> [yOffset, zOffset]}`` in element-local coords.
 
-        selection_sets: list[dict] = []
+        Distance from the integration axis to the section centroid;
+        relevant for moment computations about the geometric centerline.
+        """
+        return self._parse_all_files()["section_offsets"]
 
-        try:
-            # errors="replace" guards against non-UTF-8 bytes in the file
-            # (e.g. comments emitted by a legacy STKO build) without
-            # silently dropping legitimate UTF-8 selection-set names.
-            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
-                lines = f.readlines()
+    @cached_property
+    def element_info(self) -> dict[int, ElementInfo]:
+        """``{elem_id -> ElementInfo}`` parent geometry & property metadata.
 
-            for i, line in enumerate(lines):
-                if line.strip() != "*SELECTION_SET":
-                    continue
+        Lets callers select elements by STKO geometry/property names
+        rather than relying on pre-built selection sets.
+        """
+        return self._parse_all_files()["element_info"]
 
-                set_id = int(lines[i + 1].strip())
-                if selection_set_ids is not None and set_id not in selection_set_ids:
-                    continue
-
-                raw_set_name = lines[i + 2].strip()
-                name_length = int(raw_set_name.split()[0])
-                offset = len(str(name_length)) + 1
-                set_name = raw_set_name[offset : offset + name_length]
-
-                number_of_nodes = int(lines[i + 3].strip())
-                number_of_elements = int(lines[i + 4].strip())
-
-                selection_set: dict = {"SET_ID": set_id, "SET_NAME": set_name}
-
-                # Elements come right after the (possibly empty) nodes
-                # block. Initialize unconditionally so NNODES=0 with
-                # NELEMENTS>0 doesn't reference an unbound name.
-                elements_start_line = i + 5
-
-                if number_of_nodes > 0:
-                    nodes_end_line = elements_start_line + (number_of_nodes + 9) // 10
-                    node_lines = lines[elements_start_line:nodes_end_line]
-                    selection_set["NODES"] = np.fromstring(
-                        " ".join(node_lines).strip(), sep=" ", dtype=int
-                    )
-                    elements_start_line = nodes_end_line
-
-                if number_of_elements > 0:
-                    elements_end_line = elements_start_line + (number_of_elements + 9) // 10
-                    element_lines = lines[elements_start_line:elements_end_line]
-                    selection_set["ELEMENTS"] = np.fromstring(
-                        " ".join(element_lines).strip(), sep=" ", dtype=int
-                    )
-
-                selection_sets.append(selection_set)
-
-        except Exception:
-            # Re-raise so the dataset fails loudly at construction;
-            # silently returning [] used to mask broken cdata files
-            # until a downstream selection-set query crashed.
-            logger.exception("CData parse error in %s", file_path)
-            raise
-
-        return selection_sets
+    # ------------------------------------------------------------------ #
+    # Selection-set surface (eager from MPCODataSet.__init__)
+    # ------------------------------------------------------------------ #
 
     def _extract_selection_set_ids(
         self,
         selection_set_ids: SelectionSetIdsArg = None,
     ) -> dict[int, dict]:
-        """Aggregate selection sets across every ``.cdata`` partition.
+        """Aggregate ``*SELECTION_SET`` blocks across every partition.
 
         Args:
-            selection_set_ids: Optional ID filter. If ``None``, every set
-                from every partition is aggregated.
+            selection_set_ids: Optional ID filter. If ``None``, every
+                set from every partition is aggregated.
 
         Returns:
-            Dict mapping ``set_id -> {"SET_NAME": str, "NODES": list[int],
-            "ELEMENTS": list[int]}``. Member lists are sorted and
-            deduplicated across partitions.
+            A fresh dict mapping ``set_id -> {"SET_NAME": str,
+            "NODES": list[int], "ELEMENTS": list[int]}``. Member lists
+            are sorted and deduplicated across partitions. Safe to
+            mutate without disturbing the reader's cache.
         """
         if isinstance(selection_set_ids, (int, np.integer)):
             selection_set_ids = [int(selection_set_ids)]
-
         if selection_set_ids is not None and not isinstance(selection_set_ids, list):
             raise ValueError("selection_set_ids must be a list of integers or None.")
 
-        aggregated_data: dict[int, dict] = {}
-        file_mapping = self.dataset.cdata_partitions
-
-        for file_path in file_mapping.values():
-            selection_sets = self._extract_selection_set_ids_for_file(
-                file_path, selection_set_ids=selection_set_ids
-            )
-
-            for selection_set in selection_sets:
-                set_id = selection_set["SET_ID"]
-
-                if set_id not in aggregated_data:
-                    aggregated_data[set_id] = {
-                        "SET_NAME": selection_set["SET_NAME"],
-                        "NODES": set(selection_set.get("NODES", [])),
-                        "ELEMENTS": set(selection_set.get("ELEMENTS", [])),
-                    }
-                else:
-                    aggregated_data[set_id]["NODES"].update(selection_set.get("NODES", []))
-                    aggregated_data[set_id]["ELEMENTS"].update(selection_set.get("ELEMENTS", []))
-
-        for set_id in aggregated_data:
-            aggregated_data[set_id]["NODES"] = sorted(aggregated_data[set_id]["NODES"])
-            aggregated_data[set_id]["ELEMENTS"] = sorted(aggregated_data[set_id]["ELEMENTS"])
-
-        return aggregated_data
+        cached = self._parse_all_files()["selection_sets"]
+        if selection_set_ids is None:
+            wanted = cached.keys()
+        else:
+            wanted = set(selection_set_ids) & cached.keys()
+        return {
+            sid: {
+                "SET_NAME": cached[sid]["SET_NAME"],
+                "NODES": list(cached[sid]["NODES"]),
+                "ELEMENTS": list(cached[sid]["ELEMENTS"]),
+            }
+            for sid in wanted
+        }
 
     def print_selection_set_names(self) -> None:
         """Emit names of all available selection sets at INFO level."""
-        selection_sets = self.dataset.selection_set
+        sets = self.dataset.selection_set
         logger.info("Available selection sets:")
-        for key, payload in selection_sets.items():
+        for key, payload in sets.items():
             logger.info("  Set id: %s - Set name: %s", key, payload["SET_NAME"])
+
+    # ------------------------------------------------------------------ #
+    # Parsing internals
+    # ------------------------------------------------------------------ #
+
+    def _parse_all_files(self) -> dict:
+        """Single-pass parse across every partition; cached on ``self``."""
+        if self._parsed is not None:
+            return self._parsed
+
+        accum: dict = {
+            "selection_sets": {},      # int -> {"SET_NAME": str, "NODES": set, "ELEMENTS": set}
+            "local_axes": {},          # int -> ndarray(4,)
+            "section_offsets": {},     # int -> ndarray(2,)
+            "element_info": {},        # int -> ElementInfo
+        }
+        for file_path in self.dataset.cdata_partitions.values():
+            self._parse_file_into(file_path, accum)
+
+        # Finalize: convert member sets to sorted lists for the
+        # selection-set payload. Done once, post-aggregation.
+        for payload in accum["selection_sets"].values():
+            payload["NODES"] = sorted(payload["NODES"])
+            payload["ELEMENTS"] = sorted(payload["ELEMENTS"])
+
+        self._parsed = accum
+        return accum
+
+    def _parse_file_into(self, file_path: str, accum: dict) -> None:
+        """Single-pass parse of one ``.cdata`` file into *accum*.
+
+        Re-raises after logging on any failure so the dataset fails
+        loudly at construction; silent ``return``s used to mask broken
+        cdata files until a downstream selection-set query crashed.
+        """
+        try:
+            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()
+
+            i = 0
+            n = len(lines)
+            while i < n:
+                marker = lines[i].strip()
+                if marker == "*SELECTION_SET":
+                    i = self._parse_one_selection_set(lines, i, accum["selection_sets"])
+                elif marker == "*LOCAL_AXES":
+                    i = self._parse_local_axes(lines, i + 1, accum["local_axes"])
+                elif marker == "*SECTION_OFFSET":
+                    i = self._parse_section_offset(lines, i + 1, accum["section_offsets"])
+                elif marker == "*ELEMENT_INFO":
+                    i = self._parse_element_info(lines, i + 1, accum["element_info"])
+                else:
+                    i += 1
+        except Exception:
+            logger.exception("CData parse error in %s", file_path)
+            raise
+
+    # --- per-section parsers ----------------------------------------- #
+
+    @staticmethod
+    def _parse_one_selection_set(lines: list[str], i: int, out: dict) -> int:
+        """Parse one ``*SELECTION_SET`` block; return index after the block."""
+        set_id = int(lines[i + 1].strip())
+
+        raw_name = lines[i + 2].strip()
+        name_length = int(raw_name.split()[0])
+        offset = len(str(name_length)) + 1
+        set_name = raw_name[offset : offset + name_length]
+
+        n_nodes = int(lines[i + 3].strip())
+        n_elems = int(lines[i + 4].strip())
+
+        # Elements come right after the (possibly empty) nodes block.
+        # Initialize unconditionally so NNODES=0 + NELEMENTS>0 doesn't
+        # reference an unbound name.
+        cursor = i + 5
+
+        nodes: np.ndarray = np.empty(0, dtype=int)
+        if n_nodes > 0:
+            end = cursor + (n_nodes + 9) // 10
+            nodes = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
+            cursor = end
+
+        elements: np.ndarray = np.empty(0, dtype=int)
+        if n_elems > 0:
+            end = cursor + (n_elems + 9) // 10
+            elements = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
+            cursor = end
+
+        if set_id in out:
+            out[set_id]["NODES"].update(int(x) for x in nodes)
+            out[set_id]["ELEMENTS"].update(int(x) for x in elements)
+        else:
+            out[set_id] = {
+                "SET_NAME": set_name,
+                "NODES": set(int(x) for x in nodes),
+                "ELEMENTS": set(int(x) for x in elements),
+            }
+        return cursor
+
+    @staticmethod
+    def _parse_local_axes(lines: list[str], i: int, out: dict) -> int:
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            parts = line.split()
+            elem_id = int(parts[0])
+            out[elem_id] = np.array([float(x) for x in parts[1:5]], dtype=float)
+        return end
+
+    @staticmethod
+    def _parse_section_offset(lines: list[str], i: int, out: dict) -> int:
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            parts = line.split()
+            elem_id = int(parts[0])
+            out[elem_id] = np.array([float(x) for x in parts[1:3]], dtype=float)
+        return end
+
+    @staticmethod
+    def _parse_element_info(lines: list[str], i: int, out: dict) -> int:
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            tokens = line.split(" ", 2)
+            elem_id = int(tokens[0])
+            geom_id = int(tokens[1])
+            rest = tokens[2]
+
+            geom_name, rest = _read_length_prefixed(rest)
+
+            sub_idx_str, sub_type, rest = rest.split(" ", 2)
+            sub_geom_idx = int(sub_idx_str)
+
+            pp_id_str, rest = rest.split(" ", 1)
+            pp_id = int(pp_id_str)
+            pp_name, rest = _read_length_prefixed(rest)
+
+            ep_id_str, rest = rest.split(" ", 1)
+            ep_id = int(ep_id_str)
+            ep_name, _ = _read_length_prefixed(rest)
+
+            out[elem_id] = ElementInfo(
+                element_id=elem_id,
+                geom_id=geom_id,
+                geom_name=geom_name,
+                sub_geom_idx=sub_geom_idx,
+                sub_geom_type=sub_type,
+                physical_property_id=pp_id,
+                physical_property_name=pp_name,
+                element_property_id=ep_id,
+                element_property_name=ep_name,
+            )
+        return end
 
 
 # The legacy ``CData`` alias lives on the ``STKO_to_python.model``
@@ -175,6 +368,3 @@ class CDataReader:
 # ``STKO_to_python.model.cdata`` (DeprecationWarning via PEP 562
 # ``__getattr__`` shim). It is intentionally not declared on this
 # canonical module so that the library never trips its own warning.
-
-
-

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -33,6 +33,8 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 
+from .cdata_format import CDataFormatPolicy
+
 
 if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
@@ -136,6 +138,50 @@ def _read_section_lines(lines: list[str], start: int) -> tuple[list[str], int]:
     return data, i
 
 
+def _consume_ids(
+    lines: list[str], start: int, count: int
+) -> tuple[np.ndarray, int]:
+    """Consume exactly *count* integers starting at ``lines[start]``.
+
+    Walks forward across as many lines as needed, regardless of how
+    STKO chose to wrap the list. The current emitter uses 10 ids per
+    line, but this helper is width-agnostic so a hand-edited file
+    (or a future format variant) still parses correctly.
+
+    Returns ``(ndarray, next_index)`` where ``next_index`` is the
+    index of the first line *not* consumed.
+
+    Raises ``ValueError`` if EOF or a section boundary (``*``)
+    is reached before *count* ids have been gathered.
+    """
+    if count == 0:
+        return np.empty(0, dtype=int), start
+
+    collected: list[int] = []
+    i = start
+    n = len(lines)
+    while len(collected) < count:
+        if i >= n:
+            raise ValueError(
+                f"cdata: expected {count} ids, got only {len(collected)} "
+                f"before EOF (started at line {start + 1})."
+            )
+        s = lines[i].strip()
+        if not s or s.startswith("*"):
+            raise ValueError(
+                f"cdata: id list truncated at line {i + 1}; expected "
+                f"{count} ids, got {len(collected)}."
+            )
+        collected.extend(int(x) for x in s.split())
+        i += 1
+
+    # If the last consumed line happened to have more ids than we
+    # needed, trim. STKO doesn't currently emit this shape (its wrap
+    # is exact), but the trim makes us safe against hand-edits.
+    arr = np.array(collected[:count], dtype=int)
+    return arr, i
+
+
 # ---------------------------------------------------------------------- #
 # CDataReader
 # ---------------------------------------------------------------------- #
@@ -150,6 +196,10 @@ class CDataReader:
     The legacy name ``CData`` is preserved as a quiet alias on the
     package surface; the deep import path emits ``DeprecationWarning``.
     """
+
+    # Format policy is stateless and identical for every reader; share
+    # one class-level instance rather than allocating per dataset.
+    _format_policy: CDataFormatPolicy = CDataFormatPolicy()
 
     def __init__(self, dataset: "MPCODataSet"):
         self.dataset = dataset
@@ -297,23 +347,24 @@ class CDataReader:
             with open(file_path, "r", encoding="utf-8", errors="replace") as f:
                 lines = f.readlines()
 
+            policy = self._format_policy
             i = 0
             n = len(lines)
             while i < n:
                 marker = lines[i].strip()
-                if marker == "*SELECTION_SET":
+                if marker == policy.MARKER_SELECTION_SET:
                     i = self._parse_one_selection_set(lines, i, accum["selection_sets"])
-                elif marker == "*LOCAL_AXES":
+                elif marker == policy.MARKER_LOCAL_AXES:
                     i = self._parse_local_axes(lines, i + 1, accum["local_axes"])
-                elif marker == "*SECTION_OFFSET":
+                elif marker == policy.MARKER_SECTION_OFFSET:
                     i = self._parse_section_offset(lines, i + 1, accum["section_offsets"])
-                elif marker == "*BEAM_PROFILE":
+                elif marker == policy.MARKER_BEAM_PROFILE:
                     i = self._parse_beam_profiles(lines, i + 1, accum["beam_profiles"])
-                elif marker == "*BEAM_PROFILE_ASSIGNMENT":
+                elif marker == policy.MARKER_BEAM_PROFILE_ASSIGNMENT:
                     i = self._parse_beam_profile_assignments(
                         lines, i + 1, accum["beam_profile_assignments"]
                     )
-                elif marker == "*ELEMENT_INFO":
+                elif marker == policy.MARKER_ELEMENT_INFO:
                     i = self._parse_element_info(lines, i + 1, accum["element_info"])
                 else:
                     i += 1
@@ -325,7 +376,13 @@ class CDataReader:
 
     @staticmethod
     def _parse_one_selection_set(lines: list[str], i: int, out: dict) -> int:
-        """Parse one ``*SELECTION_SET`` block; return index after the block."""
+        """Parse one ``*SELECTION_SET`` block; return index after the block.
+
+        Node and element id lists are read via ``_consume_ids`` which is
+        width-agnostic — STKO currently wraps at 10 ids per line, but
+        this parser also accepts 1-per-line, all-on-one-line, or any
+        consistent variant.
+        """
         set_id = int(lines[i + 1].strip())
 
         raw_name = lines[i + 2].strip()
@@ -336,22 +393,12 @@ class CDataReader:
         n_nodes = int(lines[i + 3].strip())
         n_elems = int(lines[i + 4].strip())
 
-        # Elements come right after the (possibly empty) nodes block.
-        # Initialize unconditionally so NNODES=0 + NELEMENTS>0 doesn't
-        # reference an unbound name.
+        # Both lists live right after the header; nodes first, elements
+        # second. _consume_ids advances the cursor past whichever lines
+        # the wrap width happened to use.
         cursor = i + 5
-
-        nodes: np.ndarray = np.empty(0, dtype=int)
-        if n_nodes > 0:
-            end = cursor + (n_nodes + 9) // 10
-            nodes = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
-            cursor = end
-
-        elements: np.ndarray = np.empty(0, dtype=int)
-        if n_elems > 0:
-            end = cursor + (n_elems + 9) // 10
-            elements = np.fromstring(" ".join(lines[cursor:end]).strip(), sep=" ", dtype=int)
-            cursor = end
+        nodes, cursor = _consume_ids(lines, cursor, n_nodes)
+        elements, cursor = _consume_ids(lines, cursor, n_elems)
 
         if set_id in out:
             out[set_id]["NODES"].update(int(x) for x in nodes)

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -12,8 +12,11 @@ carries model metadata that does not live in HDF5:
 - ``*ELEMENT_INFO`` — parent geometry / sub-geometry / physical and
   element property metadata per element. Enables "select by geometry"
   workflows without pre-defined selection sets.
-- ``*BEAM_PROFILE`` and ``*BEAM_PROFILE_ASSIGNMENT`` — present in the
-  file but not yet parsed by this reader.
+- ``*BEAM_PROFILE`` — 2D cross-section geometry (points, triangles,
+  edges, sweeps) per profile id. Useful for plotting beam elements
+  as extruded solids.
+- ``*BEAM_PROFILE_ASSIGNMENT`` — element-id to profile-id mapping
+  with weights, expressing variable cross-section along an element.
 
 ``CDataReader`` does a single pass over every partition the first time
 any accessor is touched. ``MPCODataSet`` constructs the reader eagerly
@@ -61,6 +64,28 @@ class ElementInfo:
     physical_property_name: str
     element_property_id: int
     element_property_name: str
+
+
+@dataclass(frozen=True)
+class BeamProfile:
+    """2D cross-section geometry for a beam element profile.
+
+    Mirrors one block inside a ``*BEAM_PROFILE`` section.
+
+    - ``points`` are vertices in the section's local 2D frame.
+    - ``triangles`` is a triangulation of the section (for filled
+      rendering); each row is three 0-based point indices.
+    - ``edges`` is the outline as a list of polyline edges; each
+      edge is a 0-based ``ndarray`` of point indices, length varies
+      per edge (STKO supports curved/multi-point edges).
+    - ``sweeps`` indexes the points to sweep along the beam (for
+      generating an extruded 3D mesh).
+    """
+    profile_id: int
+    points: np.ndarray           # (npoints, 2) — x, y in section frame
+    triangles: np.ndarray        # (ntriangles, 3) — 0-based point indices
+    edges: list[np.ndarray]      # one (n_i,) array per edge, n_i varies
+    sweeps: np.ndarray           # (nsweeps,) — 0-based point indices
 
 
 # ---------------------------------------------------------------------- #
@@ -164,6 +189,28 @@ class CDataReader:
         """
         return self._parse_all_files()["element_info"]
 
+    @cached_property
+    def beam_profiles(self) -> dict[int, BeamProfile]:
+        """``{profile_id -> BeamProfile}`` 2D cross-section definitions.
+
+        Each entry holds the section's points, triangulation, edge
+        outline, and sweep indices. Profile definitions are typically
+        repeated identically across MP partitions; only the first
+        occurrence is kept.
+        """
+        return self._parse_all_files()["beam_profiles"]
+
+    @cached_property
+    def beam_profile_assignments(self) -> dict[int, list[tuple[int, float]]]:
+        """``{elem_id -> [(profile_id, weight), ...]}`` element → profile map.
+
+        Each tuple is one profile assigned to the element with a
+        weight in ``[0, 1]`` expressing relative span along the
+        element. The ``beam_profiles`` accessor resolves ``profile_id``
+        to the underlying cross-section geometry.
+        """
+        return self._parse_all_files()["beam_profile_assignments"]
+
     # ------------------------------------------------------------------ #
     # Selection-set surface (eager from MPCODataSet.__init__)
     # ------------------------------------------------------------------ #
@@ -220,10 +267,12 @@ class CDataReader:
             return self._parsed
 
         accum: dict = {
-            "selection_sets": {},      # int -> {"SET_NAME": str, "NODES": set, "ELEMENTS": set}
-            "local_axes": {},          # int -> ndarray(4,)
-            "section_offsets": {},     # int -> ndarray(2,)
-            "element_info": {},        # int -> ElementInfo
+            "selection_sets": {},              # int -> {"SET_NAME": str, "NODES": set, "ELEMENTS": set}
+            "local_axes": {},                  # int -> ndarray(4,)
+            "section_offsets": {},             # int -> ndarray(2,)
+            "element_info": {},                # int -> ElementInfo
+            "beam_profiles": {},               # int -> BeamProfile
+            "beam_profile_assignments": {},    # int -> list[tuple[int, float]]
         }
         for file_path in self.dataset.cdata_partitions.values():
             self._parse_file_into(file_path, accum)
@@ -258,6 +307,12 @@ class CDataReader:
                     i = self._parse_local_axes(lines, i + 1, accum["local_axes"])
                 elif marker == "*SECTION_OFFSET":
                     i = self._parse_section_offset(lines, i + 1, accum["section_offsets"])
+                elif marker == "*BEAM_PROFILE":
+                    i = self._parse_beam_profiles(lines, i + 1, accum["beam_profiles"])
+                elif marker == "*BEAM_PROFILE_ASSIGNMENT":
+                    i = self._parse_beam_profile_assignments(
+                        lines, i + 1, accum["beam_profile_assignments"]
+                    )
                 elif marker == "*ELEMENT_INFO":
                     i = self._parse_element_info(lines, i + 1, accum["element_info"])
                 else:
@@ -325,6 +380,84 @@ class CDataReader:
             parts = line.split()
             elem_id = int(parts[0])
             out[elem_id] = np.array([float(x) for x in parts[1:3]], dtype=float)
+        return end
+
+    @staticmethod
+    def _parse_beam_profiles(lines: list[str], i: int, out: dict) -> int:
+        """Parse one ``*BEAM_PROFILE`` section (may contain N profiles back-to-back).
+
+        Per-profile layout:
+            PROFILE_ID
+            NPOINTS NTRIANGLES NEDGES NSWEEPS
+            <NPOINTS rows of (x y)>
+            <NTRIANGLES rows of (p1 p2 p3)>
+            <NEDGES rows of (N p1 p2 ... pN)>     # variable length
+            <NSWEEPS rows of (p1)>
+        """
+        data, end = _read_section_lines(lines, i)
+        cursor = 0
+        n = len(data)
+        while cursor < n:
+            profile_id = int(data[cursor].strip())
+            cursor += 1
+            counts = [int(x) for x in data[cursor].split()]
+            n_pts, n_tris, n_edges, n_sweeps = counts[:4]
+            cursor += 1
+
+            points = np.array(
+                [[float(v) for v in data[cursor + k].split()] for k in range(n_pts)],
+                dtype=float,
+            )
+            cursor += n_pts
+
+            triangles = np.array(
+                [[int(v) for v in data[cursor + k].split()] for k in range(n_tris)],
+                dtype=int,
+            )
+            cursor += n_tris
+
+            edges: list[np.ndarray] = []
+            for _ in range(n_edges):
+                parts = [int(x) for x in data[cursor].split()]
+                # parts[0] is N (count of points in this edge), parts[1:N+1] are the indices.
+                edges.append(np.array(parts[1 : 1 + parts[0]], dtype=int))
+                cursor += 1
+
+            sweeps = np.array(
+                [int(data[cursor + k].strip()) for k in range(n_sweeps)],
+                dtype=int,
+            )
+            cursor += n_sweeps
+
+            # Profile definitions are duplicated identically across MP
+            # partitions; keep the first occurrence and drop later ones.
+            if profile_id not in out:
+                out[profile_id] = BeamProfile(
+                    profile_id=profile_id,
+                    points=points,
+                    triangles=triangles,
+                    edges=edges,
+                    sweeps=sweeps,
+                )
+        return end
+
+    @staticmethod
+    def _parse_beam_profile_assignments(lines: list[str], i: int, out: dict) -> int:
+        """Parse a ``*BEAM_PROFILE_ASSIGNMENT`` section.
+
+        Each row is ``ELEM_ID N_PROFILES PID_1 WEIGHT_1 ... PID_N WEIGHT_N``.
+        """
+        data, end = _read_section_lines(lines, i)
+        for line in data:
+            parts = line.split()
+            elem_id = int(parts[0])
+            n_prof = int(parts[1])
+            assignments: list[tuple[int, float]] = []
+            for k in range(n_prof):
+                pid = int(parts[2 + 2 * k])
+                weight = float(parts[3 + 2 * k])
+                assignments.append((pid, weight))
+            out[elem_id] = assignments
         return end
 
     @staticmethod

--- a/tests/unit/elements/test_selector.py
+++ b/tests/unit/elements/test_selector.py
@@ -24,6 +24,7 @@ import pandas as pd
 import pytest
 
 from STKO_to_python.elements.selector import ElementSelector
+from STKO_to_python.model.cdata_reader import ElementInfo
 
 
 # ---------------------------------------------------------------------- #
@@ -162,19 +163,39 @@ class _MockSelResolver:
         return np.unique(np.concatenate(gathered))
 
 
+class _MockCData:
+    """Stand-in for ``CDataReader`` exposing just the .element_info dict
+    that the selector touches."""
+
+    def __init__(self, element_info: dict):
+        self.element_info = element_info
+
+
 class _MockDataset:
-    def __init__(self, df_nodes: pd.DataFrame, resolver: _MockSelResolver):
+    def __init__(
+        self,
+        df_nodes: pd.DataFrame,
+        resolver: _MockSelResolver,
+        element_info: Optional[dict] = None,
+    ):
         self.nodes_info = {"dataframe": df_nodes}
         self._selection_resolver = resolver
+        self.cdata = _MockCData(element_info or {})
 
 
 class _MockManager:
     """Stand-in for :class:`ElementManager` exposing only the surface
     that :class:`ElementSelector` touches."""
 
-    def __init__(self, df_elems: pd.DataFrame, df_nodes: pd.DataFrame, resolver):
+    def __init__(
+        self,
+        df_elems: pd.DataFrame,
+        df_nodes: pd.DataFrame,
+        resolver,
+        element_info: Optional[dict] = None,
+    ):
         self._df = df_elems
-        self.dataset = _MockDataset(df_nodes, resolver)
+        self.dataset = _MockDataset(df_nodes, resolver, element_info)
 
     def _ensure_elem_index_df(self) -> pd.DataFrame:
         return self._df
@@ -581,3 +602,197 @@ def test_selectors_are_immutable(mgr: _MockManager):
     assert base.count() == 9
     # a and b cover disjoint x-ranges so produce disjoint id sets.
     assert set(a.ids().tolist()).isdisjoint(set(b.ids().tolist()))
+
+
+# ---------------------------------------------------------------------- #
+# Tests — *ELEMENT_INFO anchors (.of_geometry / .of_physical_property etc) #
+# ---------------------------------------------------------------------- #
+
+
+def _build_element_info() -> dict[int, ElementInfo]:
+    """Annotate every element with parent-geometry + property metadata.
+
+    Beams (ids 1..9):
+      ids 1..3   -> geom "Frame",   physical "Steel_Elastic",    element_prop "elasticBeamCol", Edge
+      ids 4..9   -> geom "Frame",   physical "Concrete_Elastic", element_prop "elasticBeamCol", Edge
+
+    Shells (ids 10..18):
+                  -> geom "Slab",   physical "Slab_Elastic",     element_prop "Q4",            Face
+    """
+    info: dict[int, ElementInfo] = {}
+    for eid in range(1, 10):
+        pp = "Steel_Elastic" if eid <= 3 else "Concrete_Elastic"
+        info[eid] = ElementInfo(
+            element_id=eid,
+            geom_id=1,
+            geom_name="Frame",
+            sub_geom_idx=0,
+            sub_geom_type="Edge",
+            physical_property_id=1,
+            physical_property_name=pp,
+            element_property_id=1,
+            element_property_name="elasticBeamCol",
+        )
+    for eid in range(10, 19):
+        info[eid] = ElementInfo(
+            element_id=eid,
+            geom_id=2,
+            geom_name="Slab",
+            sub_geom_idx=0,
+            sub_geom_type="Face",
+            physical_property_id=2,
+            physical_property_name="Slab_Elastic",
+            element_property_id=2,
+            element_property_name="Q4",
+        )
+    return info
+
+
+@pytest.fixture
+def mgr_with_info() -> _MockManager:
+    """Same geometry as ``mgr`` plus a populated ``cdata.element_info``."""
+    df_elems, df_nodes = _build_index()
+    # Reuse the same two named sets as the main fixture.
+    beam_first = (
+        df_elems[
+            (df_elems["element_type"] == BEAM_TYPE)
+            & (df_elems["centroid_x"] <= 1.0)
+        ]["element_id"]
+        .to_numpy(np.int64)
+    )
+    shell_outer = (
+        df_elems[
+            (df_elems["element_type"] == SHELL_TYPE)
+            & (
+                (df_elems["centroid_x"] < 1.0)
+                | (df_elems["centroid_x"] > 2.0)
+                | (df_elems["centroid_y"] < 11.0)
+                | (df_elems["centroid_y"] > 12.0)
+            )
+        ]["element_id"]
+        .to_numpy(np.int64)
+    )
+    resolver = _MockSelResolver(
+        element_sets={"firstcolumn": beam_first, "outer": shell_outer},
+        id_sets={1: beam_first, 2: shell_outer},
+    )
+    return _MockManager(df_elems, df_nodes, resolver, _build_element_info())
+
+
+def test_of_geometry_filters_to_named_geometry(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_geometry("Slab")
+    ids = set(sel.ids().tolist())
+    assert ids == set(range(10, 19))  # all shells
+
+
+def test_of_physical_property_filters_by_material(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_physical_property("Steel_Elastic")
+    assert sorted(sel.ids().tolist()) == [1, 2, 3]
+
+
+def test_of_element_property_filters_by_element_class_name(
+    mgr_with_info: _MockManager,
+):
+    sel = ElementSelector(mgr_with_info).of_element_property("Q4")
+    assert sorted(sel.ids().tolist()) == list(range(10, 19))
+
+
+def test_of_sub_geom_type_filters_to_topology(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_sub_geom_type("Edge")
+    assert sorted(sel.ids().tolist()) == list(range(1, 10))
+
+
+def test_element_info_anchors_compose_AND(mgr_with_info: _MockManager):
+    """Multiple element_info anchors AND-narrow within a single call chain."""
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_geometry("Frame")
+        .of_physical_property("Concrete_Elastic")
+    )
+    assert sorted(sel.ids().tolist()) == [4, 5, 6, 7, 8, 9]
+
+
+def test_element_info_anchor_composes_with_of_type(mgr_with_info: _MockManager):
+    """``of_type`` and ``of_geometry`` AND-narrow as expected."""
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_type("DispBeamColumn3d")
+        .of_physical_property("Steel_Elastic")
+    )
+    assert sorted(sel.ids().tolist()) == [1, 2, 3]
+
+
+def test_element_info_anchor_composes_with_filter_op(mgr_with_info: _MockManager):
+    """Filter ops apply after the anchor universe is resolved."""
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_geometry("Frame")
+        .within_box(min=(0.0, -0.5, 0.0), max=(1.5, 0.5, 0.5))
+    )
+    # Frame elements within the box: beam ids with centroid_x ∈ {0.5, 1.5}
+    # and centroid_z = 0 → exactly 2 beams (ids 1 and 4 in the fixture).
+    assert sel.count() == 2
+
+
+def test_unknown_geom_name_returns_empty(mgr_with_info: _MockManager):
+    """Unknown names produce empty results (consistent with ``of_type``)."""
+    sel = ElementSelector(mgr_with_info).of_geometry("DoesNotExist")
+    assert sel.count() == 0
+
+
+def test_empty_element_info_returns_empty(mgr: _MockManager):
+    """When dataset.cdata.element_info is empty, anchor resolves to empty."""
+    # The default `mgr` fixture has element_info={}.
+    sel = ElementSelector(mgr).of_geometry("anything")
+    assert sel.count() == 0
+
+
+def test_missing_cdata_attribute_raises(mgr_with_info: _MockManager):
+    """A dataset without ``cdata`` errors with a clear message."""
+    # Drop cdata to simulate an old/exotic dataset shape.
+    del mgr_with_info.dataset.cdata
+    sel = ElementSelector(mgr_with_info).of_geometry("Slab")
+    with pytest.raises(AttributeError, match="cdata"):
+        sel.ids()
+
+
+def test_element_info_anchor_negation_uses_anchor_universe(
+    mgr_with_info: _MockManager,
+):
+    """``~sel`` for an element_info anchor is well-defined: the complement
+    is everything else in the same universe (here, the anchor universe is
+    everything matching the anchor filters, so ``~`` returns everything
+    NOT matching them — which is an empty set if the universe is itself
+    just the match. We use the type universe for clarity).
+    """
+    sel = (
+        ElementSelector(mgr_with_info)
+        .of_type("DispBeamColumn3d")
+        .of_physical_property("Steel_Elastic")
+    )
+    # sel: beams 1..3
+    inv = ~sel
+    # Universe is "beams that are Steel_Elastic" = {1,2,3}; complement
+    # within that universe is empty.
+    assert inv.count() == 0
+
+
+def test_element_info_anchor_repr(mgr_with_info: _MockManager):
+    sel = ElementSelector(mgr_with_info).of_geometry("Slab").of_physical_property(
+        "Slab_Elastic"
+    )
+    r = repr(sel)
+    assert "of_geometry='Slab'" in r
+    assert "of_physical_property='Slab_Elastic'" in r
+
+
+def test_element_info_anchor_blocked_on_combined_selector(
+    mgr_with_info: _MockManager,
+):
+    a = ElementSelector(mgr_with_info).of_type("DispBeamColumn3d")
+    b = ElementSelector(mgr_with_info).of_geometry("Slab")
+    combined = a | b
+    with pytest.raises(TypeError, match="of_geometry"):
+        combined.of_geometry("Frame")
+    with pytest.raises(TypeError, match="of_physical_property"):
+        combined.of_physical_property("Steel_Elastic")

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -11,7 +11,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from STKO_to_python.model.cdata_reader import CDataReader
+import numpy as np
+
+from STKO_to_python.model.cdata_reader import (
+    CDataReader,
+    ElementInfo,
+    _read_length_prefixed,
+)
 
 
 def _ids_block(ids: list[int]) -> str:
@@ -207,3 +213,197 @@ def test_parse_errors_logged_not_printed(tmp_path, caplog) -> None:
         rec.name == "STKO_to_python.model.cdata_reader" and rec.levelno >= logging.ERROR
         for rec in caplog.records
     )
+
+
+# ---------------------------------------------------------------------- #
+# *LOCAL_AXES
+# ---------------------------------------------------------------------- #
+
+def test_local_axes_parses(tmp_path) -> None:
+    text = (
+        "*LOCAL_AXES\n"
+        "1 0 0.707107 0 0.707107\n"
+        "2 1 0 0 0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    axes = reader.local_axes
+    assert set(axes.keys()) == {1, 2}
+    np.testing.assert_allclose(axes[1], [0, 0.707107, 0, 0.707107])
+    np.testing.assert_allclose(axes[2], [1, 0, 0, 0])
+
+
+def test_local_axes_multi_partition_merge(tmp_path) -> None:
+    """Each partition owns disjoint elements; the merged dict covers both."""
+    part0 = "*LOCAL_AXES\n1 1 0 0 0\n"
+    part1 = "*LOCAL_AXES\n2 0 1 0 0\n"
+    reader = _make_reader(tmp_path, part0, part1)
+    axes = reader.local_axes
+    assert set(axes.keys()) == {1, 2}
+
+
+def test_local_axes_terminator_blank_line(tmp_path) -> None:
+    """The blank line that separates sections must end the LOCAL_AXES block."""
+    text = (
+        "*LOCAL_AXES\n"
+        "1 1 0 0 0\n"
+        "\n"
+        "#Begin SECTION OFFSET definitions.\n"
+        "*SECTION_OFFSET\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert set(reader.local_axes.keys()) == {1}
+
+
+# ---------------------------------------------------------------------- #
+# *SECTION_OFFSET
+# ---------------------------------------------------------------------- #
+
+def test_section_offset_parses(tmp_path) -> None:
+    text = (
+        "*SECTION_OFFSET\n"
+        "5 1.5 -2.0\n"
+        "6 0 0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    offsets = reader.section_offsets
+    np.testing.assert_allclose(offsets[5], [1.5, -2.0])
+    np.testing.assert_allclose(offsets[6], [0, 0])
+
+
+def test_section_offset_empty_section(tmp_path) -> None:
+    """STKO emits *SECTION_OFFSET with no data when nothing is offset
+    (matches the elasticFrame and QuadFrame examples).
+    """
+    text = (
+        "*SECTION_OFFSET\n"
+        "\n"
+        "#Begin BEAM PROFILE definitions.\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert reader.section_offsets == {}
+
+
+# ---------------------------------------------------------------------- #
+# *ELEMENT_INFO + length-prefixed name helper
+# ---------------------------------------------------------------------- #
+
+def test_read_length_prefixed_simple() -> None:
+    name, rest = _read_length_prefixed("5 Merge 0 Edge")
+    assert name == "Merge"
+    assert rest == "0 Edge"
+
+
+def test_read_length_prefixed_name_with_spaces() -> None:
+    """STKO encodes 'LENGTH NAME' with LENGTH = char count of NAME,
+    so embedded spaces in the name are preserved.
+    """
+    name, rest = _read_length_prefixed("21 New physical property 4 2 Q4")
+    assert name == "New physical property"
+    assert rest == "4 2 Q4"
+
+
+def test_read_length_prefixed_at_end_of_string() -> None:
+    name, rest = _read_length_prefixed("4 None")
+    assert name == "None"
+    assert rest == ""
+
+
+def test_element_info_parses(tmp_path) -> None:
+    """Mirrors the elasticFrame example row format."""
+    text = (
+        "*ELEMENT_INFO\n"
+        "1 7 5 Merge 0 Edge 1 7 elastic 2 14 elasticBeamCol\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    info = reader.element_info
+    assert set(info.keys()) == {1}
+    ei = info[1]
+    assert ei.element_id == 1
+    assert ei.geom_id == 7
+    assert ei.geom_name == "Merge"
+    assert ei.sub_geom_idx == 0
+    assert ei.sub_geom_type == "Edge"
+    assert ei.physical_property_id == 1
+    assert ei.physical_property_name == "elastic"
+    assert ei.element_property_id == 2
+    assert ei.element_property_name == "elasticBeamCol"
+
+
+def test_element_info_property_name_with_spaces(tmp_path) -> None:
+    """Property names can contain spaces (e.g. 'New physical property')."""
+    text = (
+        "*ELEMENT_INFO\n"
+        "498 9 5 Merge 0 Face 4 21 New physical property 4 2 Q4\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    ei = reader.element_info[498]
+    assert ei.geom_name == "Merge"
+    assert ei.sub_geom_type == "Face"
+    assert ei.physical_property_id == 4
+    assert ei.physical_property_name == "New physical property"
+    assert ei.element_property_id == 4
+    assert ei.element_property_name == "Q4"
+
+
+def test_element_info_returns_dataclass(tmp_path) -> None:
+    text = (
+        "*ELEMENT_INFO\n"
+        "1 7 5 Merge 0 Edge 0 4 None 0 4 None\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert isinstance(reader.element_info[1], ElementInfo)
+
+
+# ---------------------------------------------------------------------- #
+# Multi-section single-pass
+# ---------------------------------------------------------------------- #
+
+def test_single_pass_parses_all_sections_one_file(tmp_path) -> None:
+    """The driver dispatches markers in a single pass over the file."""
+    text = (
+        "#Begin LOCAL AXES.\n"
+        "*LOCAL_AXES\n"
+        "1 1 0 0 0\n"
+        "\n"
+        "*SECTION_OFFSET\n"
+        "1 10 20\n"
+        "\n"
+        "*ELEMENT_INFO\n"
+        "1 7 5 Merge 0 Edge 0 4 None 0 4 None\n"
+        "\n"
+        "*SELECTION_SET\n"
+        "1\n"
+        "4 Roof\n"
+        "2\n"
+        "0\n"
+        "10 20\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()  # triggers eager parse
+    assert sets[1]["NODES"] == [10, 20]
+    np.testing.assert_allclose(reader.local_axes[1], [1, 0, 0, 0])
+    np.testing.assert_allclose(reader.section_offsets[1], [10, 20])
+    assert reader.element_info[1].geom_name == "Merge"
+
+
+def test_real_quadframe_partitions(tmp_path) -> None:
+    """Smoke test against the committed multi-partition example: every
+    section that exists in the file must populate without error.
+    """
+    import os.path
+    here = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    base = os.path.join(here, "stko_results_examples", "elasticFrame", "QuadFrame_results")
+    p0 = os.path.join(base, "results.part-0.mpco.cdata")
+    p1 = os.path.join(base, "results.part-1.mpco.cdata")
+    if not (os.path.exists(p0) and os.path.exists(p1)):
+        pytest.skip("QuadFrame example not present in this checkout")
+
+    reader = CDataReader(SimpleNamespace(cdata_partitions={0: p0, 1: p1}))
+    # Each row in *LOCAL_AXES is one element; partitions should not
+    # overlap, so the merged dict has at least as many entries as either.
+    assert len(reader.local_axes) > 0
+    assert all(arr.shape == (4,) for arr in reader.local_axes.values())
+    # SECTION_OFFSET is empty in the example.
+    assert reader.section_offsets == {}
+    # ELEMENT_INFO covers every element with *LOCAL_AXES.
+    assert len(reader.element_info) >= len(reader.local_axes)

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -13,10 +13,12 @@ import pytest
 
 import numpy as np
 
+from STKO_to_python.model.cdata_format import CDataFormatPolicy
 from STKO_to_python.model.cdata_reader import (
     BeamProfile,
     CDataReader,
     ElementInfo,
+    _consume_ids,
     _read_length_prefixed,
 )
 
@@ -550,3 +552,147 @@ def test_beam_profile_assignment_multi_partition(tmp_path) -> None:
     reader = _make_reader(tmp_path, part0, part1)
     a = reader.beam_profile_assignments
     assert set(a.keys()) == {1, 2, 3, 4}
+
+
+# ---------------------------------------------------------------------- #
+# CDataFormatPolicy — section marker constants and queries
+# ---------------------------------------------------------------------- #
+
+def test_format_policy_known_markers_covers_every_section() -> None:
+    """Every section the parser dispatches on must be in known_markers().
+
+    Pins the contract: if a new *MARKER is added to the parser, it must
+    also be added to CDataFormatPolicy.
+    """
+    expected = {
+        "*SELECTION_SET",
+        "*LOCAL_AXES",
+        "*SECTION_OFFSET",
+        "*BEAM_PROFILE",
+        "*BEAM_PROFILE_ASSIGNMENT",
+        "*ELEMENT_INFO",
+    }
+    assert CDataFormatPolicy.known_markers() == expected
+
+
+def test_format_policy_is_section_marker_recognizes_known() -> None:
+    assert CDataFormatPolicy.is_section_marker("*SELECTION_SET")
+    assert CDataFormatPolicy.is_section_marker("  *LOCAL_AXES  ")
+    assert not CDataFormatPolicy.is_section_marker("*UNKNOWN")
+    assert not CDataFormatPolicy.is_section_marker("# comment")
+    assert not CDataFormatPolicy.is_section_marker("")
+
+
+def test_format_policy_is_any_marker_flags_arbitrary_star_lines() -> None:
+    """Boundary detection: any '*' line ends a section, recognized or not."""
+    assert CDataFormatPolicy.is_any_marker("*UNKNOWN")
+    assert CDataFormatPolicy.is_any_marker("*ELEMENT_INFO")
+    assert not CDataFormatPolicy.is_any_marker("# comment")
+    assert not CDataFormatPolicy.is_any_marker("")
+
+
+def test_format_policy_is_stateless_and_hashable() -> None:
+    """The policy uses __slots__ = () so instances are interchangeable."""
+    a = CDataFormatPolicy()
+    b = CDataFormatPolicy()
+    assert repr(a) == repr(b) == "CDataFormatPolicy()"
+
+
+# ---------------------------------------------------------------------- #
+# _consume_ids — width-agnostic id list reader
+# ---------------------------------------------------------------------- #
+
+def test_consume_ids_zero_count_is_noop() -> None:
+    lines = ["10 20 30\n"]
+    arr, end = _consume_ids(lines, 0, 0)
+    assert arr.shape == (0,)
+    assert end == 0
+
+
+def test_consume_ids_single_line_default_wrap() -> None:
+    lines = ["1 2 3 4 5 6 7 8 9 10\n", "11 12\n"]
+    arr, end = _consume_ids(lines, 0, 12)
+    assert arr.tolist() == list(range(1, 13))
+    assert end == 2
+
+
+def test_consume_ids_one_per_line() -> None:
+    """Width-agnostic: a file wrapped at 1 id per line still parses."""
+    lines = [f"{x}\n" for x in range(1, 11)]
+    arr, end = _consume_ids(lines, 0, 10)
+    assert arr.tolist() == list(range(1, 11))
+    assert end == 10
+
+
+def test_consume_ids_all_on_one_line() -> None:
+    """Width-agnostic: a file with no wrap (all on one line) still parses."""
+    lines = ["1 2 3 4 5 6 7 8 9 10 11 12 13 14 15\n"]
+    arr, end = _consume_ids(lines, 0, 15)
+    assert arr.tolist() == list(range(1, 16))
+    assert end == 1
+
+
+def test_consume_ids_stops_when_count_reached_in_middle_of_line() -> None:
+    """If the wrap width over-emits on the last line, take only what's needed."""
+    lines = ["1 2 3 4 5\n"]
+    arr, end = _consume_ids(lines, 0, 3)
+    assert arr.tolist() == [1, 2, 3]
+    assert end == 1
+
+
+def test_consume_ids_raises_on_truncation_by_marker() -> None:
+    lines = ["1 2 3\n", "*SELECTION_SET\n"]
+    with pytest.raises(ValueError, match="truncated"):
+        _consume_ids(lines, 0, 10)
+
+
+def test_consume_ids_raises_on_truncation_by_blank() -> None:
+    lines = ["1 2 3\n", "\n", "next section\n"]
+    with pytest.raises(ValueError, match="truncated"):
+        _consume_ids(lines, 0, 10)
+
+
+def test_consume_ids_raises_on_eof() -> None:
+    lines = ["1 2 3\n"]
+    with pytest.raises(ValueError, match="EOF"):
+        _consume_ids(lines, 0, 10)
+
+
+# ---------------------------------------------------------------------- #
+# Selection-set parser is now width-agnostic end-to-end
+# ---------------------------------------------------------------------- #
+
+def test_selection_set_parses_with_one_id_per_line_wrap(tmp_path) -> None:
+    """A file wrapping ids at width=1 should parse identically to width=10."""
+    text = (
+        "*SELECTION_SET\n"
+        "1\n"
+        "4 Test\n"
+        "5\n"           # NNODES = 5
+        "0\n"           # NELEMENTS = 0
+        # 5 nodes, one per line — atypical but legal under the new parser
+        "100\n"
+        "200\n"
+        "300\n"
+        "400\n"
+        "500\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[1]["NODES"] == [100, 200, 300, 400, 500]
+
+
+def test_selection_set_parses_with_all_ids_on_one_line(tmp_path) -> None:
+    """A file with no wrap at all should still parse."""
+    text = (
+        "*SELECTION_SET\n"
+        "2\n"
+        "3 Big\n"
+        "15\n"
+        "0\n"
+        # 15 nodes all on one line — outside the conventional wrap
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    sets = reader._extract_selection_set_ids()
+    assert sets[2]["NODES"] == list(range(1, 16))

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -14,6 +14,7 @@ import pytest
 import numpy as np
 
 from STKO_to_python.model.cdata_reader import (
+    BeamProfile,
     CDataReader,
     ElementInfo,
     _read_length_prefixed,
@@ -407,3 +408,145 @@ def test_real_quadframe_partitions(tmp_path) -> None:
     assert reader.section_offsets == {}
     # ELEMENT_INFO covers every element with *LOCAL_AXES.
     assert len(reader.element_info) >= len(reader.local_axes)
+    # Beam profile 1 (the rectangular section) exists in both partitions
+    # — dedup should produce exactly one entry.
+    assert 1 in reader.beam_profiles
+    p1 = reader.beam_profiles[1]
+    assert p1.points.shape == (4, 2)
+    # Every beam element in the file has a profile assignment.
+    assert len(reader.beam_profile_assignments) > 0
+
+
+# ---------------------------------------------------------------------- #
+# *BEAM_PROFILE
+# ---------------------------------------------------------------------- #
+
+# Rectangular 4-point profile with 2 triangles, 4 straight edges, 4 sweep
+# points. Mirrors the bundled elasticFrame example exactly.
+_RECT_PROFILE = (
+    "*BEAM_PROFILE\n"
+    "1\n"
+    "4 2 4 4\n"
+    "-150 -200\n"
+    "150 -200\n"
+    "150 200\n"
+    "-150 200\n"
+    "0 1 2\n"
+    "0 2 3\n"
+    "2 0 1\n"
+    "2 1 2\n"
+    "2 2 3\n"
+    "2 3 0\n"
+    "0\n"
+    "1\n"
+    "2\n"
+    "3\n"
+)
+
+
+def test_beam_profile_rectangle_parses(tmp_path) -> None:
+    reader = _make_reader(tmp_path, _RECT_PROFILE)
+    profiles = reader.beam_profiles
+    assert set(profiles.keys()) == {1}
+
+    p = profiles[1]
+    assert isinstance(p, BeamProfile)
+    assert p.profile_id == 1
+    np.testing.assert_allclose(
+        p.points, [[-150, -200], [150, -200], [150, 200], [-150, 200]]
+    )
+    np.testing.assert_array_equal(p.triangles, [[0, 1, 2], [0, 2, 3]])
+    # All 4 edges are 2-point edges around the rectangle outline.
+    assert len(p.edges) == 4
+    np.testing.assert_array_equal(p.edges[0], [0, 1])
+    np.testing.assert_array_equal(p.edges[3], [3, 0])
+    np.testing.assert_array_equal(p.sweeps, [0, 1, 2, 3])
+
+
+def test_beam_profile_variable_length_edges(tmp_path) -> None:
+    """An edge with more than 2 points (curved outline)."""
+    text = (
+        "*BEAM_PROFILE\n"
+        "5\n"
+        "3 1 2 1\n"
+        "0 0\n"
+        "1 0\n"
+        "0 1\n"
+        "0 1 2\n"        # 1 triangle
+        "3 0 1 2\n"      # edge with 3 points
+        "2 2 0\n"        # edge with 2 points
+        "0\n"            # 1 sweep
+    )
+    reader = _make_reader(tmp_path, text)
+    p = reader.beam_profiles[5]
+    assert len(p.edges) == 2
+    np.testing.assert_array_equal(p.edges[0], [0, 1, 2])
+    np.testing.assert_array_equal(p.edges[1], [2, 0])
+
+
+def test_beam_profile_multiple_profiles_in_one_section(tmp_path) -> None:
+    """A *BEAM_PROFILE section can carry several profile blocks back-to-back."""
+    text = (
+        "*BEAM_PROFILE\n"
+        # profile 1: 2 points, 0 tris, 1 edge (2-point), 0 sweeps
+        "1\n"
+        "2 0 1 0\n"
+        "0 0\n"
+        "1 0\n"
+        "2 0 1\n"
+        # profile 2: 3 points, 1 tri, 0 edges, 1 sweep
+        "2\n"
+        "3 1 0 1\n"
+        "0 0\n"
+        "1 0\n"
+        "0 1\n"
+        "0 1 2\n"
+        "0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert set(reader.beam_profiles.keys()) == {1, 2}
+    assert reader.beam_profiles[1].points.shape == (2, 2)
+    assert reader.beam_profiles[2].triangles.shape == (1, 3)
+
+
+def test_beam_profile_multi_partition_dedup_first_wins(tmp_path) -> None:
+    """Profile defs are duplicated identically across MP partitions; keep one."""
+    reader = _make_reader(tmp_path, _RECT_PROFILE, _RECT_PROFILE)
+    assert set(reader.beam_profiles.keys()) == {1}
+
+
+# ---------------------------------------------------------------------- #
+# *BEAM_PROFILE_ASSIGNMENT
+# ---------------------------------------------------------------------- #
+
+def test_beam_profile_assignment_simple(tmp_path) -> None:
+    text = (
+        "*BEAM_PROFILE_ASSIGNMENT\n"
+        "1 1 1 1\n"
+        "2 1 1 1\n"
+        "3 1 2 0.5\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    a = reader.beam_profile_assignments
+    assert a[1] == [(1, 1.0)]
+    assert a[2] == [(1, 1.0)]
+    assert a[3] == [(2, 0.5)]
+
+
+def test_beam_profile_assignment_multiple_profiles_per_element(tmp_path) -> None:
+    """An element can carry multiple profiles, modelling a tapered section."""
+    text = (
+        "*BEAM_PROFILE_ASSIGNMENT\n"
+        "1 2 1 0.3 2 0.7\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    assert reader.beam_profile_assignments[1] == [(1, 0.3), (2, 0.7)]
+
+
+def test_beam_profile_assignment_multi_partition(tmp_path) -> None:
+    """Each element is owned by exactly one partition; merging is dict-union."""
+    part0 = "*BEAM_PROFILE_ASSIGNMENT\n1 1 1 1\n2 1 1 1\n"
+    part1 = "*BEAM_PROFILE_ASSIGNMENT\n3 1 1 1\n4 1 1 1\n"
+    reader = _make_reader(tmp_path, part0, part1)
+    a = reader.beam_profile_assignments
+    assert set(a.keys()) == {1, 2, 3, 4}


### PR DESCRIPTION
## Why this PR exists

The stack #57–#61 was built and reviewed as five layered PRs, each with the one below as its base. **Only [#57](https://github.com/nmorabowen/STKO_to_python/pull/57) actually landed on \`main\`** — the other four (#58, #59, #60, #61) show as MERGED on GitHub but each merged into the *intermediate* branch one step below it in the stack, never reaching \`main\`.

This PR delivers the four commits that are currently orphaned on \`origin/guppi/cdata-format-policy\` to \`main\` in one shot. No new code — just plumbing.

## What's in the diff

Four commits (\`git log main..guppi/cdata-format-policy\`):

| Commit | Title | Net |
|---|---|---|
| af4c4c8 | Add CDataFormatPolicy and make id-list parsing width-agnostic | [#61](https://github.com/nmorabowen/STKO_to_python/pull/61) |
| 3120c92 | Add ElementSelector anchors backed by *ELEMENT_INFO | [#60](https://github.com/nmorabowen/STKO_to_python/pull/60) |
| 3a384b5 | Parse *BEAM_PROFILE and *BEAM_PROFILE_ASSIGNMENT from .cdata | [#59](https://github.com/nmorabowen/STKO_to_python/pull/59) |
| e3fe91c | Parse *LOCAL_AXES, *SECTION_OFFSET, *ELEMENT_INFO from .cdata | [#58](https://github.com/nmorabowen/STKO_to_python/pull/58) |

\`git diff --stat origin/main..origin/guppi/cdata-format-policy\` shows 7 files, +1447 / -121.

## Public API surface added

- \`STKO_to_python.ElementInfo\`, \`STKO_to_python.BeamProfile\` (frozen dataclasses)
- New accessors on \`CDataReader\`: \`local_axes\`, \`section_offsets\`, \`element_info\`, \`beam_profiles\`, \`beam_profile_assignments\`
- New \`ElementSelector\` anchors: \`of_geometry\`, \`of_physical_property\`, \`of_element_property\`, \`of_sub_geom_type\`
- New module \`STKO_to_python.model.cdata_format.CDataFormatPolicy\`

Per CLAUDE.md's semver policy this is a **MINOR** addition (new backward-compatible API). The version bump to \`1.3.0\` and tag will follow once this lands.

## Test plan

- [x] All four commits' tests already passed when their respective PRs landed in their (now-orphaned) intermediate branches.
- [x] No new code or merges introduced by this PR — fast-forward of the same four commits to \`main\`.
- [x] CI on this rescue PR will re-run the full test matrix on top of current \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)