### PR TITLE
Apply *LOCAL_AXES: quaternion-to-rotation helper + ElementResults round-trip

### DIFF
--- a/docs/cookbook/08-rotate-beam-forces-to-global.md
+++ b/docs/cookbook/08-rotate-beam-forces-to-global.md
@@ -1,0 +1,193 @@
+# Rotate beam-local forces and moments to the global frame
+
+> Take OpenSees ``localForce`` output and rotate it back to global
+> coordinates using the per-element quaternions STKO writes in the
+> ``*LOCAL_AXES`` section of the ``.cdata`` sidecar. End-to-end
+> verification against ``globalForces`` on the same elements.
+
+The engineering question is: *I have section forces / moments in the
+element-local frame and I need them in global — what's the rotation?*
+STKO writes one quaternion per element to the ``.cdata`` sidecar;
+v1.3.0+ parses it. v1.4.0 turns it into a rotation matrix you can
+multiply through.
+
+The fixture used here is
+``stko_results_examples/elasticFrame/elasticFrame_mesh_results`` — 11
+``5-ElasticBeam3d`` elements (six columns running along global Z, five
+beams running along global X). It happens to record *both* ``force``
+(global) and ``localForce`` (element-local), which means we can
+**verify the rotation by round-tripping**: rotate ``localForce`` with
+the cdata quaternion and check it matches ``force``.
+
+```python
+from pathlib import Path
+import numpy as np
+
+from STKO_to_python import MPCODataSet
+
+REPO_ROOT = Path("path/to/STKO_to_python")
+DATASET = REPO_ROOT / "stko_results_examples" / "elasticFrame" / "elasticFrame_mesh_results"
+
+ds = MPCODataSet(str(DATASET), "results", verbose=False)
+```
+
+---
+
+## 1. Inspect the per-element orientation
+
+`ds.cdata.local_axes` carries one unit quaternion per element, in
+`(qw, qx, qy, qz)` order. STKO writes it relative to the global frame
+— it describes how the *element-local* axes sit in global. Visiting
+two elements with different orientations:
+
+```python
+print("column q:", ds.cdata.local_axes[1])
+# column q: [0.       0.707107 0.       0.707107]
+print("beam q  :", ds.cdata.local_axes[7])
+# beam q  : [1. 0. 0. 0.]
+```
+
+The beam quaternion is the identity (beams run along global X — no
+rotation needed). The column quaternion is a 180° rotation about the
+in-plane diagonal that makes the element-local x-axis point along
+global Z.
+
+`ds.cdata.rotation_matrix(elem_id)` turns the quaternion into a
+``(3, 3)`` matrix you apply to local-frame 3-vectors:
+
+```python
+R = ds.cdata.rotation_matrix(1)
+print(R)
+# [[-0.  0.  1.]
+#  [ 0. -1.  0.]
+#  [ 1.  0. -0.]]
+print(R @ np.array([1.0, 0.0, 0.0]))   # local x in global coords
+# [-2.22e-16  0.  1.]
+```
+
+The first column of `R` is `local-x in global`. For the column it's
+``(0, 0, 1)`` — exactly along global Z. ✓
+
+---
+
+## 2. Compare a single time step in both frames
+
+Fetch the same instant from both recorders and stack the results
+side-by-side. The last load step:
+
+```python
+er_global = ds.elements.get_element_results(
+    results_name="force",      element_type="5-ElasticBeam3d",
+    model_stage="MODEL_STAGE[1]", element_ids=[1],
+)
+er_local = ds.elements.get_element_results(
+    results_name="localForce", element_type="5-ElasticBeam3d",
+    model_stage="MODEL_STAGE[1]", element_ids=[1],
+)
+print(er_global.df.iloc[-1])
+# Px_1   -7.644e+03
+# Py_1    0.000e+00
+# Pz_1    2.500e+04
+# Mx_1    0.000e+00
+# My_1   -7.588e+06
+# Mz_1    0.000e+00
+# ...
+
+print(er_local.df.iloc[-1])
+# N_1     2.500e+04   ← axial = force along local x = global Z
+# Vy_1    0.000e+00
+# Vz_1   -7.644e+03   ← transverse shear = -global X
+# T_1    -0.000e+00
+# My_1    7.588e+06
+# Mz_1    0.000e+00
+# ...
+```
+
+The numbers line up the way the rotation matrix says they should:
+applying ``R`` to local ``(N=25000, Vy=0, Vz=-7644)`` gives global
+``(Px=-7644, Py=0, Pz=25000)``.
+
+---
+
+## 3. Rotate `localForce` and verify it matches `force`
+
+`force` carries 12 components per step in the order
+``(Px_1, Py_1, Pz_1, Mx_1, My_1, Mz_1, Px_2, Py_2, Pz_2, Mx_2, My_2, Mz_2)``:
+force then moment at each of the two end nodes. `localForce` has the
+same layout in the element-local frame
+(``N, Vy, Vz, T, My, Mz`` per node). So the rotation is four
+``(3,)``-vector rotations per row:
+
+```python
+R = ds.cdata.rotation_matrix(1)
+local_df = er_local.df
+
+# Right-multiply by R.T so each row's four 3-vectors get rotated.
+rotated = local_df.values.copy()
+for k in range(4):
+    cols = slice(3 * k, 3 * (k + 1))
+    rotated[:, cols] = local_df.values[:, cols] @ R.T
+
+diff = np.max(np.abs(rotated - er_global.df.values))
+print(f"max |R @ localForce - force| = {diff:.3e}")
+# max |R @ localForce - force| = 3.725e-09     ← machine precision
+```
+
+The reason the round-trip is exact (not 1e-6) is that
+`quaternion_to_rotation_matrix` normalizes the input quaternion
+before building `R`. STKO writes ``0.707107`` to six digits — without
+normalization the resulting matrix is off-orthogonality by ~1e-6,
+which compounds to errors of a few units on 1e6-magnitude moments.
+
+---
+
+## 4. Vectorized: every element at once
+
+For real models, fetch every rotation matrix in one batch and apply
+them to the result tensor with `np.einsum`:
+
+```python
+ids, R = ds.cdata.rotation_matrices()        # (N,), (N, 3, 3)
+print(ids.shape, R.shape)
+# (11,) (11, 3, 3)
+```
+
+If you have a ``(steps, n_elements, 3)`` local-frame array of shears
+(or any 3-vector quantity) you can rotate every row in one shot:
+
+```python
+# Imagine V_local has shape (n_steps, n_elements, 3) in element-local.
+# Align it row-for-row with ids, then:
+V_global = np.einsum("eij,sej->sei", R, V_local)
+```
+
+Same shape for moments. For the full 12-component beam output you
+just do the einsum on each `(steps, n_elements, 3)` slice (`F_1`,
+`M_1`, `F_2`, `M_2`).
+
+---
+
+## Variations
+
+- **Going the other way (global → local).** ``R`` is orthogonal,
+  so the inverse is the transpose: ``v_local = R.T @ v_global``.
+  Useful when you have global section forces and want them in the
+  local frame to interpret as N / V / M.
+- **Section forces at integration points.** ``section.force`` is
+  local-frame per IP. Apply the same per-element rotation across
+  every IP slice — the orientation doesn't vary along an element.
+- **Other beam-output names.** OpenSees emits ``force`` (global) and
+  ``localForce`` (local) by default for elastic beams. Force-based
+  fiber elements may only record ``localForce``; check
+  `ds.element_results_names`.
+- **Use the free function directly.** ``quaternion_to_rotation_matrix``
+  is re-exported at the top level if you have quaternions from
+  somewhere other than STKO:
+
+  ```python
+  from STKO_to_python import quaternion_to_rotation_matrix
+  R = quaternion_to_rotation_matrix(np.array([1.0, 0.0, 0.0, 0.0]))
+  # identity
+  ```
+
+  The batched form accepts ``(N, 4)`` and returns ``(N, 3, 3)``.

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -18,6 +18,7 @@ workflows the library is built around. Each tutorial:
 | 5 | [Element selector + mask pipeline](05-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | `64-DispBeamColumn3d` |
 | 6 | [Node selector + mask pipeline](06-node-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | (node-side; any element family) |
 | 7 | [Select by STKO geometry and property name](07-select-by-geometry-and-property.md) | `elasticFrame/QuadFrame_results` | `203-ASDShellQ4` + `5-ElasticBeam3d` |
+| 8 | [Rotate beam-local forces to global](08-rotate-beam-forces-to-global.md) | `elasticFrame/elasticFrame_mesh_results` | `5-ElasticBeam3d` |
 
 For broader tours of the API on a single fixture see the
 [Examples](../examples/usage_tour.md) section. For the reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - Element selector + mask pipeline: cookbook/05-selector-and-mask-pipeline.md
       - Node selector + mask pipeline: cookbook/06-node-selector-and-mask-pipeline.md
       - Select by STKO geometry and property name: cookbook/07-select-by-geometry-and-property.md
+      - Rotate beam-local forces to global: cookbook/08-rotate-beam-forces-to-global.md
   - Examples:
       - Usage tour: examples/usage_tour.md
       - Elastic frame: examples/elastic_frame.md

--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -11,6 +11,7 @@ from .elements.selector import ElementSelector
 from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
 from .model.cdata_reader import BeamProfile, CDataReader, ElementInfo
+from .model.transforms import quaternion_to_rotation_matrix
 
 from .plotting.plot import Plot
 from .plotting.plot_settings import PlotSettings
@@ -42,6 +43,7 @@ __all__ = [
     "CData",
     "ElementInfo",
     "BeamProfile",
+    "quaternion_to_rotation_matrix",
     "Nodes",
     "Elements",
     "ElementResults",

--- a/src/STKO_to_python/model/__init__.py
+++ b/src/STKO_to_python/model/__init__.py
@@ -1,5 +1,6 @@
 from .model_info_reader import ModelInfoReader
 from .cdata_reader import BeamProfile, CDataReader, ElementInfo
+from .transforms import quaternion_to_rotation_matrix
 
 # Back-compat aliases preserved on the package surface (quiet); the
 # deep paths ``STKO_to_python.model.model_info.ModelInfo`` and
@@ -15,4 +16,5 @@ __all__ = [
     "CDataReader",
     "ElementInfo",
     "BeamProfile",
+    "quaternion_to_rotation_matrix",
 ]

--- a/src/STKO_to_python/model/cdata_reader.py
+++ b/src/STKO_to_python/model/cdata_reader.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 import numpy as np
 
 from .cdata_format import CDataFormatPolicy
+from .transforms import quaternion_to_rotation_matrix
 
 
 if TYPE_CHECKING:
@@ -260,6 +261,73 @@ class CDataReader:
         to the underlying cross-section geometry.
         """
         return self._parse_all_files()["beam_profile_assignments"]
+
+    # ------------------------------------------------------------------ #
+    # Rotation matrices derived from local_axes
+    # ------------------------------------------------------------------ #
+
+    def rotation_matrix(self, element_id: int) -> np.ndarray:
+        """Local-to-global rotation matrix for one element.
+
+        Args:
+            element_id: Element id; must have a ``*LOCAL_AXES`` entry.
+
+        Returns:
+            Shape ``(3, 3)`` ``float`` matrix. Applying it to a vector
+            in the element-local frame yields the same vector in global
+            coordinates: ``v_global = R @ v_local``.
+
+        Raises:
+            KeyError: If the element has no recorded local axes.
+        """
+        eid = int(element_id)
+        try:
+            q = self.local_axes[eid]
+        except KeyError:
+            raise KeyError(
+                f"Element {eid} has no *LOCAL_AXES entry in the .cdata file."
+            ) from None
+        return quaternion_to_rotation_matrix(q)
+
+    def rotation_matrices(
+        self,
+        element_ids: Optional[Sequence[int]] = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Local-to-global rotation matrices for many elements at once.
+
+        Args:
+            element_ids: Subset of element ids to extract. If ``None``,
+                every element with a ``*LOCAL_AXES`` entry is returned,
+                sorted by id.
+
+        Returns:
+            ``(ids, R)`` where ``ids`` is an ``int64`` array of shape
+            ``(N,)`` and ``R`` is a ``float`` array of shape
+            ``(N, 3, 3)`` aligned to ``ids`` row-for-row. Apply via
+            ``v_global[k] = R[k] @ v_local[k]`` per element.
+
+        Raises:
+            KeyError: If any requested id is missing from ``local_axes``;
+                the message lists up to five missing ids for context.
+        """
+        axes = self.local_axes
+        if element_ids is None:
+            ids = np.array(sorted(axes.keys()), dtype=np.int64)
+        else:
+            ids = np.asarray(list(element_ids), dtype=np.int64).ravel()
+            missing = [int(e) for e in ids if int(e) not in axes]
+            if missing:
+                preview = ", ".join(str(m) for m in missing[:5])
+                more = f" (and {len(missing) - 5} more)" if len(missing) > 5 else ""
+                raise KeyError(
+                    f"No *LOCAL_AXES entry for elements: {preview}{more}"
+                )
+
+        if ids.size == 0:
+            return ids, np.empty((0, 3, 3), dtype=float)
+
+        quats = np.stack([axes[int(e)] for e in ids])
+        return ids, quaternion_to_rotation_matrix(quats)
 
     # ------------------------------------------------------------------ #
     # Selection-set surface (eager from MPCODataSet.__init__)

--- a/src/STKO_to_python/model/transforms.py
+++ b/src/STKO_to_python/model/transforms.py
@@ -1,0 +1,95 @@
+"""Coordinate-frame transforms backed by ``.cdata`` ``*LOCAL_AXES``.
+
+STKO emits one orientation quaternion per element in the
+``*LOCAL_AXES`` section of the ``.cdata`` sidecar. The quaternion
+describes the element-local frame relative to global; applying the
+corresponding rotation matrix transforms a vector from element-local
+coordinates to global coordinates.
+
+This module provides:
+
+- :func:`quaternion_to_rotation_matrix` — pure numpy, vectorized,
+  ``(qw, qx, qy, qz)`` → ``(3, 3)`` (or batched).
+- :meth:`STKO_to_python.model.cdata_reader.CDataReader.rotation_matrix`
+  and
+  :meth:`STKO_to_python.model.cdata_reader.CDataReader.rotation_matrices` —
+  reader-side conveniences that fold the quaternion lookup and the
+  conversion into one call.
+
+Convention
+----------
+A quaternion ``q = (qw, qx, qy, qz)`` from the ``*LOCAL_AXES`` section
+describes the orientation of the element-local frame relative to
+global. The returned matrix ``R`` rotates a vector from the
+*element-local* frame to *global* coordinates::
+
+    v_global = R @ v_local
+
+Inverse: ``v_local = R.T @ v_global``. Verified against the
+``elasticFrame_mesh_results`` fixture (columns parallel to global Z,
+beams parallel to global X) and the ``force`` / ``localForce``
+recorders on the same elements.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def quaternion_to_rotation_matrix(q: np.ndarray) -> np.ndarray:
+    """Convert one or more unit quaternions to ``(3, 3)`` rotation matrices.
+
+    Args:
+        q: Either a single quaternion as shape ``(4,)`` or a batch as
+            ``(N, 4)``. Component order is ``(qw, qx, qy, qz)`` — the
+            same order STKO writes in ``*LOCAL_AXES``.
+
+    Returns:
+        Shape ``(3, 3)`` for a single quaternion, ``(N, 3, 3)`` for a
+        batch. The returned matrix transforms a vector from the
+        element-local frame to global coordinates::
+
+            v_global = R @ v_local
+
+    Notes:
+        The quaternion is normalized internally so the returned ``R``
+        is exactly orthogonal even when the input has limited precision.
+        STKO emits ``*LOCAL_AXES`` quaternions at six significant
+        figures; without normalization the resulting matrix is off
+        orthogonality by ~1e-6, which compounds into errors of a few
+        units in 1e6-magnitude force outputs.
+
+    Raises:
+        ValueError: if the last dimension is not 4, or if any input
+        quaternion has zero magnitude.
+    """
+    arr = np.asarray(q, dtype=float)
+    single = arr.ndim == 1
+    if single:
+        arr = arr[None, :]
+    if arr.shape[-1] != 4:
+        raise ValueError(
+            f"Expected last dimension of size 4 (qw, qx, qy, qz); got {arr.shape!r}."
+        )
+
+    norms = np.linalg.norm(arr, axis=-1)
+    if np.any(norms == 0):
+        raise ValueError("quaternion_to_rotation_matrix: zero-magnitude quaternion.")
+    arr = arr / norms[:, None]
+
+    qw = arr[:, 0]
+    qx = arr[:, 1]
+    qy = arr[:, 2]
+    qz = arr[:, 3]
+
+    R = np.empty((arr.shape[0], 3, 3), dtype=float)
+    R[:, 0, 0] = 1.0 - 2.0 * (qy * qy + qz * qz)
+    R[:, 0, 1] = 2.0 * (qx * qy - qw * qz)
+    R[:, 0, 2] = 2.0 * (qx * qz + qw * qy)
+    R[:, 1, 0] = 2.0 * (qx * qy + qw * qz)
+    R[:, 1, 1] = 1.0 - 2.0 * (qx * qx + qz * qz)
+    R[:, 1, 2] = 2.0 * (qy * qz - qw * qx)
+    R[:, 2, 0] = 2.0 * (qx * qz - qw * qy)
+    R[:, 2, 1] = 2.0 * (qy * qz + qw * qx)
+    R[:, 2, 2] = 1.0 - 2.0 * (qx * qx + qy * qy)
+
+    return R[0] if single else R

--- a/tests/unit/test_cdata_reader.py
+++ b/tests/unit/test_cdata_reader.py
@@ -696,3 +696,109 @@ def test_selection_set_parses_with_all_ids_on_one_line(tmp_path) -> None:
     reader = _make_reader(tmp_path, text)
     sets = reader._extract_selection_set_ids()
     assert sets[2]["NODES"] == list(range(1, 16))
+
+
+# ---------------------------------------------------------------------- #
+# CDataReader.rotation_matrix / .rotation_matrices                       #
+# ---------------------------------------------------------------------- #
+
+def test_rotation_matrix_identity_quaternion(tmp_path) -> None:
+    text = "*LOCAL_AXES\n42 1 0 0 0\n"
+    reader = _make_reader(tmp_path, text)
+    R = reader.rotation_matrix(42)
+    np.testing.assert_allclose(R, np.eye(3), atol=1e-12)
+
+
+def test_rotation_matrix_unknown_element_raises(tmp_path) -> None:
+    reader = _make_reader(tmp_path, "*LOCAL_AXES\n1 1 0 0 0\n")
+    with pytest.raises(KeyError, match=r"Element 999 has no"):
+        reader.rotation_matrix(999)
+
+
+def test_rotation_matrices_returns_aligned_ids_and_matrices(tmp_path) -> None:
+    text = (
+        "*LOCAL_AXES\n"
+        "1 1 0 0 0\n"      # identity
+        "5 0 1 0 0\n"      # 180° about X
+        "9 0 0 1 0\n"      # 180° about Y
+    )
+    reader = _make_reader(tmp_path, text)
+    ids, R = reader.rotation_matrices()
+    assert ids.tolist() == [1, 5, 9]
+    assert R.shape == (3, 3, 3)
+    np.testing.assert_allclose(R[0], np.eye(3), atol=1e-12)
+    np.testing.assert_allclose(R[1], np.diag([1.0, -1.0, -1.0]), atol=1e-12)
+    np.testing.assert_allclose(R[2], np.diag([-1.0, 1.0, -1.0]), atol=1e-12)
+
+
+def test_rotation_matrices_subset_in_caller_order(tmp_path) -> None:
+    """Caller-specified ids preserve their order in the returned arrays."""
+    text = (
+        "*LOCAL_AXES\n"
+        "1 1 0 0 0\n"
+        "2 1 0 0 0\n"
+        "3 1 0 0 0\n"
+    )
+    reader = _make_reader(tmp_path, text)
+    ids, R = reader.rotation_matrices(element_ids=[3, 1])
+    assert ids.tolist() == [3, 1]
+    assert R.shape == (2, 3, 3)
+
+
+def test_rotation_matrices_missing_ids_raise_with_preview(tmp_path) -> None:
+    reader = _make_reader(tmp_path, "*LOCAL_AXES\n1 1 0 0 0\n")
+    with pytest.raises(KeyError, match="100, 200"):
+        reader.rotation_matrices(element_ids=[1, 100, 200])
+
+
+def test_rotation_matrices_empty_when_no_local_axes(tmp_path) -> None:
+    reader = _make_reader(tmp_path, "#nothing here\n")
+    ids, R = reader.rotation_matrices()
+    assert ids.shape == (0,)
+    assert R.shape == (0, 3, 3)
+
+
+def test_rotation_round_trip_against_global_force_recorder() -> None:
+    """End-to-end: rotating ``localForce`` with R must match ``force``
+    (which OpenSees emits in global) on the bundled elasticFrame fixture.
+
+    Exercises every layer — cdata parsing, the rotation_matrix helper,
+    and the actual ElasticBeam3d force output. Tolerance is set to the
+    machine-precision level the normalization step achieves.
+    """
+    import os.path
+    here = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    fixture = os.path.join(
+        here, "stko_results_examples", "elasticFrame",
+        "elasticFrame_mesh_results",
+    )
+    if not os.path.isdir(fixture):
+        pytest.skip("elasticFrame fixture not present in this checkout")
+
+    from STKO_to_python import MPCODataSet
+    ds = MPCODataSet(fixture, "results", verbose=False)
+
+    # Element 1 is a column (q non-trivial); 7 is a beam (identity q).
+    # Both must round-trip exactly.
+    for eid in (1, 7):
+        er_global = ds.elements.get_element_results(
+            results_name="force", element_type="5-ElasticBeam3d",
+            model_stage="MODEL_STAGE[1]", element_ids=[eid],
+        )
+        er_local = ds.elements.get_element_results(
+            results_name="localForce", element_type="5-ElasticBeam3d",
+            model_stage="MODEL_STAGE[1]", element_ids=[eid],
+        )
+        R = ds.cdata.rotation_matrix(eid)
+
+        # 12 cols per step: Fx_1, Fy_1, Fz_1, Mx_1, My_1, Mz_1, Fx_2, ...
+        g = er_global.df.values
+        l = er_local.df.values
+        # Apply R to each of the 4 (force_n1, moment_n1, force_n2, moment_n2)
+        # 3-vectors per row.
+        rotated = np.empty_like(l)
+        for k in range(4):
+            cols = slice(3 * k, 3 * (k + 1))
+            rotated[:, cols] = l[:, cols] @ R.T
+
+        np.testing.assert_allclose(rotated, g, atol=1e-7)

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -1,0 +1,100 @@
+"""Unit tests for ``STKO_to_python.model.transforms``.
+
+The transforms module is pure-math: every test below operates on a
+fixed quaternion and checks the resulting matrix. No HDF5 / fixture
+access needed.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.model.transforms import quaternion_to_rotation_matrix
+
+
+def test_identity_quaternion_gives_identity_matrix() -> None:
+    R = quaternion_to_rotation_matrix(np.array([1.0, 0.0, 0.0, 0.0]))
+    np.testing.assert_allclose(R, np.eye(3), atol=1e-15)
+
+
+def test_single_input_returns_2d_matrix() -> None:
+    R = quaternion_to_rotation_matrix(np.array([1.0, 0.0, 0.0, 0.0]))
+    assert R.shape == (3, 3)
+
+
+def test_batched_input_returns_3d_array() -> None:
+    q = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],   # identity
+            [0.0, 1.0, 0.0, 0.0],   # 180° about X
+        ]
+    )
+    R = quaternion_to_rotation_matrix(q)
+    assert R.shape == (2, 3, 3)
+    np.testing.assert_allclose(R[0], np.eye(3), atol=1e-15)
+    np.testing.assert_allclose(
+        R[1], np.diag([1.0, -1.0, -1.0]), atol=1e-15
+    )
+
+
+def test_column_quaternion_maps_local_x_to_global_z() -> None:
+    """The STKO column quaternion from the elasticFrame fixture.
+
+    A column running along global Z has a local-x axis aligned with
+    global Z. So R @ (1, 0, 0) (local x basis vector) must equal
+    (0, 0, 1) (global Z).
+    """
+    s = np.sqrt(0.5)
+    R = quaternion_to_rotation_matrix(np.array([0.0, s, 0.0, s]))
+    np.testing.assert_allclose(R @ np.array([1.0, 0.0, 0.0]), [0.0, 0.0, 1.0], atol=1e-12)
+
+
+def test_returned_matrix_is_orthogonal() -> None:
+    """R @ R.T = I for any unit quaternion."""
+    q = np.array([0.0, np.sqrt(0.5), 0.0, np.sqrt(0.5)])
+    R = quaternion_to_rotation_matrix(q)
+    np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-12)
+
+
+def test_normalizes_off_unit_input() -> None:
+    """STKO writes quaternions to six digits, so |q|² is not exactly 1.
+
+    The function must normalize internally so a 1.0000046-magnitude
+    input still produces an exactly orthogonal matrix.
+    """
+    q_off = np.array([0.0, 0.707107, 0.0, 0.707107])  # exactly as STKO emits
+    assert abs(np.linalg.norm(q_off) - 1.0) > 0
+    R = quaternion_to_rotation_matrix(q_off)
+    np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-12)
+
+
+def test_zero_quaternion_raises() -> None:
+    with pytest.raises(ValueError, match="zero-magnitude"):
+        quaternion_to_rotation_matrix(np.zeros(4))
+
+
+def test_wrong_dim_raises() -> None:
+    with pytest.raises(ValueError, match="size 4"):
+        quaternion_to_rotation_matrix(np.array([1.0, 0.0, 0.0]))
+
+
+def test_conjugate_quaternion_gives_inverse_matrix() -> None:
+    """For unit q with conjugate q* = (qw, -qx, -qy, -qz), R(q*) = R(q).T."""
+    q = np.array([0.5, 0.5, 0.5, 0.5])  # arbitrary unit quaternion
+    q_conj = np.array([q[0], -q[1], -q[2], -q[3]])
+    R = quaternion_to_rotation_matrix(q)
+    R_inv = quaternion_to_rotation_matrix(q_conj)
+    np.testing.assert_allclose(R_inv, R.T, atol=1e-12)
+
+
+def test_batch_agrees_with_per_element() -> None:
+    """Vectorized result must equal looped scalar results."""
+    rng = np.random.default_rng(seed=42)
+    q = rng.normal(size=(5, 4))
+    q = q / np.linalg.norm(q, axis=1, keepdims=True)
+
+    batched = quaternion_to_rotation_matrix(q)
+    one_by_one = np.stack(
+        [quaternion_to_rotation_matrix(q[i]) for i in range(len(q))]
+    )
+    np.testing.assert_allclose(batched, one_by_one, atol=1e-15)


### PR DESCRIPTION
## Summary

The `.cdata` `*LOCAL_AXES` section (parsed in v1.3.0) carries one unit quaternion per element describing the element-local frame relative to global. Until now users had to re-derive the rotation matrix from node coordinates by hand. This PR turns the parsed quaternion into a usable rotation matrix — verified end-to-end against the bundled fixture, where rotating `localForce` matches `force` (OpenSees-emitted global) to machine precision.

## Public API surface added

```python
from STKO_to_python import quaternion_to_rotation_matrix

R = quaternion_to_rotation_matrix(np.array([1.0, 0.0, 0.0, 0.0]))   # (3, 3)
R = quaternion_to_rotation_matrix(np.random.randn(N, 4))            # (N, 3, 3)

# Reader-side conveniences:
R          = ds.cdata.rotation_matrix(element_id)        # one element
ids, R     = ds.cdata.rotation_matrices(element_ids=None)  # batched
```

Convention: ``v_global = R @ v_local``.

## Why the round-trip matters

The `elasticFrame_mesh_results` fixture happens to record *both* `force` (global) and `localForce` (element-local) for every step. So a self-checking test is possible: rotate `localForce` with the cdata quaternion and check it matches `force`. The new unit test does exactly that on both a column (non-trivial rotation, `q=[0, 0.707, 0, 0.707]`) and a beam (`q=[1, 0, 0, 0]` identity), passing to machine precision (`~1e-9`).

The reason it's machine-precision instead of `1e-6` is that `quaternion_to_rotation_matrix` normalizes its input. STKO writes quaternions to six digits, so without normalization the rotation matrix is off-orthogonality by ~`1e-6`, compounding to errors of a few units on `1e6`-magnitude moment outputs. Verified empirically.

## What's *not* in this PR

- **No version bump.** [PR #64](https://github.com/nmorabowen/STKO_to_python/pull/64) (changelog + docs polish) is still open against main and hasn't merged yet. Once both PRs are in, a small release PR can bump `pyproject.toml` to `1.4.0`, add a `[1.4.0]` entry to `CHANGELOG.md`, and tag.
- **No rotation of `ElementResults` directly.** The library provides the rotation matrix; users compose with their results. Wiring a higher-level `er.to_global()` would require knowing the force-output layout per element class (different for `5-ElasticBeam3d`, `force-based fiber`, shells, etc.) — better done as a separate feature once we know which element families users care about.

## Test plan

- [x] `python -m pytest tests/unit/test_transforms.py -v` — 10 new tests pass:
  - identity quaternion → identity matrix
  - single vs batched output shapes
  - column quaternion maps local-x to global Z
  - `R @ R.T = I` orthogonality
  - normalization fixes off-unit STKO input
  - zero quaternion raises
  - wrong shape raises
  - conjugate quaternion gives transposed matrix
  - batched output matches per-element loop
- [x] `python -m pytest tests/unit/test_cdata_reader.py -k rotation` — 7 new tests pass:
  - identity quaternion through the reader
  - unknown element id raises `KeyError`
  - batched matrices with sorted ids
  - subset preserves caller order
  - missing ids raise with preview
  - empty `local_axes` returns empty arrays
  - **real-fixture round-trip**: `R @ localForce ≈ force` on column and beam
- [x] `python -m pytest tests/unit -q` — **630 passed**, 1 skipped (pre-existing).
- [x] Every code block in [`docs/cookbook/08-rotate-beam-forces-to-global.md`](docs/cookbook/08-rotate-beam-forces-to-global.md) was run end-to-end; numeric outputs in comments are the actual values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)