### PR TITLE
Fix broken cross-refs in selector_and_mask_pipeline.md

### DIFF
--- a/docs/selector_and_mask_pipeline.md
+++ b/docs/selector_and_mask_pipeline.md
@@ -1059,5 +1059,5 @@ er[m]                                                   # fresh ElementResults
 ```
 
 For the underlying type signatures see
-[ElementResults — Element selectors](../api/element-results.md#element-selectors-pre-fetch)
-and [ElementResults — Result masks](../api/element-results.md#result-masks-post-fetch).
+[ElementResults — Element selectors](api/element-results.md#element-selectors-pre-fetch)
+and [ElementResults — Result masks](api/element-results.md#result-masks-post-fetch).


### PR DESCRIPTION
## Summary

\`mkdocs build --strict\` aborted with two warnings:

\`\`\`
WARNING -  Doc file 'selector_and_mask_pipeline.md' contains a link
  '../api/element-results.md#element-selectors-pre-fetch', but the target
  '../api/element-results.md' is not found among documentation files.
  Did you mean 'api/element-results.md#element-selectors-pre-fetch'?
WARNING -  ...same for #result-masks-post-fetch
Aborted with 2 warnings in strict mode!
\`\`\`

\`docs/selector_and_mask_pipeline.md\` lives in the docs root, so \`../\` resolves above \`docs/\` and the link breaks. The correct prefix from a docs-root file is just \`api/...\`. Anchors at the targets exist; only the path needed fixing.

Pre-existing — introduced in #55 (Promote selector+mask reference to a top-level guide) when the file moved from \`docs/api/\` to \`docs/\`. mkdocs strict mode catches it; relaxed builds quietly produce broken anchors at runtime.

After this fix \`mkdocs build --strict\` exits clean.

## Test plan

- [x] \`mkdocs build --strict\` — passes (was aborting before)
- [x] Two-line diff, no other content changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)