### PR TITLE
Add extrude_beam_geometry pure-numpy helper (PR 2A of 3 for 3D beam viz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ## [Unreleased]
 
+### Added (internal)
+
+- `STKO_to_python.plotting.beam_solid.extrude_beam_geometry(...)` —
+  pure-numpy helper that sweeps a `BeamProfile` between two beam
+  endpoints (with optional `*SECTION_OFFSET`) and returns
+  `(vertices, faces)` as a 3D triangle mesh. Foundation for the
+  upcoming `ds.plot.beam_solids` rendering wrapper; the geometry
+  function is matplotlib-free so it can be unit-tested without a
+  display backend.
+
 ### Changed (internal)
 
 - `MPCODataSet.selection_set` and `MPCODataSet._selection_resolver` are
@@ -33,6 +43,12 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
   - `selection_set` / `_selection_resolver` are absent from
     `ds.__dict__` immediately after construction.
   - Repeat access returns the same cached object.
+- Added `tests/unit/test_beam_extrude.py` (13 tests) covering the
+  geometry-helper contract: vertex placement under identity / rotated
+  frames, section-offset translation, cap winding, side-surface
+  triangulation from the sweep loop, and degenerate profiles (no
+  triangles, no sweeps). Includes a real-fixture smoke check on the
+  `elasticFrame/results` beam profile.
 
 ---
 

--- a/src/STKO_to_python/plotting/beam_solid.py
+++ b/src/STKO_to_python/plotting/beam_solid.py
@@ -1,0 +1,141 @@
+"""Geometry helpers for rendering beam elements as 3D extruded solids.
+
+Builds a triangle mesh from a 2D cross-section (``BeamProfile``) swept
+along a 1D axis between two endpoints. The output is a pair of plain
+numpy arrays — vertices in global coordinates and triangular faces as
+integer indices — that downstream callers can feed to
+``mpl_toolkits.mplot3d.art3d.Poly3DCollection`` or any other triangle
+renderer.
+
+PR scope
+--------
+This module is intentionally matplotlib-free. The dataset-level plot
+wrapper (``ds.plot.beam_solids``) that consumes :func:`extrude_beam_geometry`
+lands in a follow-up PR. The function takes a single profile per call,
+so variable cross-section (multiple ``(profile_id, weight)`` entries in
+``beam_profile_assignments``) is handled by the caller — typically by
+picking the first entry until the v2 follow-up.
+
+Coordinate convention
+---------------------
+- The profile lives in the section's local ``(y, z)`` plane; column 0
+  of ``profile.points`` is local-y, column 1 is local-z.
+- The beam's local x-axis runs along the element from ``axis_start`` to
+  ``axis_end``. ``R`` is the local→global rotation produced by
+  :func:`STKO_to_python.quaternion_to_rotation_matrix` (``v_global =
+  R @ v_local``).
+- ``section_offset = (yOff, zOff)`` is applied in the section's local
+  frame before the rotation; it shifts the geometric centroid relative
+  to the integration axis (matches the ``*SECTION_OFFSET`` cdata block).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..model.cdata_reader import BeamProfile
+
+
+def extrude_beam_geometry(
+    profile: "BeamProfile",
+    axis_start: np.ndarray,
+    axis_end: np.ndarray,
+    R: np.ndarray,
+    section_offset: Optional[np.ndarray] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Extrude a 2D section between two beam endpoints to a triangle mesh.
+
+    Two copies of the profile's points are placed in 3D — one at
+    ``axis_start``, one at ``axis_end`` — both lifted from local
+    ``(y, z)`` to global via ``R`` and shifted by ``section_offset``
+    in the local frame. The returned mesh has three face groups:
+
+    1. **End-1 cap** — ``profile.triangles`` with the winding reversed
+       so the cap's outward normal points away from ``axis_end``.
+    2. **End-2 cap** — ``profile.triangles`` with vertex indices
+       offset by ``n_pts`` so the cap's outward normal points away
+       from ``axis_start``.
+    3. **Side surface** — two triangles per segment of the
+       ``profile.sweeps`` polyline, treated as a closed loop (the
+       last sweep point wraps to the first). For a profile with no
+       sweeps (or only one), no side surface is emitted.
+
+    Args:
+        profile: A :class:`BeamProfile`. Used read-only.
+        axis_start: ``(3,)`` global coordinates of the beam's first
+            end node.
+        axis_end: ``(3,)`` global coordinates of the beam's second
+            end node.
+        R: ``(3, 3)`` rotation matrix from element-local to global
+            (``v_global = R @ v_local``).
+        section_offset: Optional ``(2,)`` ``(yOff, zOff)`` offset in
+            the section's local frame. Defaults to zero.
+
+    Returns:
+        Tuple ``(vertices, faces)``:
+
+        - ``vertices``: ``(2 * n_pts, 3)`` ``float64`` array. Rows
+          ``0..n_pts`` are the end-1 cap; rows ``n_pts..2*n_pts``
+          are the end-2 cap, aligned row-for-row.
+        - ``faces``: ``(n_faces, 3)`` ``int64`` array of vertex
+          indices into ``vertices``.
+    """
+    points = np.asarray(profile.points, dtype=float)
+    triangles = np.asarray(profile.triangles, dtype=np.int64)
+    sweeps = np.asarray(profile.sweeps, dtype=np.int64)
+
+    n_pts = points.shape[0]
+    if section_offset is None:
+        yoff, zoff = 0.0, 0.0
+    else:
+        yoff, zoff = float(section_offset[0]), float(section_offset[1])
+
+    # Lift each (y, z) profile point into local 3D as (0, y, z) so the
+    # extrusion runs along the element's local x-axis.
+    local = np.zeros((n_pts, 3), dtype=float)
+    local[:, 1] = points[:, 0] + yoff
+    local[:, 2] = points[:, 1] + zoff
+
+    # Rotate every local row to global in one matmul. For per-row
+    # `v_global = R @ v_local`, the equivalent batched form is
+    # `local @ R.T`.
+    R_arr = np.asarray(R, dtype=float)
+    global_rel = local @ R_arr.T
+
+    end1 = global_rel + np.asarray(axis_start, dtype=float)
+    end2 = global_rel + np.asarray(axis_end, dtype=float)
+    vertices = np.vstack([end1, end2])
+
+    # End-1 cap: reverse winding so the outward normal points along
+    # local -x (away from axis_end). End-2 cap keeps the original
+    # winding so its outward normal points along local +x.
+    if triangles.size:
+        cap_end1 = triangles[:, [0, 2, 1]]
+        cap_end2 = triangles + n_pts
+    else:
+        cap_end1 = np.empty((0, 3), dtype=np.int64)
+        cap_end2 = np.empty((0, 3), dtype=np.int64)
+
+    # Side surface: each sweep segment becomes a quad split into two
+    # triangles. With sweeps wound CCW when viewed from local +x, the
+    # outward normal points radially outward.
+    if sweeps.size >= 2:
+        i0 = sweeps
+        i1 = np.roll(sweeps, -1)
+        a = i0
+        b = i1
+        c = i1 + n_pts
+        d = i0 + n_pts
+        side_tri_1 = np.stack([a, b, c], axis=1)
+        side_tri_2 = np.stack([a, c, d], axis=1)
+        side = np.vstack([side_tri_1, side_tri_2])
+    else:
+        side = np.empty((0, 3), dtype=np.int64)
+
+    faces = np.vstack([cap_end1, cap_end2, side]).astype(np.int64, copy=False)
+    return vertices, faces
+
+
+__all__ = ["extrude_beam_geometry"]

--- a/tests/unit/test_beam_extrude.py
+++ b/tests/unit/test_beam_extrude.py
@@ -1,0 +1,300 @@
+"""Unit tests for :func:`STKO_to_python.plotting.beam_solid.extrude_beam_geometry`.
+
+Pure-geometry tests — no matplotlib, no .mpco fixture. Builds synthetic
+``BeamProfile`` instances with known shapes (single triangle, unit
+square) and verifies vertex positions, face winding, dtypes, and the
+identities ``vertices[k+n_pts] - vertices[k] == axis_end - axis_start``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.model.cdata_reader import BeamProfile
+from STKO_to_python.plotting.beam_solid import extrude_beam_geometry
+
+
+# ---------------------------------------------------------------------- #
+# Profile factories
+# ---------------------------------------------------------------------- #
+def _triangle_profile() -> BeamProfile:
+    """Right triangle in the local (y, z) plane with one outline."""
+    return BeamProfile(
+        profile_id=1,
+        points=np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=float),
+        triangles=np.array([[0, 1, 2]], dtype=int),
+        edges=[np.array([0, 1, 2, 0], dtype=int)],
+        sweeps=np.array([0, 1, 2], dtype=int),
+    )
+
+
+def _unit_square_profile() -> BeamProfile:
+    """Unit square in local (y, z), CCW from outside, two triangles, closed sweep."""
+    return BeamProfile(
+        profile_id=2,
+        points=np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            dtype=float,
+        ),
+        triangles=np.array([[0, 1, 2], [0, 2, 3]], dtype=int),
+        edges=[np.array([0, 1, 2, 3, 0], dtype=int)],
+        sweeps=np.array([0, 1, 2, 3], dtype=int),
+    )
+
+
+def _no_caps_profile() -> BeamProfile:
+    """Sweeps-only profile (open shell) — no fill triangles."""
+    return BeamProfile(
+        profile_id=3,
+        points=np.array([[0.0, 0.0], [1.0, 0.0]], dtype=float),
+        triangles=np.empty((0, 3), dtype=int),
+        edges=[np.array([0, 1], dtype=int)],
+        sweeps=np.array([0, 1], dtype=int),
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Shape / dtype contract
+# ---------------------------------------------------------------------- #
+def test_vertex_count_is_twice_npts():
+    p = _unit_square_profile()
+    v, _ = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    assert v.shape == (8, 3)
+    assert v.dtype == np.float64
+
+
+def test_face_array_is_int64():
+    p = _unit_square_profile()
+    _, f = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    assert f.dtype == np.int64
+    assert f.shape[1] == 3
+    # 2 cap triangles per end + 4 sweep segments * 2 triangles
+    assert f.shape[0] == 2 + 2 + 4 * 2
+
+
+def test_face_indices_within_vertex_range():
+    p = _unit_square_profile()
+    v, f = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([5.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    assert f.min() >= 0
+    assert f.max() < v.shape[0]
+
+
+# ---------------------------------------------------------------------- #
+# Vertex placement
+# ---------------------------------------------------------------------- #
+def test_identity_rotation_places_section_in_yz_plane():
+    """With R=I and axis along global x, the cross-section's (y, z) coords
+    map straight to global (y, z) at both endpoints.
+    """
+    p = _triangle_profile()
+    start = np.array([0.0, 0.0, 0.0])
+    end = np.array([10.0, 0.0, 0.0])
+    v, _ = extrude_beam_geometry(p, axis_start=start, axis_end=end, R=np.eye(3))
+
+    # End-1 ring: (0, y, z) at axis_start
+    expected_end1 = np.array(
+        [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=float,
+    )
+    np.testing.assert_allclose(v[:3], expected_end1)
+
+    # End-2 ring: same (0, y, z) added to axis_end
+    expected_end2 = expected_end1 + np.array([10.0, 0.0, 0.0])
+    np.testing.assert_allclose(v[3:], expected_end2)
+
+
+def test_end_pair_differs_by_axis_delta():
+    """For every k in [0, n_pts), vertices[k+n_pts] - vertices[k] must
+    equal axis_end - axis_start exactly.
+    """
+    p = _unit_square_profile()
+    start = np.array([1.0, 2.0, 3.0])
+    end = np.array([4.0, 8.0, -1.0])
+    R = np.eye(3)
+    v, _ = extrude_beam_geometry(p, axis_start=start, axis_end=end, R=R)
+    n_pts = p.points.shape[0]
+    delta = v[n_pts:] - v[:n_pts]
+    expected = np.broadcast_to(end - start, (n_pts, 3))
+    np.testing.assert_allclose(delta, expected)
+
+
+def test_rotation_maps_local_y_to_global_x():
+    """A 90-deg rotation about local-z that takes local-y to global-x.
+
+    Equivalent matrix:
+        R = [[0, -1, 0],
+             [1,  0, 0],
+             [0,  0, 1]]
+    so R @ (0, 1, 0) = (-1, 0, 0). Wait — we need R @ local_y to be
+    global +x. R @ (0, 1, 0) reads column-1 of R, so we want
+    R[:, 1] == (1, 0, 0). Build R accordingly.
+    """
+    R = np.array(
+        [[0.0, 1.0, 0.0],
+         [-1.0, 0.0, 0.0],
+         [0.0, 0.0, 1.0]],
+        dtype=float,
+    )
+    # Profile with one point at local (y, z) = (1, 0)
+    profile = BeamProfile(
+        profile_id=99,
+        points=np.array([[1.0, 0.0]], dtype=float),
+        triangles=np.empty((0, 3), dtype=int),
+        edges=[],
+        sweeps=np.array([0], dtype=int),
+    )
+    v, _ = extrude_beam_geometry(
+        profile, axis_start=np.zeros(3), axis_end=np.zeros(3), R=R,
+    )
+    # local (0, 1, 0) → global (1, 0, 0)
+    np.testing.assert_allclose(v[0], [1.0, 0.0, 0.0])
+
+
+def test_section_offset_translates_in_local_frame():
+    """A section offset of (yOff, zOff) must shift every vertex by
+    R @ (0, yOff, zOff) — the local-frame translation, then rotated.
+    """
+    p = _triangle_profile()
+    R = np.eye(3)
+    offset = np.array([0.5, -0.25])
+    v_no_offset, _ = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]), R=R,
+    )
+    v_offset, _ = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]), R=R,
+        section_offset=offset,
+    )
+    # With R = I, the global delta equals (0, 0.5, -0.25) per vertex.
+    expected_delta = np.tile([0.0, 0.5, -0.25], (v_no_offset.shape[0], 1))
+    np.testing.assert_allclose(v_offset - v_no_offset, expected_delta)
+
+
+# ---------------------------------------------------------------------- #
+# Face structure
+# ---------------------------------------------------------------------- #
+def test_end1_cap_winding_reversed():
+    """End-1 cap reverses ``profile.triangles`` winding so the outward
+    normal points along local -x (away from axis_end).
+    """
+    p = _triangle_profile()
+    _, faces = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    # First face is end-1 cap, reversed: (0, 2, 1) from (0, 1, 2)
+    assert faces[0].tolist() == [0, 2, 1]
+
+
+def test_end2_cap_offset_by_npts():
+    p = _triangle_profile()
+    n_pts = p.points.shape[0]
+    _, faces = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    # Second face is end-2 cap, same winding as profile.triangles[0]
+    # shifted by n_pts: (0+3, 1+3, 2+3) = (3, 4, 5).
+    assert faces[1].tolist() == [0 + n_pts, 1 + n_pts, 2 + n_pts]
+
+
+def test_side_surface_uses_sweep_loop():
+    """Square sweep [0, 1, 2, 3] should produce 4 quads = 8 triangles
+    on the side surface, with indices wrapping around the loop.
+    """
+    p = _unit_square_profile()
+    n_pts = p.points.shape[0]
+    _, faces = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    # Skip the 2 + 2 cap faces; remaining are 8 side triangles.
+    side = faces[4:]
+    assert side.shape == (8, 3)
+    # First side quad: a=0, b=1, c=1+n_pts, d=0+n_pts; triangulated
+    # as (a, b, c) and (a, c, d).
+    assert side[0].tolist() == [0, 1, 1 + n_pts]
+    assert side[4].tolist() == [0, 1 + n_pts, 0 + n_pts]
+    # Wrap-around quad: a=3, b=0, c=0+n_pts, d=3+n_pts.
+    assert side[3].tolist() == [3, 0, 0 + n_pts]
+    assert side[7].tolist() == [3, 0 + n_pts, 3 + n_pts]
+
+
+def test_no_sweeps_emits_caps_only():
+    """A profile with sweeps.size < 2 produces only the two end caps."""
+    profile = BeamProfile(
+        profile_id=4,
+        points=np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=float),
+        triangles=np.array([[0, 1, 2]], dtype=int),
+        edges=[],
+        sweeps=np.array([0], dtype=int),  # single sweep — no segment
+    )
+    _, faces = extrude_beam_geometry(
+        profile, axis_start=np.zeros(3), axis_end=np.array([1.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    # Just 2 caps (1 triangle each).
+    assert faces.shape[0] == 2
+
+
+def test_no_triangles_emits_side_surface_only():
+    """A profile without fill triangles still produces side faces."""
+    p = _no_caps_profile()
+    _, faces = extrude_beam_geometry(
+        p, axis_start=np.zeros(3), axis_end=np.array([2.0, 0.0, 0.0]),
+        R=np.eye(3),
+    )
+    # No caps. Sweeps [0, 1] = 2 points; closed loop gives 2 segments,
+    # each split into 2 triangles → 4 side triangles.
+    assert faces.shape[0] == 4
+    assert faces.min() >= 0 and faces.max() < 4  # 2*n_pts = 4 vertices
+
+
+# ---------------------------------------------------------------------- #
+# Real-fixture smoke test
+# ---------------------------------------------------------------------- #
+def test_extrude_runs_on_elastic_frame_first_element(elastic_frame_dir):
+    """End-to-end smoke: real beam profile + real local axes + real
+    end-node coords. Does not assert geometry correctness — just that
+    the function returns sane shapes on a real fixture.
+    """
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    profiles = ds.cdata.beam_profiles
+    assignments = ds.cdata.beam_profile_assignments
+    assert profiles and assignments
+
+    eid = next(iter(assignments))
+    pid, _weight = assignments[eid][0]
+    profile = profiles[pid]
+    R = ds.cdata.rotation_matrix(eid)
+
+    # Pull the two end-node coords from the element index dataframe.
+    df = ds.elements_info["dataframe"]
+    row = df.loc[df["element_id"] == eid].iloc[0]
+    node_ids = row["node_list"]
+    nodes_df = ds.nodes_info["dataframe"]
+    n0 = nodes_df.loc[nodes_df["node_id"] == int(node_ids[0])].iloc[0]
+    n1 = nodes_df.loc[nodes_df["node_id"] == int(node_ids[1])].iloc[0]
+    axis_start = np.array([n0["x"], n0["y"], n0["z"]], dtype=float)
+    axis_end = np.array([n1["x"], n1["y"], n1["z"]], dtype=float)
+
+    v, f = extrude_beam_geometry(
+        profile, axis_start=axis_start, axis_end=axis_end, R=R,
+    )
+    n_pts = profile.points.shape[0]
+    assert v.shape == (2 * n_pts, 3)
+    assert f.shape[1] == 3
+    assert f.dtype == np.int64
+    # End-pair invariant on a real element too.
+    delta = v[n_pts:] - v[:n_pts]
+    np.testing.assert_allclose(delta, np.tile(axis_end - axis_start, (n_pts, 1)))


### PR DESCRIPTION
## Summary

First of three small PRs for the 3D beam visualization feature. This one is **scaffolding only** — no user-facing API, no matplotlib. Just the load-bearing geometry math the later PRs build on.

- `STKO_to_python.plotting.beam_solid.extrude_beam_geometry(profile, axis_start, axis_end, R, section_offset=None)` — sweeps a `BeamProfile` between two beam endpoints and returns `(vertices, faces)` as a 3D triangle mesh.
- Vertices: `(2 * n_pts, 3)` float64. First `n_pts` rows are the section at `axis_start`, next `n_pts` at `axis_end`, aligned row-for-row.
- Faces: `(n_faces, 3)` int64. End-1 cap (winding reversed for outward normal), end-2 cap, plus 2 triangles per segment of the `profile.sweeps` polyline treated as a closed loop.
- Section offset (`*SECTION_OFFSET` from the cdata sidecar) is applied in the section's local `(y, z)` frame before the rotation, matching the convention `v_global = R @ v_local + node`.

PATCH-level change per [CLAUDE.md versioning policy](CLAUDE.md#versioning-policy) — deep-import-only scaffolding, not re-exported through the public package surface. CHANGELOG entry under `[Unreleased]` → "Added (internal)".

## Test plan

- [x] `pytest tests/` — 810 passed, 34 fixture-skipped (was 797 + 13 new geometry tests).
- [x] `mkdocs build --strict` — clean.
- [x] Geometry contract pinned in `tests/unit/test_beam_extrude.py`:
  - Vertex / face dtypes and shapes.
  - Identity rotation places section in the global yz-plane.
  - `vertices[k+n_pts] - vertices[k] == axis_end - axis_start` for every k.
  - 90-deg rotation maps local-y to global-x via `R @ (0, 1, 0)`.
  - Section offset translates every vertex by `R @ (0, yOff, zOff)`.
  - End-1 cap winding reversed; end-2 cap indices offset by `n_pts`.
  - Square sweep loop produces 8 side triangles wrapping around correctly.
  - Degenerate profiles (no triangles, single sweep point) emit only the surviving face groups.
- [x] Real-fixture smoke check: extrudes the first beam in `elasticFrame/results` using the quaternion-derived rotation and asserts the end-pair invariant on real coords.

## Follow-up

- **PR 2B** — `ds.plot.beam_solids(...)` wrapper that resolves `beam_profile_assignments` per element, pulls end-node coords + local-axes rotation, calls into `extrude_beam_geometry`, and renders via `Poly3DCollection`. Cookbook recipe 09.
- **PR 2C** — deformed variant fed by `displacement` at the chosen step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)