### PR TITLE
Lazy selection_set / _selection_resolver on MPCODataSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,27 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ## [Unreleased]
 
-_Nothing pending._
+### Changed (internal)
+
+- `MPCODataSet.selection_set` and `MPCODataSet._selection_resolver` are
+  now lazy `@cached_property` attributes. Dataset construction no
+  longer parses the `.cdata` selection-set blocks; the parse triggers
+  on first access. Workflows that only fetch element results without
+  passing `selection_set_*` arguments now skip the cdata parse
+  entirely.
+- `NodalResultsQueryEngine` and `ElementResultsQueryEngine` no longer
+  take `resolver=` in their constructor; they read
+  `dataset._selection_resolver` at query time. Internal refactor —
+  the public managers (`Nodes.get_nodal_results`,
+  `Elements.get_element_results`) behave identically.
+
+### Test coverage
+
+- Added two regression guards under
+  `tests/unit/selection/test_dataset_resolver_integration.py`:
+  - `selection_set` / `_selection_resolver` are absent from
+    `ds.__dict__` immediately after construction.
+  - Repeat access returns the same cached object.
 
 ---
 

--- a/src/STKO_to_python/core/dataset.py
+++ b/src/STKO_to_python/core/dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import logging
+from functools import cached_property
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Any
 
@@ -239,32 +240,54 @@ class MPCODataSet:
         # Extract the model steps information
         self.number_of_steps=self.model_info._get_number_of_steps()
         
-        # Get the selection set mapping (This is the only place cdata is used)
-        self.selection_set=self.cdata._extract_selection_set_ids()
+        # ``selection_set`` and ``_selection_resolver`` are exposed as
+        # ``@cached_property`` below; they trigger the .cdata parse on
+        # first access. ``print_summary`` (called only when verbose) and
+        # the lazy property on the dataset are the two entry points.
 
-        # Phase 2: centralized resolver (side-by-side with legacy per-manager
-        # helpers; consumers will switch over in a later phase).
-        self._selection_resolver = SelectionSetResolver(self.selection_set)
-
-        # Phase 2.8: query engines (side-by-side; managers remain the public
-        # entry point, the engines add caching and will own the read logic
-        # in a later phase).
+        # Phase 2.8: query engines. Eagerly constructed but read the
+        # dataset's lazy resolver at query time — so dataset construction
+        # no longer pays the .cdata parse unless something needs it.
         self._nodal_query_engine = NodalResultsQueryEngine(
             dataset=self,
             pool=self._pool,
             policy=self._format_policy,
-            resolver=self._selection_resolver,
         )
         self._element_query_engine = ElementResultsQueryEngine(
             dataset=self,
             pool=self._pool,
             policy=self._format_policy,
-            resolver=self._selection_resolver,
         )
 
         if self.verbose:
             self.print_summary()
-        
+
+    @cached_property
+    def selection_set(self) -> Dict[int, dict]:
+        """``{set_id -> {"SET_NAME", "NODES", "ELEMENTS"}}`` from .cdata.
+
+        Parsed lazily on first access via
+        :meth:`CDataReader._extract_selection_set_ids`. The .cdata files
+        can be large (95k+ lines on real models), so dataset construction
+        used to pay this cost unconditionally; making it lazy means
+        callers that never touch selection-set logic skip the parse.
+
+        The cached dict is returned by-reference — mutating it corrupts
+        every subsequent access. Treat as read-only.
+        """
+        return self.cdata._extract_selection_set_ids()
+
+    @cached_property
+    def _selection_resolver(self) -> "SelectionSetResolver":
+        """Centralized name/id → id-array resolver, lazy on selection_set.
+
+        First access triggers the .cdata parse via :attr:`selection_set`,
+        then builds the resolver. The query engines pull from this
+        property at query time, so the resolver is built only when a
+        fetch actually needs it.
+        """
+        return SelectionSetResolver(self.selection_set)
+
     def print_summary(self):
         """
         Emit a summary of the virtual dataset at INFO level on the

--- a/src/STKO_to_python/query/base_query_engine.py
+++ b/src/STKO_to_python/query/base_query_engine.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
     from ..io.partition_pool import Hdf5PartitionPool
     from ..io.format_policy import MpcoFormatPolicy
-    from ..selection.resolver import SelectionSetResolver
 
 logger = logging.getLogger(__name__)
 
@@ -59,24 +58,30 @@ class BaseResultsQueryEngine(ABC):
     ----------
     dataset:
         Parent ``MPCODataSet`` instance. Held by reference; the engine
-        does not own it. Used only to read already-built attributes
-        (e.g. ``dataset.model_stages``) — no HDF5 access via dataset.
+        does not own it. Used to read already-built attributes (e.g.
+        ``dataset.model_stages``) and the lazy
+        ``dataset._selection_resolver`` at query time — no HDF5 access
+        via dataset.
     pool:
         Shared :class:`Hdf5PartitionPool` for HDF5 handle reuse.
     policy:
         :class:`MpcoFormatPolicy` for path templates.
-    resolver:
-        :class:`SelectionSetResolver` for name/id → id-array resolution.
     cache_size:
         LRU capacity for fetch-result caching. ``0`` disables caching.
         Default is :data:`DEFAULT_CACHE_SIZE` (32).
+
+    Notes
+    -----
+    The selection resolver is *not* a constructor argument — concrete
+    engines reach into ``dataset._selection_resolver`` inside
+    :meth:`fetch`. This keeps the dataset's ``@cached_property`` lazy:
+    constructing the engine no longer forces the ``.cdata`` parse.
     """
 
     __slots__ = (
         "_dataset",
         "_pool",
         "_policy",
-        "_resolver",
         "_cache_size",
         "_result_cache",
         "_step_axis_cache",
@@ -90,7 +95,6 @@ class BaseResultsQueryEngine(ABC):
         dataset: "MPCODataSet",
         pool: "Hdf5PartitionPool",
         policy: "MpcoFormatPolicy",
-        resolver: "SelectionSetResolver",
         cache_size: int = DEFAULT_CACHE_SIZE,
     ) -> None:
         if cache_size < 0:
@@ -98,7 +102,6 @@ class BaseResultsQueryEngine(ABC):
         self._dataset = dataset
         self._pool = pool
         self._policy = policy
-        self._resolver = resolver
         self._cache_size = int(cache_size)
         self._result_cache: "OrderedDict[Hashable, pd.DataFrame]" = OrderedDict()
         self._step_axis_cache: dict[str, pd.Index] = {}

--- a/src/STKO_to_python/query/element_query_engine.py
+++ b/src/STKO_to_python/query/element_query_engine.py
@@ -57,7 +57,7 @@ class ElementResultsQueryEngine(BaseResultsQueryEngine):
             or selection_set_id is not None
             or selection_set_name is not None
         ):
-            resolved_ids = self._resolver.resolve_elements(
+            resolved_ids = self._dataset._selection_resolver.resolve_elements(
                 names=selection_set_name,
                 ids=selection_set_id,
                 explicit_ids=element_ids,

--- a/src/STKO_to_python/query/nodal_query_engine.py
+++ b/src/STKO_to_python/query/nodal_query_engine.py
@@ -58,7 +58,7 @@ class NodalResultsQueryEngine(BaseResultsQueryEngine):
         """
         manager = self._dataset.nodes
 
-        resolved_ids = self._resolver.resolve_nodes(
+        resolved_ids = self._dataset._selection_resolver.resolve_nodes(
             names=selection_set_name,
             ids=selection_set_id,
             explicit_ids=node_ids,

--- a/tests/integration/test_examples_end_to_end.py
+++ b/tests/integration/test_examples_end_to_end.py
@@ -58,7 +58,6 @@ def test_elastic_frame_engine_parity_and_cache(elastic_frame_dir: Path):
         dataset=ds,
         pool=ds._pool,
         policy=ds._format_policy,
-        resolver=ds._selection_resolver,
     )
     nr1 = engine.fetch(
         results_name="DISPLACEMENT",
@@ -93,7 +92,6 @@ def test_elastic_frame_element_engine_parity_and_cache(elastic_frame_dir: Path):
         dataset=ds,
         pool=ds._pool,
         policy=ds._format_policy,
-        resolver=ds._selection_resolver,
     )
     er1 = engine.fetch(
         "force",

--- a/tests/unit/query/test_base_query_engine.py
+++ b/tests/unit/query/test_base_query_engine.py
@@ -2,8 +2,8 @@
 
 Uses a minimal concrete subclass because the base is abstract. No real
 ``.mpco`` fixture — everything is exercised through fake HDF5 datasets
-(numpy arrays quacking like ``h5py.Dataset``) and a ``SelectionSetResolver``
-built from a plain dict.
+(numpy arrays quacking like ``h5py.Dataset``); selection resolution is
+not in the base's surface, so no resolver wiring is needed here.
 """
 from __future__ import annotations
 
@@ -14,7 +14,6 @@ import pandas as pd
 import pytest
 
 from STKO_to_python.query import BaseResultsQueryEngine
-from STKO_to_python.selection import SelectionSetResolver
 
 
 class _ConcreteEngine(BaseResultsQueryEngine):
@@ -27,12 +26,10 @@ class _ConcreteEngine(BaseResultsQueryEngine):
 
 
 def _make_engine(cache_size: int = 32) -> _ConcreteEngine:
-    resolver = SelectionSetResolver({})
     return _ConcreteEngine(
         dataset=object(),          # engine only holds the ref
         pool=object(),             # not exercised in these tests
         policy=object(),
-        resolver=resolver,
         cache_size=cache_size,
     )
 
@@ -43,7 +40,7 @@ def _make_engine(cache_size: int = 32) -> _ConcreteEngine:
 def test_abstract_base_cannot_be_instantiated():
     with pytest.raises(TypeError):
         BaseResultsQueryEngine(  # type: ignore[abstract]
-            dataset=None, pool=None, policy=None, resolver=None,
+            dataset=None, pool=None, policy=None,
         )
 
 
@@ -51,7 +48,7 @@ def test_cache_size_negative_rejected():
     with pytest.raises(ValueError, match="cache_size must be >= 0"):
         _ConcreteEngine(
             dataset=object(), pool=object(), policy=object(),
-            resolver=SelectionSetResolver({}), cache_size=-1,
+            cache_size=-1,
         )
 
 

--- a/tests/unit/query/test_element_query_engine.py
+++ b/tests/unit/query/test_element_query_engine.py
@@ -15,12 +15,11 @@ def _make_engine(selection_set: dict | None = None, cache_size: int = 32):
     dataset = MagicMock()
     dataset.elements = manager
     dataset.model_stages = ("MODEL_STAGE[0]",)
-    resolver = SelectionSetResolver(selection_set or {})
+    dataset._selection_resolver = SelectionSetResolver(selection_set or {})
     engine = ElementResultsQueryEngine(
         dataset=dataset,
         pool=MagicMock(),
         policy=MagicMock(),
-        resolver=resolver,
         cache_size=cache_size,
     )
     return engine, manager

--- a/tests/unit/query/test_nodal_query_engine.py
+++ b/tests/unit/query/test_nodal_query_engine.py
@@ -27,12 +27,11 @@ def _make_engine(selection_set: dict | None = None, cache_size: int = 32):
     dataset = MagicMock()
     dataset.nodes = manager
     dataset.model_stages = ("MODEL_STAGE[0]",)
-    resolver = SelectionSetResolver(selection_set or {})
+    dataset._selection_resolver = SelectionSetResolver(selection_set or {})
     engine = NodalResultsQueryEngine(
         dataset=dataset,
         pool=MagicMock(),
         policy=MagicMock(),
-        resolver=resolver,
         cache_size=cache_size,
     )
     return engine, manager, dataset

--- a/tests/unit/selection/test_dataset_resolver_integration.py
+++ b/tests/unit/selection/test_dataset_resolver_integration.py
@@ -1,8 +1,9 @@
 """Phase 2 integration contract: ``MPCODataSet`` exposes a resolver.
 
-The resolver is attached during ``__init__`` from the already-built
-``self.selection_set`` dict. These tests pin the import path and the
-attribute wiring at the class level without constructing a full dataset.
+The resolver is wired as a ``@cached_property`` on the dataset that
+builds itself from the lazy ``selection_set`` property. These tests pin
+the import path and the wiring contract without constructing a full
+dataset.
 """
 from __future__ import annotations
 
@@ -31,18 +32,51 @@ def test_resolver_constructs_from_dataset_selection_set_shape() -> None:
     assert sorted(r.resolve_elements(names="Bar").tolist()) == [100]
 
 
-def test_dataset_wires_resolver_side_by_side() -> None:
-    """On a synthetic dataset instance with a selection_set attribute, the
-    wiring code that ``MPCODataSet.__init__`` performs must still work —
-    pinning the contract that ``self._selection_resolver`` is the result of
+def test_dataset_resolver_property_builds_from_seeded_selection_set() -> None:
+    """Pin the contract that ``self._selection_resolver`` is the result of
     ``SelectionSetResolver(self.selection_set)``.
+
+    Pre-seeds both ``__dict__`` slots so the lazy property short-circuits
+    without touching the cdata parser; the chained derivation still has
+    to produce a working resolver.
     """
     ds = MPCODataSet.__new__(MPCODataSet)
-    ds.selection_set = {
+    # Pre-fill the cached_property slots so accessing them doesn't trigger
+    # the parser; mirrors what real construction does after first access.
+    ds.__dict__["selection_set"] = {
         5: {"SET_NAME": "Roof", "NODES": {10, 11}, "ELEMENTS": set()},
     }
-    # Mirror the exact assignment made in MPCODataSet.__init__:
-    ds._selection_resolver = SelectionSetResolver(ds.selection_set)  # type: ignore[attr-defined]
+    ds.__dict__["_selection_resolver"] = SelectionSetResolver(ds.selection_set)
 
     assert isinstance(ds._selection_resolver, SelectionSetResolver)
     assert ds._selection_resolver.resolve_nodes(names="Roof").tolist() == [10, 11]
+
+
+def test_selection_set_is_lazy_on_construction(elastic_frame_dir) -> None:
+    """``selection_set`` must NOT be materialized during ``__init__``.
+
+    The whole point of the @cached_property is to defer the .cdata parse
+    until something actually needs it. If a future change re-eagers it,
+    this test catches it.
+    """
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    assert "selection_set" not in ds.__dict__
+    assert "_selection_resolver" not in ds.__dict__
+
+    # Touching the property triggers the parse and fills __dict__.
+    _ = ds.selection_set
+    assert "selection_set" in ds.__dict__
+
+    # The resolver is independently lazy — pulling it should also work
+    # after the selection_set has been materialized.
+    _ = ds._selection_resolver
+    assert "_selection_resolver" in ds.__dict__
+
+
+def test_selection_set_returns_cached_instance(elastic_frame_dir) -> None:
+    """Repeated access of the lazy properties must return the same object."""
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    first = ds.selection_set
+    second = ds.selection_set
+    assert first is second
+    assert ds._selection_resolver is ds._selection_resolver


### PR DESCRIPTION
## Summary

- `MPCODataSet.selection_set` and `MPCODataSet._selection_resolver` become lazy `@cached_property` attributes. Dataset construction no longer parses the `.cdata` selection-set blocks; the parse triggers on first access. Element-only workflows that don't pass `selection_set_*` arguments now skip the cdata parse entirely.
- `NodalResultsQueryEngine` / `ElementResultsQueryEngine` drop `resolver=` from their constructors and instead read `dataset._selection_resolver` at query time. Internal refactor — the public `Nodes.get_nodal_results` / `Elements.get_element_results` behave identically.
- Sets up the §6 architecture work in [docs/architecture-refactor-proposal.md](docs/architecture-refactor-proposal.md) — `@cached_property` for derived quantities is exactly the pattern the proposal recommends.

PATCH-level change per [CLAUDE.md versioning policy](CLAUDE.md#versioning-policy); CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `pytest tests/` — 797 passing, 34 fixture-skipped (was 795 + 2 new lazy regression tests under `tests/unit/selection/test_dataset_resolver_integration.py`).
- [x] `mkdocs build --strict` — clean.
- [x] Two regression guards locked in:
  - `selection_set` / `_selection_resolver` absent from `ds.__dict__` immediately after construction.
  - Repeat access of either property returns the same cached object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)