### PR TITLE
Add ds.plot.beam_solids: render beams as 3D extruded section solids (PR 2B of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,35 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ## [Unreleased]
 
+### Added
+
+- **`ds.plot.beam_solids(...)`** — new method on the dataset plot
+  facade that renders beam elements as 3D extruded section solids,
+  using the cdata sidecar's `*BEAM_PROFILE`,
+  `*BEAM_PROFILE_ASSIGNMENT`, `*LOCAL_AXES`, and `*SECTION_OFFSET`
+  blocks. Builds one triangle batch per beam via the geometry kernel
+  added previously, accumulates a single
+  `Poly3DCollection` for the fill, and overlays the section perimeters
+  + sweep longitudinals as a `Line3DCollection` (interior
+  triangulation edges intentionally suppressed). Accepts the same
+  `element_ids` / `selection_set_id` / `selection_set_name` filter as
+  the rest of the plot facade and silently filters out elements that
+  aren't beams. Returns `(ax, meta)` with `element_count`,
+  `triangle_count`, `skipped_elements`, and `profile_ids`.
+- New cookbook recipe
+  [09 — Render beams as 3D extruded solids](docs/cookbook/09-render-beam-solids.md)
+  walks through the default render, selection-set filtering,
+  composition with the shell mesh, and the low-level geometry-kernel
+  escape hatch.
+
 ### Added (internal)
 
 - `STKO_to_python.plotting.beam_solid.extrude_beam_geometry(...)` —
   pure-numpy helper that sweeps a `BeamProfile` between two beam
   endpoints (with optional `*SECTION_OFFSET`) and returns
   `(vertices, faces)` as a 3D triangle mesh. Foundation for the
-  upcoming `ds.plot.beam_solids` rendering wrapper; the geometry
-  function is matplotlib-free so it can be unit-tested without a
-  display backend.
+  `ds.plot.beam_solids` rendering wrapper; the geometry function is
+  matplotlib-free so it can be unit-tested without a display backend.
 
 ### Changed (internal)
 
@@ -49,6 +69,13 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
   triangulation from the sweep loop, and degenerate profiles (no
   triangles, no sweeps). Includes a real-fixture smoke check on the
   `elasticFrame/results` beam profile.
+- Added `tests/integration/test_beam_solids.py` (7 tests) exercising
+  the `ds.plot.beam_solids` renderer on both single-partition
+  (`elasticFrame/results`, 3 beams) and multi-class
+  (`elasticFrame/QuadFrame_results`, 75 beams + 625 shells) fixtures.
+  Pins the `(ax, meta)` contract, the explicit-id and unknown-id
+  filter behavior, the `edge_color=None` switch, and composition with
+  a user-supplied 3D axes.
 
 ---
 

--- a/docs/cookbook/09-render-beam-solids.md
+++ b/docs/cookbook/09-render-beam-solids.md
@@ -1,0 +1,148 @@
+# Render beam elements as 3D extruded solids
+
+> Turn 1D beam elements into 3D extruded section solids using the
+> `*BEAM_PROFILE` + `*BEAM_PROFILE_ASSIGNMENT` + `*LOCAL_AXES` data
+> STKO writes to the `.cdata` sidecar. One call to
+> `ds.plot.beam_solids(...)` does the entire pipeline.
+
+The engineering question is: *I have a frame of `5-ElasticBeam3d`
+elements — line elements in the recorder — and I want to see the
+actual section shape extruded along each member.* STKO already records
+everything we need: a 2D cross-section per profile, an element →
+profile assignment, and a local-frame rotation per element. v1.4.0+
+parses these into the cdata reader; this recipe wires them through to
+a 3D matplotlib plot.
+
+The fixture used here is
+`stko_results_examples/elasticFrame/QuadFrame_results` — 75
+`5-ElasticBeam3d` elements arranged as a frame, plus 625
+`203-ASDShellQ4` shell elements in the cladding. The renderer
+**silently filters out** anything that isn't in
+`beam_profile_assignments`, so the shells stay out of the way.
+
+```python
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+from STKO_to_python import MPCODataSet
+
+REPO_ROOT = Path("path/to/STKO_to_python")
+DATASET = REPO_ROOT / "stko_results_examples" / "elasticFrame" / "QuadFrame_results"
+
+ds = MPCODataSet(str(DATASET), "results", verbose=False)
+```
+
+---
+
+## 1. Render every beam in the model
+
+The default call extrudes every element with a profile assignment:
+
+```python
+ax, meta = ds.plot.beam_solids()
+print(meta["element_count"])     # 75
+print(meta["triangle_count"])    # 900
+print(meta["profile_ids"])       # [1]
+plt.show()
+```
+
+`meta["skipped_elements"]` lists IDs that were filtered but lacked
+`*LOCAL_AXES` (rare in practice — STKO writes axes for every line
+element) or referenced a profile id that wasn't defined.
+
+The structural-edge overlay (section perimeter at both ends + sweep
+longitudinals) is on by default in dark gray. Disable it for a flat
+filled look:
+
+```python
+ax, _ = ds.plot.beam_solids(edge_color=None, face_color="C2")
+```
+
+---
+
+## 2. Narrow the rendered set with selection inputs
+
+Mix and match `element_ids`, `selection_set_id`, and
+`selection_set_name`; the union is intersected with the set of
+elements that actually have profile assignments. Selection-set names
+go through the same case-insensitive resolver the rest of the library
+uses, so the lookup matches STKO's `*SELECTION_SET` blocks verbatim.
+
+```python
+# Just the columns:
+ax, _ = ds.plot.beam_solids(selection_set_name="Columns")
+
+# A small subset by explicit id:
+ax, _ = ds.plot.beam_solids(element_ids=[1, 2, 3])
+```
+
+If the filter produces no matching beam elements the renderer raises
+`ValueError("No beam elements with profile assignments matched the filter.")`
+— the same shape as the rest of the plot facade.
+
+---
+
+## 3. Compose with the shell mesh
+
+`ds.plot.beam_solids` accepts a pre-existing 3D `matplotlib` axes via
+the `ax` parameter, so the beam solids can sit on top of (or under) a
+shell mesh on the same canvas. Both `ds.plot.mesh` and
+`ds.plot.deformed_shape` auto-select 3D when the model is
+non-planar, so the combined plot looks consistent:
+
+```python
+ax, _ = ds.plot.mesh(element_type="ASDShellQ4")
+ds.plot.beam_solids(ax=ax, face_color="C3", alpha=0.7)
+```
+
+The order matters for matplotlib's depth sort — draw the wireframe
+first, then the solids, so the column volumes occlude the shell edges
+that pass behind them.
+
+---
+
+## 4. Per-element profile vs. uniform section
+
+STKO supports variable cross-section through
+`*BEAM_PROFILE_ASSIGNMENT` entries with weight pairs. **This release
+picks the first profile per element**; weighted blending is a future
+extension. For elements with one assignment (the common case)
+behavior is unchanged.
+
+If you need the lower-level building blocks — say, to export the
+triangulated mesh to a different renderer — call into the geometry
+kernel directly:
+
+```python
+from STKO_to_python.plotting.beam_solid import extrude_beam_geometry
+
+eid = 1
+pid, _weight = ds.cdata.beam_profile_assignments[eid][0]
+profile = ds.cdata.beam_profiles[pid]
+R = ds.cdata.rotation_matrix(eid)
+# end-node coords from your favourite source...
+vertices, faces = extrude_beam_geometry(
+    profile, axis_start=n0, axis_end=n1, R=R,
+    section_offset=ds.cdata.section_offsets.get(eid),
+)
+```
+
+`vertices` is `(2 * n_pts, 3)` global coordinates and `faces` is
+`(n_tri, 3)` zero-based indices — drop them into any triangle-mesh
+viewer.
+
+---
+
+## Variations
+
+- **Render the deformed solid** — wait for PR 2C; the deformed
+  variant feeds the same kernel with `node + scale * displacement`
+  instead of the original nodal coords.
+- **Color beams by force** — fetch element results, build a per-element
+  scalar, normalize, and pass `face_color` as an array; the
+  `Poly3DCollection` accepts a colormap-compatible value array via
+  `set_array`.
+- **Export to STL** — `vertices` and `faces` from
+  `extrude_beam_geometry` are the canonical STL inputs; concatenate
+  the per-element batches with a vertex offset and write with
+  ``numpy-stl`` or similar.

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -19,6 +19,7 @@ workflows the library is built around. Each tutorial:
 | 6 | [Node selector + mask pipeline](06-node-selector-and-mask-pipeline.md) | `elasticFrame/elasticFrame_mesh_displacementBased_results` | (node-side; any element family) |
 | 7 | [Select by STKO geometry and property name](07-select-by-geometry-and-property.md) | `elasticFrame/QuadFrame_results` | `203-ASDShellQ4` + `5-ElasticBeam3d` |
 | 8 | [Rotate beam-local forces to global](08-rotate-beam-forces-to-global.md) | `elasticFrame/elasticFrame_mesh_results` | `5-ElasticBeam3d` |
+| 9 | [Render beams as 3D extruded solids](09-render-beam-solids.md) | `elasticFrame/QuadFrame_results` | `5-ElasticBeam3d` (+ shell backdrop) |
 
 For broader tours of the API on a single fixture see the
 [Examples](../examples/usage_tour.md) section. For the reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Node selector + mask pipeline: cookbook/06-node-selector-and-mask-pipeline.md
       - Select by STKO geometry and property name: cookbook/07-select-by-geometry-and-property.md
       - Rotate beam-local forces to global: cookbook/08-rotate-beam-forces-to-global.md
+      - Render beams as 3D extruded solids: cookbook/09-render-beam-solids.md
   - Examples:
       - Usage tour: examples/usage_tour.md
       - Elastic frame: examples/elastic_frame.md

--- a/src/STKO_to_python/plotting/beam_solid.py
+++ b/src/STKO_to_python/plotting/beam_solid.py
@@ -1,20 +1,25 @@
-"""Geometry helpers for rendering beam elements as 3D extruded solids.
+"""Geometry helpers and renderer for beam elements as 3D extruded solids.
 
-Builds a triangle mesh from a 2D cross-section (``BeamProfile``) swept
-along a 1D axis between two endpoints. The output is a pair of plain
-numpy arrays — vertices in global coordinates and triangular faces as
-integer indices — that downstream callers can feed to
-``mpl_toolkits.mplot3d.art3d.Poly3DCollection`` or any other triangle
-renderer.
+:func:`extrude_beam_geometry` is the pure-numpy geometry kernel — it
+sweeps a ``BeamProfile`` between two beam endpoints and returns
+``(vertices, faces)`` for one element.
+
+:func:`plot_beam_solids` is the dataset-level renderer (wired on the
+:class:`~STKO_to_python.plotting.plot.Plot` facade as
+``ds.plot.beam_solids``). It walks the cdata's
+``beam_profile_assignments``, builds the per-element extrusion using
+the geometry kernel, accumulates one combined triangle batch, and
+renders it as a :class:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`.
+Optional structural edges (section outlines at both ends + per-sweep
+longitudinals) overlay as a :class:`~mpl_toolkits.mplot3d.art3d.Line3DCollection`.
 
 PR scope
 --------
-This module is intentionally matplotlib-free. The dataset-level plot
-wrapper (``ds.plot.beam_solids``) that consumes :func:`extrude_beam_geometry`
-lands in a follow-up PR. The function takes a single profile per call,
-so variable cross-section (multiple ``(profile_id, weight)`` entries in
-``beam_profile_assignments``) is handled by the caller — typically by
-picking the first entry until the v2 follow-up.
+Variable cross-section (multiple ``(profile_id, weight)`` entries in
+``beam_profile_assignments``) is not yet supported: the renderer picks
+the **first** profile assignment per element. The geometry kernel
+itself only ever takes one profile per call, so a future per-segment
+variant can layer on top without changing the public API here.
 
 Coordinate convention
 ---------------------
@@ -30,12 +35,17 @@ Coordinate convention
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+import logging
+import warnings
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from ..core.dataset import MPCODataSet
     from ..model.cdata_reader import BeamProfile
+
+logger = logging.getLogger(__name__)
 
 
 def extrude_beam_geometry(
@@ -138,4 +148,345 @@ def extrude_beam_geometry(
     return vertices, faces
 
 
-__all__ = ["extrude_beam_geometry"]
+def _structural_edge_segments(
+    profile: "BeamProfile",
+    end1_vertices: np.ndarray,
+    end2_vertices: np.ndarray,
+) -> np.ndarray:
+    """Collect the "visually structural" edges of one extruded element.
+
+    Returns a ``(n_segments, 2, 3)`` array of line endpoints in global
+    coordinates, suitable for feeding to a
+    :class:`~mpl_toolkits.mplot3d.art3d.Line3DCollection`. Three groups
+    of edges are emitted:
+
+    1. The section outline at ``axis_start`` (one polyline per entry
+       of ``profile.edges``).
+    2. The section outline at ``axis_end`` (same polylines, end-2 copy).
+    3. The sweep longitudinals — one straight line per ``profile.sweeps``
+       point, connecting the end-1 and end-2 copies of that point.
+
+    Interior triangulation edges are intentionally not emitted. The
+    overlay is the difference between "this looks like a triangulated
+    surface" and "this looks like a beam".
+    """
+    segs: List[np.ndarray] = []
+
+    # Section outlines: each `edge` is a polyline of point indices.
+    for end_vertices in (end1_vertices, end2_vertices):
+        for edge_indices in profile.edges:
+            if edge_indices.size < 2:
+                continue
+            pts = end_vertices[edge_indices]
+            # Consecutive endpoint pairs: (p0, p1), (p1, p2), ...
+            for i in range(pts.shape[0] - 1):
+                segs.append(np.stack([pts[i], pts[i + 1]]))
+
+    # Sweep longitudinals: one straight line per sweep point.
+    sweeps = np.asarray(profile.sweeps, dtype=np.int64)
+    for s in sweeps:
+        segs.append(np.stack([end1_vertices[int(s)], end2_vertices[int(s)]]))
+
+    if not segs:
+        return np.empty((0, 2, 3), dtype=float)
+    return np.asarray(segs, dtype=float)
+
+
+def plot_beam_solids(
+    dataset: "MPCODataSet",
+    *,
+    element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+    selection_set_id: Union[int, Sequence[int], None] = None,
+    selection_set_name: Union[str, Sequence[str], None] = None,
+    ax: Any = None,
+    face_color: Any = "C0",
+    edge_color: Optional[Any] = "0.25",
+    linewidth: float = 0.6,
+    alpha: float = 0.85,
+    title: Optional[str] = None,
+) -> Tuple[Any, Dict[str, Any]]:
+    """Render beam elements as 3D extruded section solids.
+
+    Walks the cdata sidecar's ``beam_profile_assignments`` to find every
+    element that has a section profile, builds one
+    :func:`extrude_beam_geometry` triangle batch per element, and renders
+    the combined mesh as a single
+    :class:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`. When
+    ``edge_color`` is set, the **structural** outline of each element
+    (section perimeter at both ends + sweep longitudinals; no interior
+    triangulation edges) is overlaid via
+    :class:`~mpl_toolkits.mplot3d.art3d.Line3DCollection`.
+
+    Args:
+        dataset: Source :class:`MPCODataSet`.
+        element_ids: Optional explicit element IDs. May combine with the
+            two ``selection_set_*`` parameters; their union is intersected
+            with the set of elements that actually have profile
+            assignments.
+        selection_set_id: Optional selection-set ID (or sequence).
+        selection_set_name: Optional selection-set name (or sequence).
+        ax: Existing 3D matplotlib axes. ``None`` creates a new figure
+            with a ``projection="3d"`` subplot. If you supply ``ax``
+            yourself, it must be 3D — the renderer does not downscale to
+            2D because the extrusion is inherently three-dimensional.
+        face_color: Polygon fill color (matplotlib color spec).
+        edge_color: Structural-edge color, or ``None`` to disable the
+            edge overlay. Defaults to dark gray so the section outlines
+            and sweep longitudinals are visible against the fill.
+        linewidth: Width of structural edges (no effect when
+            ``edge_color`` is ``None``).
+        alpha: Polygon alpha. Transparency lets overlapping beams stay
+            readable; the default ``0.85`` is opaque enough to read
+            shape but still hint at occluded geometry.
+        title: Optional axes title.
+
+    Returns:
+        ``(ax, meta)``. ``meta`` carries:
+
+        * ``element_count`` — number of beams rendered.
+        * ``triangle_count`` — total triangles in the Poly3DCollection.
+        * ``skipped_elements`` — list of ids skipped because of missing
+          ``*LOCAL_AXES``, missing nodes, or a profile id not present
+          in ``cdata.beam_profiles``. Skipped reason logged at INFO.
+        * ``profile_ids`` — sorted list of unique profile ids that
+          actually contributed to the rendered mesh.
+        * ``is_3d`` — always ``True``; kept for parity with the other
+          plot helpers' meta blocks.
+
+    Raises:
+        ValueError: if the cdata sidecar carries no beam profile
+            assignments at all, or if the filter resolves to zero
+            elements with assignments.
+    """
+    assignments = dataset.cdata.beam_profile_assignments
+    profiles = dataset.cdata.beam_profiles
+    if not assignments:
+        raise ValueError(
+            "Dataset has no *BEAM_PROFILE_ASSIGNMENT entries in its "
+            ".cdata sidecar — nothing to render."
+        )
+    if not profiles:
+        raise ValueError(
+            "Dataset has no *BEAM_PROFILE entries in its .cdata sidecar — "
+            "assignments reference profile ids that aren't defined."
+        )
+
+    assignment_ids = {int(eid) for eid in assignments.keys()}
+
+    user_filtered = (
+        element_ids is not None
+        or selection_set_id is not None
+        or selection_set_name is not None
+    )
+    if user_filtered:
+        resolved = dataset._selection_resolver.resolve_elements(
+            names=selection_set_name,
+            ids=selection_set_id,
+            explicit_ids=element_ids,
+        )
+        target = sorted(assignment_ids & {int(e) for e in resolved})
+    else:
+        target = sorted(assignment_ids)
+
+    if not target:
+        raise ValueError(
+            "No beam elements with profile assignments matched the filter."
+        )
+
+    # Pull every element's end-node coords from the cached dataframe in
+    # one pass; build an eid → (n0_xyz, n1_xyz) lookup so we don't pay
+    # per-element dataframe filtering inside the geometry loop.
+    df_elements = dataset.elements_info["dataframe"]
+    df_nodes = dataset.nodes_info["dataframe"]
+    node_coords = {
+        int(row.node_id): np.array([row.x, row.y, row.z], dtype=float)
+        for row in df_nodes.itertuples(index=False)
+    }
+    elements_by_id = df_elements.set_index("element_id", drop=False)
+
+    # Vectorized rotation lookup. Elements without *LOCAL_AXES are
+    # filtered out before this call so rotation_matrices doesn't raise.
+    local_axes = dataset.cdata.local_axes
+    section_offsets = dataset.cdata.section_offsets
+
+    skipped: List[int] = []
+    eligible_ids: List[int] = []
+    for eid in target:
+        if eid not in local_axes:
+            skipped.append(eid)
+            logger.info(
+                "plot_beam_solids: skipping element %d — no *LOCAL_AXES entry",
+                eid,
+            )
+            continue
+        eligible_ids.append(eid)
+
+    if not eligible_ids:
+        raise ValueError(
+            "All matched elements lacked *LOCAL_AXES entries; nothing to draw."
+        )
+
+    ids_arr, R_batch = dataset.cdata.rotation_matrices(eligible_ids)
+    # ids_arr should align with eligible_ids after the rotation_matrices
+    # call sorts. Re-key R by element id so the geometry loop is clear.
+    R_by_id = {int(eid): R for eid, R in zip(ids_arr.tolist(), R_batch)}
+
+    # Per-element accumulators. Concatenate vertices/faces with running
+    # offsets so the final Poly3DCollection sees one big batch.
+    all_vertices: List[np.ndarray] = []
+    all_faces: List[np.ndarray] = []
+    all_edge_segs: List[np.ndarray] = []
+    profile_ids_used: set = set()
+    vertex_offset = 0
+
+    for eid in eligible_ids:
+        # Resolve profile (first assignment for v1 — variable cross-section
+        # is a future extension).
+        pid, _weight = assignments[eid][0]
+        profile = profiles.get(int(pid))
+        if profile is None:
+            skipped.append(eid)
+            logger.info(
+                "plot_beam_solids: skipping element %d — profile id %d not in beam_profiles",
+                eid,
+                pid,
+            )
+            continue
+
+        try:
+            elem_row = elements_by_id.loc[eid]
+        except KeyError:
+            skipped.append(eid)
+            logger.info(
+                "plot_beam_solids: skipping element %d — not in elements_info",
+                eid,
+            )
+            continue
+
+        node_list = elem_row["node_list"]
+        if len(node_list) != 2:
+            # Beam profile assignments shouldn't exist for non-line
+            # elements, but guard anyway.
+            skipped.append(eid)
+            logger.info(
+                "plot_beam_solids: skipping element %d — expected 2-node line element, got %d nodes",
+                eid,
+                len(node_list),
+            )
+            continue
+        try:
+            n0 = node_coords[int(node_list[0])]
+            n1 = node_coords[int(node_list[1])]
+        except KeyError:
+            skipped.append(eid)
+            logger.info(
+                "plot_beam_solids: skipping element %d — node not in nodes_info",
+                eid,
+            )
+            continue
+
+        R = R_by_id[eid]
+        offset_xy = section_offsets.get(eid)  # may be None
+        vertices, faces = extrude_beam_geometry(
+            profile,
+            axis_start=n0,
+            axis_end=n1,
+            R=R,
+            section_offset=offset_xy,
+        )
+        all_vertices.append(vertices)
+        all_faces.append(faces + vertex_offset)
+        if edge_color is not None:
+            n_pts = profile.points.shape[0]
+            end1 = vertices[:n_pts]
+            end2 = vertices[n_pts:]
+            all_edge_segs.append(_structural_edge_segments(profile, end1, end2))
+        vertex_offset += vertices.shape[0]
+        profile_ids_used.add(int(pid))
+
+    if not all_vertices:
+        raise ValueError(
+            "Every matched element was skipped; check the logger output "
+            "for individual reasons (no profile, no local axes, etc.)."
+        )
+
+    combined_vertices = np.vstack(all_vertices)
+    combined_faces = np.vstack(all_faces)
+    polygons = combined_vertices[combined_faces]  # (n_faces, 3, 3)
+
+    # Axes creation. The output is inherently 3D — caller's `ax` must be
+    # a 3D axes if supplied, otherwise we make one.
+    if ax is None:
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+
+    from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+    poly = Poly3DCollection(
+        polygons,
+        facecolors=face_color,
+        edgecolors="none",
+        linewidths=0.0,
+        alpha=alpha,
+    )
+    ax.add_collection3d(poly)
+
+    if edge_color is not None and all_edge_segs:
+        from mpl_toolkits.mplot3d.art3d import Line3DCollection
+
+        edge_array = np.vstack(all_edge_segs)
+        line_coll = Line3DCollection(
+            edge_array,
+            colors=edge_color,
+            linewidths=linewidth,
+            alpha=1.0,
+        )
+        ax.add_collection3d(line_coll)
+
+    # Framing from the combined vertex cloud.
+    from .deformed_shape import _autoscale_axes
+
+    _autoscale_axes(ax, combined_vertices, is_3d=True)
+
+    # Equal-aspect 3D box. matplotlib's default 3D axes use a unit cube
+    # regardless of data extents, which makes beams look squashed when
+    # one dimension dominates. ``set_box_aspect`` accepts the post-pad
+    # span tuple so the visual proportions match the data.
+    spans = np.array(
+        [
+            ax.get_xlim3d(),
+            ax.get_ylim3d(),
+            ax.get_zlim3d(),
+        ],
+        dtype=float,
+    )
+    span_lengths = spans[:, 1] - spans[:, 0]
+    if np.all(span_lengths > 0):
+        ax.set_box_aspect(tuple(span_lengths))
+
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel("z")
+    if title is not None:
+        ax.set_title(title)
+
+    if skipped:
+        warnings.warn(
+            f"[plot_beam_solids] Skipped {len(skipped)} elements "
+            f"(see INFO log for details).",
+            RuntimeWarning,
+        )
+
+    meta: Dict[str, Any] = {
+        "element_count": len(all_vertices),
+        "triangle_count": int(combined_faces.shape[0]),
+        "skipped_elements": skipped,
+        "profile_ids": sorted(profile_ids_used),
+        "is_3d": True,
+    }
+    return ax, meta
+
+
+__all__ = ["extrude_beam_geometry", "plot_beam_solids"]

--- a/src/STKO_to_python/plotting/plot.py
+++ b/src/STKO_to_python/plotting/plot.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
 import numpy as np
 import matplotlib.pyplot as plt
 
+from .beam_solid import plot_beam_solids
 from .deformed_shape import plot_deformed_shape, plot_undeformed_shape
 from .mesh import plot_mesh, plot_mesh_with_contour
 
@@ -253,6 +254,66 @@ class Plot:
             axes=axes,
             title=title,
             **scatter_kwargs,
+        )
+
+
+    # ------------------------------------------------------------------ #
+    # 3D beam-solid visualization
+    # ------------------------------------------------------------------ #
+
+    def beam_solids(
+        self,
+        *,
+        element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+        selection_set_id: Union[int, Sequence[int], None] = None,
+        selection_set_name: Union[str, Sequence[str], None] = None,
+        ax: Any = None,
+        face_color: Any = "C0",
+        edge_color: Optional[Any] = "0.25",
+        linewidth: float = 0.6,
+        alpha: float = 0.85,
+        title: Optional[str] = None,
+    ) -> Tuple[Any, dict]:
+        """Render beam elements as 3D extruded section solids.
+
+        Walks the cdata sidecar's ``beam_profile_assignments`` to build
+        an extruded triangle mesh per beam element, then draws the
+        combined mesh as a single
+        :class:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`. When
+        ``edge_color`` is set (default), the section perimeter at both
+        ends and the sweep longitudinals are overlaid as a
+        :class:`~mpl_toolkits.mplot3d.art3d.Line3DCollection` — interior
+        triangulation edges are intentionally not drawn.
+
+        See :func:`STKO_to_python.plotting.beam_solid.plot_beam_solids`
+        for the full parameter list. ``meta`` carries ``element_count``,
+        ``triangle_count``, ``skipped_elements``, ``profile_ids``, and
+        ``is_3d``.
+
+        Examples
+        --------
+        Render every beam in the model::
+
+            ax, meta = ds.plot.beam_solids()
+
+        Limit to a selection set and skip the structural-edge overlay::
+
+            ax, meta = ds.plot.beam_solids(
+                selection_set_name="Columns",
+                edge_color=None,
+            )
+        """
+        return plot_beam_solids(
+            self._dataset,
+            element_ids=element_ids,
+            selection_set_id=selection_set_id,
+            selection_set_name=selection_set_name,
+            ax=ax,
+            face_color=face_color,
+            edge_color=edge_color,
+            linewidth=linewidth,
+            alpha=alpha,
+            title=title,
         )
 
 

--- a/tests/integration/test_beam_solids.py
+++ b/tests/integration/test_beam_solids.py
@@ -1,0 +1,131 @@
+"""Integration tests for ``ds.plot.beam_solids``.
+
+Exercises the real fixtures (single-partition pure-beam frame, and the
+multi-partition shells + beams frame) and verifies:
+
+* the `(ax, meta)` contract;
+* per-element triangle counts match the profile's triangulation
+  (2 caps + 2*n_sweeps side triangles per element);
+* multi-class models render only beams (shells are silently filtered
+  out by the assignment lookup);
+* selection-set and explicit-id filters narrow the rendered subset;
+* the ``edge_color=None`` switch suppresses the structural-edge overlay
+  without changing the triangle count.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+
+
+# ---------------------------------------------------------------------- #
+# Single-partition (3 beams, 1 profile)
+# ---------------------------------------------------------------------- #
+def test_beam_solids_elastic_frame_basic_meta(elastic_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.beam_solids()
+        assert ax is not None
+        # 3 elements × profile-1 triangulation (2 caps × 1 tri/cap +
+        # 2 × n_sweeps side tris = 2 + 8 = 12 tri/element on the
+        # 4-pt square outline of elasticFrame's profile)
+        assert meta["element_count"] == 3
+        assert meta["triangle_count"] == 3 * (2 * 2 + 2 * 4)
+        assert meta["skipped_elements"] == []
+        assert meta["profile_ids"] == [1]
+        assert meta["is_3d"] is True
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_explicit_element_ids_filter(elastic_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.beam_solids(element_ids=[1, 2])
+        assert meta["element_count"] == 2
+        # Same per-element triangulation, halved twice.
+        assert meta["triangle_count"] == 2 * (2 * 2 + 2 * 4)
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_edge_color_none_keeps_triangle_count(
+    elastic_frame_dir: Path,
+) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        _, meta_edges = ds.plot.beam_solids(edge_color="0.25")
+        plt.close("all")
+        _, meta_no_edges = ds.plot.beam_solids(edge_color=None)
+        # Suppressing edges must not change the underlying triangle mesh.
+        assert meta_edges["triangle_count"] == meta_no_edges["triangle_count"]
+        assert meta_edges["element_count"] == meta_no_edges["element_count"]
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_accepts_user_axes(elastic_frame_dir: Path) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    fig = plt.figure()
+    user_ax = fig.add_subplot(111, projection="3d")
+    try:
+        ax, meta = ds.plot.beam_solids(ax=user_ax)
+        assert ax is user_ax
+        assert meta["element_count"] > 0
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_unknown_element_id_raises(elastic_frame_dir: Path) -> None:
+    """The resolver short-circuits to an empty intersection with the
+    assignment set, and we raise a friendly error.
+    """
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        with pytest.raises(ValueError, match="No beam elements"):
+            ds.plot.beam_solids(element_ids=[99999])
+    finally:
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# Multi-class (beams + shells) — non-beams must be silently filtered
+# ---------------------------------------------------------------------- #
+def test_beam_solids_quad_frame_renders_only_beams(quad_frame_dir: Path) -> None:
+    """QuadFrame has 75 beams + 625 ASDShellQ4 elements. The renderer
+    should pick up exactly the 75 beams from beam_profile_assignments.
+    """
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.beam_solids()
+        assert meta["element_count"] == 75
+        assert meta["triangle_count"] == 75 * (2 * 2 + 2 * 4)
+        assert meta["skipped_elements"] == []
+        # All beams share one profile in this fixture.
+        assert meta["profile_ids"] == [1]
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_quad_frame_passthrough_to_user_3d_axes(
+    quad_frame_dir: Path,
+) -> None:
+    """Composes cleanly with an existing 3D axes (e.g., user overlays
+    beam solids on top of a shell mesh plot).
+    """
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    fig = plt.figure()
+    user_ax = fig.add_subplot(111, projection="3d")
+    try:
+        ax, _ = ds.plot.beam_solids(ax=user_ax)
+        assert ax is user_ax
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary

Second of three small PRs for 3D beam visualization. Wires the geometry kernel from [#69](https://github.com/nmorabowen/STKO_to_python/pull/69) into a user-facing renderer.

- **`ds.plot.beam_solids(...)`** on the [Plot](src/STKO_to_python/plotting/plot.py) facade. Walks `cdata.beam_profile_assignments`, extrudes each beam via [`extrude_beam_geometry`](src/STKO_to_python/plotting/beam_solid.py), and renders one combined `Poly3DCollection` for fills plus a `Line3DCollection` overlay of section perimeters + sweep longitudinals. Interior triangulation edges are intentionally suppressed so the result reads as a beam, not a triangulated surface.
- Accepts the standard `element_ids` / `selection_set_id` / `selection_set_name` filter (union, intersected with the assignment set). Multi-class models render only their beams — shells fall through the assignment lookup silently.
- Auto-`set_box_aspect` from the data ranges so the 3D plot doesn't look squashed by matplotlib's default unit cube.
- New cookbook recipe [09 — Render beams as 3D extruded solids](docs/cookbook/09-render-beam-solids.md).

**Scope limit:** picks the first profile per element. Variable cross-section (multiple `(profile_id, weight)` entries in `beam_profile_assignments`) is a follow-up — the kernel already accepts one profile per call, so a future per-segment renderer layers on top without changing this API.

MINOR-level change per [CLAUDE.md versioning policy](CLAUDE.md#versioning-policy) — new public API on the plot facade. CHANGELOG entry under `[Unreleased]` → "Added".

## Visual sanity check

`elasticFrame/results` (3 beams) — 2 columns + 1 horizontal, rendered as proper rectangular extruded solids:

![elasticFrame 3 beams](https://github.com/user-attachments/assets/placeholder-elastic.png)

`elasticFrame/QuadFrame_results` (75 beams + 625 shells) — frame perimeter renders cleanly with the shells filtered out:

![QuadFrame default aspect](https://github.com/user-attachments/assets/placeholder-quad.png)

(Both PNGs generated locally; matplotlib renders for visual verification, not committed to the repo.)

## Test plan

- [x] `pytest tests/` — **817 passed, 34 fixture-skipped** (was 810 + 7 new integration tests).
- [x] `mkdocs build --strict` — clean.
- [x] [tests/integration/test_beam_solids.py](tests/integration/test_beam_solids.py) covers:
  - Default render on `elasticFrame/results` — 3 beams, 36 triangles (12 per element: 2 caps × 2 ends + 8 side tris).
  - Explicit `element_ids` filter narrows to a subset.
  - `edge_color=None` suppresses the overlay without changing triangle count.
  - Pre-existing 3D `ax` is honored (composition with `ds.plot.mesh`).
  - Unknown `element_ids` raises `ValueError("No beam elements with profile assignments matched the filter.")`.
  - `QuadFrame_results` renders exactly 75 beams (shells silently filtered).
  - QuadFrame composes with a user 3D axes.

## Follow-up

- **PR 2C** — deformed variant: same geometry kernel, end-node coords replaced with `node + scale * displacement_at_step`. Drops into the existing pipeline as `ds.plot.beam_solids_deformed(model_stage=..., step=..., scale=...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)