### PR TITLE
Add CHANGELOG.md and surface v1.3.0 in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,170 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project adheres to [Semantic Versioning](https://semver.org/) as
+spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
+
+- **MAJOR** (`vX.0.0`) — breaking changes to the public API.
+- **MINOR** (`v1.X.0`) — new backward-compatible features.
+- **PATCH** (`v1.x.Y`) — bug fixes, docs, internal refactors with no API change.
+
+## [Unreleased]
+
+_Nothing pending._
+
+---
+
+## [1.3.0] — 2026-05-11
+
+Adds full parsing of the `.cdata` sidecar file (every section, not just
+`*SELECTION_SET`) and turns the new metadata into a user-facing
+"select by STKO geometry/property name" workflow on `ElementSelector`.
+Verified end-to-end against the bundled 95k-line example.
+
+### Added
+
+- **`CDataReader` now parses every `.cdata` section** in one pass per
+  partition. New `@cached_property` accessors on the reader (and
+  reachable via `dataset.cdata.X`):
+  - `local_axes` — `{elem_id: ndarray([qw, qx, qy, qz])}` per-element
+    rotation quaternion ([#58](https://github.com/nmorabowen/STKO_to_python/pull/58))
+  - `section_offsets` — `{elem_id: ndarray([yOff, zOff])}` in
+    element-local coords ([#58](https://github.com/nmorabowen/STKO_to_python/pull/58))
+  - `element_info` — `{elem_id: ElementInfo}` parent geometry,
+    sub-geometry type, and physical/element property names
+    ([#58](https://github.com/nmorabowen/STKO_to_python/pull/58))
+  - `beam_profiles` — `{profile_id: BeamProfile}` 2D cross-section
+    geometry (points, triangulation, edge outline, sweep indices)
+    ([#59](https://github.com/nmorabowen/STKO_to_python/pull/59))
+  - `beam_profile_assignments` — `{elem_id: [(profile_id, weight), ...]}`
+    element-to-profile mapping ([#59](https://github.com/nmorabowen/STKO_to_python/pull/59))
+- **`ElementInfo`** and **`BeamProfile`** frozen dataclasses,
+  re-exported at the top level (`STKO_to_python.ElementInfo`,
+  `STKO_to_python.BeamProfile`).
+- **Four new `ElementSelector` anchor primitives** resolving against
+  `.cdata` `*ELEMENT_INFO` ([#60](https://github.com/nmorabowen/STKO_to_python/pull/60)):
+  - `.of_geometry(name)` — STKO parent geometry name
+  - `.of_physical_property(name)` — material/section property name
+  - `.of_element_property(name)` — element class property name
+  - `.of_sub_geom_type(t)` — `"Edge"` / `"Face"` / `"Solid"`
+- **`STKO_to_python.model.cdata_format.CDataFormatPolicy`** — pure-
+  functional policy class mirroring `MpcoFormatPolicy`. Owns the six
+  section marker tokens plus `known_markers()`, `is_section_marker()`,
+  `is_any_marker()` ([#61](https://github.com/nmorabowen/STKO_to_python/pull/61)).
+- Cookbook recipe
+  [`07-select-by-geometry-and-property.md`](docs/cookbook/07-select-by-geometry-and-property.md) —
+  end-to-end walk-through of the new selector anchors.
+
+### Changed
+
+- **Selection-set id-list parsing is now wrap-width agnostic.** The
+  previous parser assumed exactly 10 ids per line via `(n + 9) // 10`;
+  the new `_consume_ids` helper scans forward consuming integers until
+  the expected count is reached, so any wrap width parses correctly
+  ([#61](https://github.com/nmorabowen/STKO_to_python/pull/61)).
+- **`.cdata` parse failures fail fast.** Previously a malformed file
+  silently returned `[]`, producing a partial `dataset.selection_set`
+  that broke downstream queries far from the cause. Now the parser
+  logs the offending file via `logger.exception` and re-raises, so
+  dataset construction fails loudly at the source
+  ([#57](https://github.com/nmorabowen/STKO_to_python/pull/57)).
+
+### Fixed
+
+- `.cdata` files are now opened with `encoding="utf-8", errors="replace"` —
+  fixes a `UnicodeDecodeError` on Windows when files contain non-ASCII
+  bytes (`cp1252` was the previous default)
+  ([#57](https://github.com/nmorabowen/STKO_to_python/pull/57)).
+- Latent `UnboundLocalError` when a selection set had `NNODES=0` and
+  `NELEMENTS>0` (the element parsing branch referenced an unbound
+  `nodes_end_line`). Not triggered by current STKO output but real
+  ([#57](https://github.com/nmorabowen/STKO_to_python/pull/57)).
+- `print_selection_set_names` now routes through the module logger
+  (`logger.info`) instead of `print`, matching every sibling reader
+  ([#57](https://github.com/nmorabowen/STKO_to_python/pull/57)).
+- Dropped a wasteful `np.array(lines, dtype=str)` wrapper in the
+  selection-set parser — it allocated a fixed-width `U`-array sized
+  to the longest line for no speedup ([#57](https://github.com/nmorabowen/STKO_to_python/pull/57)).
+- Removed a stale docstring on `_extract_selection_set_ids`
+  referencing a `fileName` argument that the method does not take
+  ([#57](https://github.com/nmorabowen/STKO_to_python/pull/57)).
+
+### Test coverage
+
+- 30 new unit tests for the `.cdata` parser (selection-set, every new
+  section, the width-agnostic id consumer, format policy, error paths).
+- 13 new unit tests for the `ElementSelector` anchors backed by
+  `*ELEMENT_INFO`.
+- Real-file smoke checks against the bundled `QuadFrame_results` and
+  the 95k-line `examples/New/results_nodes.mpco.cdata` sidecar.
+- Total unit suite: **613 passed** (was 566 before the stack), 1
+  pre-existing skip.
+
+---
+
+## [1.2.0] — 2026-05-09
+
+### Added
+
+- **`ElementSelector`** — lazy, chainable, composable element-id
+  queries with spatial primitives (`within_box`, `within_distance`,
+  `nearest_to`, `on_plane`, `near_line`, `centroid_in`, `where`)
+  and Boolean composition (`&` / `|` / `~`).
+- **`NodeSelector` + `NodeResultMask`** — node-side equivalents,
+  with the same anchor / filter-op / boolean-algebra design.
+- **`ResultMask`** — per-element boolean mask built from value
+  conditions over a time window, applied via `er[mask]`.
+- Top-level [selector + mask pipeline guide](docs/selector_and_mask_pipeline.md)
+  promoted to a primary doc.
+- Cookbook recipes 05 (element pipeline) and 06 (node pipeline).
+- Test CI workflow, benchmark CI workflow.
+
+### Changed
+
+- Group B file renames: managers are now on canonical paths
+  (`nodes.node_manager`, `elements.element_manager`, etc.).
+  Legacy paths emit `DeprecationWarning` via PEP 562 `__getattr__`
+  shims and continue to import.
+- `Gauss` / `shape` modules relocated from `utilities/` to `format/`.
+- `__slots__` applied to `NodalResults` and `_ResultView` for memory
+  footprint (Phase 4a).
+
+---
+
+## [1.1.0] — 2026-04 / 2026-05
+
+### Added
+
+- Layered shells support (MPCO recorder + `ElementResults`).
+- Per-element fixtures and demo notebooks under `examples/`.
+- API stubs filled in across the doc tree.
+- Spatial-query polish for `ElementResults`.
+
+### Changed
+
+- Examples nav and index restructuring; element-results API and
+  navigation overhauled.
+
+See the merge log for full detail:
+`git log --merges v1.0.0..v1.1.0`.
+
+---
+
+## [1.0.0] — initial public release
+
+Initial release. `MPCODataSet` opens MPCO HDF5 recorder output;
+`NodalResults` / `ElementResults` expose result DataFrames;
+`Aggregator` provides cross-element/cross-step engineering reductions
+(interstory drift, envelopes, residuals, orbits); `NodalResultsPlotter`
+produces publication figures. Multi-partition MP output is read
+transparently.
+
+See `git log --merges v1.0.0` for the full pre-1.0 history.
+
+[Unreleased]: https://github.com/nmorabowen/STKO_to_python/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/nmorabowen/STKO_to_python/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ pytest tests/ -q                 # full test suite (unit + integration)
 pytest bench/ -q                 # benchmarks (requires the `bench` extra)
 ```
 
-Test suite is **349 green** as of Phase 5. Benchmarks are opt-in and
+The unit suite runs in a few seconds. Benchmarks are opt-in and
 scoped to `bench/` so the default `pytest tests/` command doesn't pay
 their collection overhead.
+
+## What's new
+
+Per-release notes live in [`CHANGELOG.md`](CHANGELOG.md). The latest
+release, **v1.3.0**, parses every section of the `.cdata` sidecar
+(not just `*SELECTION_SET`) and adds *select-by-STKO-geometry-name*
+anchors on `ElementSelector` — see [cookbook 07](docs/cookbook/07-select-by-geometry-and-property.md)
+for the walkthrough.

--- a/docs/MPCODataSet.md
+++ b/docs/MPCODataSet.md
@@ -48,7 +48,30 @@ ds.selection_set           # dict — {id: {'SET_NAME': ..., 'NODES': [...], 'EL
 ds.results_partitions      # dict — {file_id: filepath}
 ds.nodes_info              # dict — {'array': np.ndarray, 'dataframe': pd.DataFrame}
 ds.elements_info           # dict — {'array': np.ndarray, 'dataframe': pd.DataFrame}
+ds.cdata                   # CDataReader — see "STKO metadata via cdata" below
 ```
+
+## STKO metadata via `cdata`
+
+`ds.cdata` is a `CDataReader` that exposes every section the
+`.cdata` sidecar carries — parsed once at construction:
+
+```python
+ds.cdata.element_info               # {elem_id: ElementInfo}
+ds.cdata.local_axes                 # {elem_id: ndarray([qw, qx, qy, qz])}
+ds.cdata.section_offsets            # {elem_id: ndarray([yOff, zOff])}
+ds.cdata.beam_profiles              # {profile_id: BeamProfile}
+ds.cdata.beam_profile_assignments   # {elem_id: [(profile_id, weight), ...]}
+```
+
+`ElementInfo` is a frozen dataclass with the STKO names every element
+carries — parent geometry, sub-geometry type, physical/element
+property names. It's what powers the `select().of_geometry(...)`
+family of anchors. `BeamProfile` carries the 2D cross-section
+geometry of each profile (points, triangulation, edges, sweeps).
+
+See [cookbook 07 — Select by STKO geometry and property name](cookbook/07-select-by-geometry-and-property.md)
+for the end-to-end workflow.
 
 ## Exploring the Dataset
 

--- a/docs/api/mpco-dataset.md
+++ b/docs/api/mpco-dataset.md
@@ -33,7 +33,26 @@ ds = MPCODataSet(
 | `ds.time` | `pd.DataFrame` | Time array per stage |
 | `ds.nodes` | `NodeManager` | Nodal result manager |
 | `ds.elements` | `ElementManager` | Element result manager |
+| `ds.cdata` | `CDataReader` | Parsed `.cdata` sections (see below) |
 | `ds.plot` | plot facade | Dataset-level XY plotter |
+
+### `ds.cdata` accessors
+
+The reader parses the `.cdata` sidecar once at construction; each
+accessor below is a `cached_property` over the result:
+
+| Accessor | Type | Source section |
+|---|---|---|
+| `ds.cdata.element_info` | `dict[int, ElementInfo]` | `*ELEMENT_INFO` |
+| `ds.cdata.local_axes` | `dict[int, ndarray(4,)]` | `*LOCAL_AXES` |
+| `ds.cdata.section_offsets` | `dict[int, ndarray(2,)]` | `*SECTION_OFFSET` |
+| `ds.cdata.beam_profiles` | `dict[int, BeamProfile]` | `*BEAM_PROFILE` |
+| `ds.cdata.beam_profile_assignments` | `dict[int, list[(int, float)]]` | `*BEAM_PROFILE_ASSIGNMENT` |
+
+`ElementInfo` and `BeamProfile` are frozen dataclasses re-exported
+at the top level. `element_info` is what powers the
+`select().of_geometry(...)` / `.of_physical_property(...)` family of
+`ElementSelector` anchors.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,9 @@ ds.plot.xy(
   [Node selector + mask pipeline](cookbook/06-node-selector-and-mask-pipeline.md)
   are the recipe-style introductions to the lazy-query / value-mask
   workflow on each side.
+  [Select by STKO geometry and property name](cookbook/07-select-by-geometry-and-property.md)
+  (v1.3.0+) covers the cdata-backed `of_geometry` / `of_physical_property`
+  family of selector anchors.
 - **[Architecture](architecture.md)** — the layered design, what lives
   where, pickle compatibility, and the per-phase refactor history.
 - **[API reference](api/index.md)** — class-by-class docs generated

--- a/docs/selector_and_mask_pipeline.md
+++ b/docs/selector_and_mask_pipeline.md
@@ -123,7 +123,9 @@ An unanchored selector resolves over **every element in the index**
 
 ### 2.2 Anchors — set the universe
 
-Three ways to anchor:
+Seven ways to anchor: three over the element index itself, and four
+over the STKO names recorded in the `.cdata` sidecar (added in
+v1.3.0).
 
 ```python
 # By element class (decorated [bracket] suffix is stripped automatically)
@@ -140,17 +142,39 @@ walls = ds.elements.select().from_selection(["Walls", "Slabs"])  # several
 # By explicit ids
 some = ds.elements.select().with_ids([1, 5, 9])
 print(some.count())                 # 3
+
+# By STKO names from .cdata *ELEMENT_INFO (v1.3.0+)
+shells   = ds.elements.select().of_sub_geom_type("Face")           # Edge / Face / Solid
+slabs    = ds.elements.select().of_geometry("Slab")                # STKO parent geometry
+elastics = ds.elements.select().of_physical_property("elastic")    # material / section
+q4s      = ds.elements.select().of_element_property("Q4")          # element class name
 ```
+
+The four `of_geometry` / `of_physical_property` / `of_element_property` /
+`of_sub_geom_type` anchors resolve against
+`ds.cdata.element_info` — see
+[cookbook 07](cookbook/07-select-by-geometry-and-property.md) for an
+end-to-end walkthrough. They behave exactly like the three older
+anchors: AND-narrowing when stacked, valid universe for `~`, blocked
+on combinators (`a & b`).
 
 Anchors are the universe used by negation (`~`) — see §3.3.
 
-You can stack anchors (intersection):
+You can stack anchors (intersection) — including mixing classic and
+cdata-backed:
 
 ```python
 sel = (ds.elements.select()
        .of_type("DispBeamColumn3d")
        .with_ids([1, 5, 9, 99]))
 print(sel.ids().tolist())   # [1, 5, 9]   ← 99 is not in the index
+
+# Beams that are also load-bearing (filtering out rigid-link edges):
+loadbearing_beams = (
+    ds.elements.select()
+    .of_sub_geom_type("Edge")
+    .of_element_property("elasticBeamCol")
+)
 ```
 
 ### 2.3 Spatial primitives


### PR DESCRIPTION
## Summary

The project had no changelog. This PR adds one (Keep-a-Changelog format) and threads the v1.3.0 features through the four docs that didn't yet mention them.

## What's in the diff

### `CHANGELOG.md` (new)

- **Full detail for `v1.3.0`** — every Added / Changed / Fixed line links back to its source PR (#57–#63 in the cdata stack), with the test-coverage delta (566 → 613 unit tests) called out at the bottom.
- **Summary entries for `v1.2.0` / `v1.1.0` / `v1.0.0`** — high-level descriptions plus a `git log --merges` pointer rather than retroactively manufacturing detail.
- **Diff links** at the bottom (`v1.0.0...v1.1.0`, etc.) so readers can jump straight to the relevant commit range.

### Docs

- **`README.md`** — dropped the stale "349 green as of Phase 5" claim (the suite is much larger now and the absolute number rots fast). Added a "What's new" pointer to `CHANGELOG.md` + cookbook 07.
- **`docs/MPCODataSet.md`** — new "STKO metadata via cdata" section showing the five new `cached_property` accessors (`element_info`, `local_axes`, `section_offsets`, `beam_profiles`, `beam_profile_assignments`) and linking to cookbook 07.
- **`docs/api/mpco-dataset.md`** — `ds.cdata` row added to the attributes table, plus a sub-table breaking down the five accessors with types and source `.cdata` sections.
- **`docs/selector_and_mask_pipeline.md`** — §2.2 expanded from "Three ways to anchor" to "Seven ways to anchor" with the four new `of_geometry` / `of_physical_property` / `of_element_property` / `of_sub_geom_type` anchors, including a load-bearing-beams composition example mixing classic + cdata anchors.
- **`docs/index.md`** — added cookbook 07 reference to the "Where to read next" cookbook bullet.

## What's *not* in the diff

- `CHANGELOG.md` is **not** added to the mkdocs nav. It lives at the repo root (GitHub convention); plumbing it into mkdocs cleanly needs either a plugin or a duplicated copy under `docs/`, which felt out of scope for a polish PR. The README and `docs/index.md` link to it where appropriate.

## Test plan

- [x] No code changes — docs-only.
- [x] Every new accessor / anchor mentioned in the changelog and docs actually exists on `main` (cross-checked against the merged commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)