### PR TITLE
Add ds.plot.beam_solids_deformed: render beams at a displaced step (PR 2C of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ### Added
 
+- **`ds.plot.beam_solids_deformed(model_stage, step, scale=1.0, ...)`** —
+  deformed twin of `ds.plot.beam_solids`. Fetches `DISPLACEMENT` at the
+  requested step, shifts every end node by `scale * disp`, and feeds
+  the displaced coordinates through the same extrusion pipeline.
+  `scale=0` collapses to the undeformed configuration without
+  fetching displacements. `meta` carries `model_stage`, `step`, and
+  `scale` on top of the standard keys. The cross-section's local
+  frame is taken from the undeformed `*LOCAL_AXES` quaternion — STKO
+  does not record a deformed local frame, so translations are exact
+  but large rotations on slender members may show a slightly off
+  section orientation (documented in the cookbook recipe).
+- Cookbook recipe 09 extended with a "Render the deformed
+  configuration" section covering scale selection and the
+  undeformed-local-frame caveat.
+
 - **`ds.plot.beam_solids(...)`** — new method on the dataset plot
   facade that renders beam elements as 3D extruded section solids,
   using the cdata sidecar's `*BEAM_PROFILE`,
@@ -69,13 +84,15 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
   triangulation from the sweep loop, and degenerate profiles (no
   triangles, no sweeps). Includes a real-fixture smoke check on the
   `elasticFrame/results` beam profile.
-- Added `tests/integration/test_beam_solids.py` (7 tests) exercising
-  the `ds.plot.beam_solids` renderer on both single-partition
-  (`elasticFrame/results`, 3 beams) and multi-class
-  (`elasticFrame/QuadFrame_results`, 75 beams + 625 shells) fixtures.
-  Pins the `(ax, meta)` contract, the explicit-id and unknown-id
-  filter behavior, the `edge_color=None` switch, and composition with
-  a user-supplied 3D axes.
+- Added `tests/integration/test_beam_solids.py` (12 tests) exercising
+  the `ds.plot.beam_solids` and `ds.plot.beam_solids_deformed`
+  renderers on both single-partition (`elasticFrame/results`, 3 beams)
+  and multi-class (`elasticFrame/QuadFrame_results`, 75 beams + 625
+  shells) fixtures. Pins the `(ax, meta)` contract, filter behavior,
+  the `edge_color=None` switch, user-supplied 3D axes composition,
+  the deformed `scale=0` short-circuit, and a monkeypatched
+  displacement test that proves the scaled displacement flows into
+  the rendered vertex positions.
 
 ---
 

--- a/docs/cookbook/09-render-beam-solids.md
+++ b/docs/cookbook/09-render-beam-solids.md
@@ -101,7 +101,46 @@ that pass behind them.
 
 ---
 
-## 4. Per-element profile vs. uniform section
+## 4. Render the deformed configuration
+
+`ds.plot.beam_solids_deformed(model_stage, step, scale)` is the
+deformed twin of `beam_solids`. It fetches `DISPLACEMENT` at the
+requested step, shifts every end node by `scale * disp`, and feeds
+those into the same extrusion pipeline. `meta` carries `model_stage`,
+`step`, and `scale` on top of the standard keys.
+
+```python
+ax, meta = ds.plot.beam_solids_deformed(
+    model_stage="MODEL_STAGE[2]",
+    step=9,
+    scale=2000.0,
+    face_color="C3",
+)
+```
+
+Two things to know:
+
+1. **Pick a scale that makes sense for your model.** Elastic frames
+   under service-load levels produce displacements that are orders of
+   magnitude smaller than member lengths — at true-to-life scale, the
+   deformation is invisible. The default in literature is 50-1000×;
+   the fixture used here needs ~2000× because the imposed load is
+   very small.
+2. **The cross-section's local frame is taken from the *undeformed*
+   `*LOCAL_AXES` quaternion.** STKO does not record a deformed local
+   frame, so we cannot rotate the section with the deformed tangent.
+   Translations look correct; large rotations on slender members may
+   show a slightly off section orientation. For visualization this is
+   acceptable; for downstream geometry export, use the undeformed
+   render plus a custom transform.
+
+`scale=0` collapses to the undeformed configuration without fetching
+DISPLACEMENT — useful for code paths that toggle deformed/undeformed
+behind a flag.
+
+---
+
+## 5. Per-element profile vs. uniform section
 
 STKO supports variable cross-section through
 `*BEAM_PROFILE_ASSIGNMENT` entries with weight pairs. **This release
@@ -135,13 +174,14 @@ viewer.
 
 ## Variations
 
-- **Render the deformed solid** — wait for PR 2C; the deformed
-  variant feeds the same kernel with `node + scale * displacement`
-  instead of the original nodal coords.
 - **Color beams by force** — fetch element results, build a per-element
   scalar, normalize, and pass `face_color` as an array; the
   `Poly3DCollection` accepts a colormap-compatible value array via
   `set_array`.
+- **Animate a pushover** — call `beam_solids_deformed` in a loop over
+  step indices and use `matplotlib.animation.FuncAnimation` to drive
+  the timeline. Hold the axes fixed (don't reset between frames) so
+  the camera stays steady.
 - **Export to STL** — `vertices` and `faces` from
   `extrude_beam_geometry` are the canonical STL inputs; concatenate
   the per-element batches with a vertex offset and write with

--- a/src/STKO_to_python/plotting/beam_solid.py
+++ b/src/STKO_to_python/plotting/beam_solid.py
@@ -192,6 +192,277 @@ def _structural_edge_segments(
     return np.asarray(segs, dtype=float)
 
 
+def _resolve_target_beam_ids(
+    dataset: "MPCODataSet",
+    *,
+    element_ids: Union[int, Sequence[int], np.ndarray, None],
+    selection_set_id: Union[int, Sequence[int], None],
+    selection_set_name: Union[str, Sequence[str], None],
+) -> List[int]:
+    """Return the sorted list of element ids to extrude.
+
+    Validates that the cdata sidecar carries beam profiles and
+    assignments, then intersects the user filter (if any) with the
+    set of elements that actually have an assignment.
+
+    Raises:
+        ValueError: if the sidecar is empty or the filter produces no
+            matching elements.
+    """
+    assignments = dataset.cdata.beam_profile_assignments
+    profiles = dataset.cdata.beam_profiles
+    if not assignments:
+        raise ValueError(
+            "Dataset has no *BEAM_PROFILE_ASSIGNMENT entries in its "
+            ".cdata sidecar — nothing to render."
+        )
+    if not profiles:
+        raise ValueError(
+            "Dataset has no *BEAM_PROFILE entries in its .cdata sidecar — "
+            "assignments reference profile ids that aren't defined."
+        )
+
+    assignment_ids = {int(eid) for eid in assignments.keys()}
+
+    user_filtered = (
+        element_ids is not None
+        or selection_set_id is not None
+        or selection_set_name is not None
+    )
+    if user_filtered:
+        resolved = dataset._selection_resolver.resolve_elements(
+            names=selection_set_name,
+            ids=selection_set_id,
+            explicit_ids=element_ids,
+        )
+        target = sorted(assignment_ids & {int(e) for e in resolved})
+    else:
+        target = sorted(assignment_ids)
+
+    if not target:
+        raise ValueError(
+            "No beam elements with profile assignments matched the filter."
+        )
+    return target
+
+
+def _undeformed_node_coords(dataset: "MPCODataSet") -> Dict[int, np.ndarray]:
+    """Build the ``{node_id: (3,)}`` mapping from ``nodes_info``."""
+    df_nodes = dataset.nodes_info["dataframe"]
+    return {
+        int(row.node_id): np.array([row.x, row.y, row.z], dtype=float)
+        for row in df_nodes.itertuples(index=False)
+    }
+
+
+def _render_extruded_beams(
+    dataset: "MPCODataSet",
+    target: Sequence[int],
+    node_coords: Dict[int, np.ndarray],
+    *,
+    log_label: str,
+    ax: Any,
+    face_color: Any,
+    edge_color: Optional[Any],
+    linewidth: float,
+    alpha: float,
+    title: Optional[str],
+) -> Tuple[Any, Dict[str, Any]]:
+    """Build per-element extrusions and render the combined mesh.
+
+    Shared backbone of :func:`plot_beam_solids` and
+    :func:`plot_beam_solids_deformed`. The undeformed renderer feeds in
+    coordinates straight from ``nodes_info``; the deformed renderer
+    feeds in ``original + scale * displacement``. Everything downstream
+    — eligibility filtering, rotation lookup, per-element extrusion,
+    Poly3DCollection / Line3DCollection assembly, framing — is identical.
+
+    ``log_label`` is the prefix used in INFO-level skip log lines and
+    the RuntimeWarning, so users can tell ``plot_beam_solids`` and
+    ``plot_beam_solids_deformed`` apart in mixed logs.
+    """
+    assignments = dataset.cdata.beam_profile_assignments
+    profiles = dataset.cdata.beam_profiles
+    local_axes = dataset.cdata.local_axes
+    section_offsets = dataset.cdata.section_offsets
+    elements_by_id = dataset.elements_info["dataframe"].set_index(
+        "element_id", drop=False
+    )
+
+    # Eligibility = subset of target with a *LOCAL_AXES entry, so the
+    # vectorized rotation_matrices call doesn't raise.
+    skipped: List[int] = []
+    eligible_ids: List[int] = []
+    for eid in target:
+        if eid not in local_axes:
+            skipped.append(eid)
+            logger.info(
+                "%s: skipping element %d — no *LOCAL_AXES entry",
+                log_label,
+                eid,
+            )
+            continue
+        eligible_ids.append(eid)
+
+    if not eligible_ids:
+        raise ValueError(
+            "All matched elements lacked *LOCAL_AXES entries; nothing to draw."
+        )
+
+    ids_arr, R_batch = dataset.cdata.rotation_matrices(eligible_ids)
+    R_by_id = {int(eid): R for eid, R in zip(ids_arr.tolist(), R_batch)}
+
+    all_vertices: List[np.ndarray] = []
+    all_faces: List[np.ndarray] = []
+    all_edge_segs: List[np.ndarray] = []
+    profile_ids_used: set = set()
+    vertex_offset = 0
+
+    for eid in eligible_ids:
+        # Variable cross-section is deferred — pick the first profile.
+        pid, _weight = assignments[eid][0]
+        profile = profiles.get(int(pid))
+        if profile is None:
+            skipped.append(eid)
+            logger.info(
+                "%s: skipping element %d — profile id %d not in beam_profiles",
+                log_label,
+                eid,
+                pid,
+            )
+            continue
+
+        try:
+            elem_row = elements_by_id.loc[eid]
+        except KeyError:
+            skipped.append(eid)
+            logger.info(
+                "%s: skipping element %d — not in elements_info",
+                log_label,
+                eid,
+            )
+            continue
+
+        node_list = elem_row["node_list"]
+        if len(node_list) != 2:
+            skipped.append(eid)
+            logger.info(
+                "%s: skipping element %d — expected 2-node line element, got %d nodes",
+                log_label,
+                eid,
+                len(node_list),
+            )
+            continue
+        try:
+            n0 = node_coords[int(node_list[0])]
+            n1 = node_coords[int(node_list[1])]
+        except KeyError:
+            skipped.append(eid)
+            logger.info(
+                "%s: skipping element %d — node not in nodes_info",
+                log_label,
+                eid,
+            )
+            continue
+
+        R = R_by_id[eid]
+        offset_xy = section_offsets.get(eid)
+        vertices, faces = extrude_beam_geometry(
+            profile,
+            axis_start=n0,
+            axis_end=n1,
+            R=R,
+            section_offset=offset_xy,
+        )
+        all_vertices.append(vertices)
+        all_faces.append(faces + vertex_offset)
+        if edge_color is not None:
+            n_pts = profile.points.shape[0]
+            end1 = vertices[:n_pts]
+            end2 = vertices[n_pts:]
+            all_edge_segs.append(_structural_edge_segments(profile, end1, end2))
+        vertex_offset += vertices.shape[0]
+        profile_ids_used.add(int(pid))
+
+    if not all_vertices:
+        raise ValueError(
+            "Every matched element was skipped; check the logger output "
+            "for individual reasons (no profile, no local axes, etc.)."
+        )
+
+    combined_vertices = np.vstack(all_vertices)
+    combined_faces = np.vstack(all_faces)
+    polygons = combined_vertices[combined_faces]
+
+    if ax is None:
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+
+    from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+    poly = Poly3DCollection(
+        polygons,
+        facecolors=face_color,
+        edgecolors="none",
+        linewidths=0.0,
+        alpha=alpha,
+    )
+    ax.add_collection3d(poly)
+
+    if edge_color is not None and all_edge_segs:
+        from mpl_toolkits.mplot3d.art3d import Line3DCollection
+
+        edge_array = np.vstack(all_edge_segs)
+        line_coll = Line3DCollection(
+            edge_array,
+            colors=edge_color,
+            linewidths=linewidth,
+            alpha=1.0,
+        )
+        ax.add_collection3d(line_coll)
+
+    from .deformed_shape import _autoscale_axes
+
+    _autoscale_axes(ax, combined_vertices, is_3d=True)
+
+    # Equal-aspect 3D box — see plot_beam_solids docstring for rationale.
+    spans = np.array(
+        [
+            ax.get_xlim3d(),
+            ax.get_ylim3d(),
+            ax.get_zlim3d(),
+        ],
+        dtype=float,
+    )
+    span_lengths = spans[:, 1] - spans[:, 0]
+    if np.all(span_lengths > 0):
+        ax.set_box_aspect(tuple(span_lengths))
+
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel("z")
+    if title is not None:
+        ax.set_title(title)
+
+    if skipped:
+        warnings.warn(
+            f"[{log_label}] Skipped {len(skipped)} elements "
+            f"(see INFO log for details).",
+            RuntimeWarning,
+        )
+
+    meta: Dict[str, Any] = {
+        "element_count": len(all_vertices),
+        "triangle_count": int(combined_faces.shape[0]),
+        "skipped_elements": skipped,
+        "profile_ids": sorted(profile_ids_used),
+        "is_3d": True,
+    }
+    return ax, meta
+
+
 def plot_beam_solids(
     dataset: "MPCODataSet",
     *,
@@ -216,6 +487,10 @@ def plot_beam_solids(
     (section perimeter at both ends + sweep longitudinals; no interior
     triangulation edges) is overlaid via
     :class:`~mpl_toolkits.mplot3d.art3d.Line3DCollection`.
+
+    The renderer auto-sets the 3D box aspect from the data ranges
+    because matplotlib's default unit cube makes beams look squashed
+    when one dimension dominates.
 
     Args:
         dataset: Source :class:`MPCODataSet`.
@@ -258,235 +533,131 @@ def plot_beam_solids(
             assignments at all, or if the filter resolves to zero
             elements with assignments.
     """
-    assignments = dataset.cdata.beam_profile_assignments
-    profiles = dataset.cdata.beam_profiles
-    if not assignments:
-        raise ValueError(
-            "Dataset has no *BEAM_PROFILE_ASSIGNMENT entries in its "
-            ".cdata sidecar — nothing to render."
-        )
-    if not profiles:
-        raise ValueError(
-            "Dataset has no *BEAM_PROFILE entries in its .cdata sidecar — "
-            "assignments reference profile ids that aren't defined."
-        )
-
-    assignment_ids = {int(eid) for eid in assignments.keys()}
-
-    user_filtered = (
-        element_ids is not None
-        or selection_set_id is not None
-        or selection_set_name is not None
+    target = _resolve_target_beam_ids(
+        dataset,
+        element_ids=element_ids,
+        selection_set_id=selection_set_id,
+        selection_set_name=selection_set_name,
     )
-    if user_filtered:
-        resolved = dataset._selection_resolver.resolve_elements(
-            names=selection_set_name,
-            ids=selection_set_id,
-            explicit_ids=element_ids,
-        )
-        target = sorted(assignment_ids & {int(e) for e in resolved})
-    else:
-        target = sorted(assignment_ids)
-
-    if not target:
-        raise ValueError(
-            "No beam elements with profile assignments matched the filter."
-        )
-
-    # Pull every element's end-node coords from the cached dataframe in
-    # one pass; build an eid → (n0_xyz, n1_xyz) lookup so we don't pay
-    # per-element dataframe filtering inside the geometry loop.
-    df_elements = dataset.elements_info["dataframe"]
-    df_nodes = dataset.nodes_info["dataframe"]
-    node_coords = {
-        int(row.node_id): np.array([row.x, row.y, row.z], dtype=float)
-        for row in df_nodes.itertuples(index=False)
-    }
-    elements_by_id = df_elements.set_index("element_id", drop=False)
-
-    # Vectorized rotation lookup. Elements without *LOCAL_AXES are
-    # filtered out before this call so rotation_matrices doesn't raise.
-    local_axes = dataset.cdata.local_axes
-    section_offsets = dataset.cdata.section_offsets
-
-    skipped: List[int] = []
-    eligible_ids: List[int] = []
-    for eid in target:
-        if eid not in local_axes:
-            skipped.append(eid)
-            logger.info(
-                "plot_beam_solids: skipping element %d — no *LOCAL_AXES entry",
-                eid,
-            )
-            continue
-        eligible_ids.append(eid)
-
-    if not eligible_ids:
-        raise ValueError(
-            "All matched elements lacked *LOCAL_AXES entries; nothing to draw."
-        )
-
-    ids_arr, R_batch = dataset.cdata.rotation_matrices(eligible_ids)
-    # ids_arr should align with eligible_ids after the rotation_matrices
-    # call sorts. Re-key R by element id so the geometry loop is clear.
-    R_by_id = {int(eid): R for eid, R in zip(ids_arr.tolist(), R_batch)}
-
-    # Per-element accumulators. Concatenate vertices/faces with running
-    # offsets so the final Poly3DCollection sees one big batch.
-    all_vertices: List[np.ndarray] = []
-    all_faces: List[np.ndarray] = []
-    all_edge_segs: List[np.ndarray] = []
-    profile_ids_used: set = set()
-    vertex_offset = 0
-
-    for eid in eligible_ids:
-        # Resolve profile (first assignment for v1 — variable cross-section
-        # is a future extension).
-        pid, _weight = assignments[eid][0]
-        profile = profiles.get(int(pid))
-        if profile is None:
-            skipped.append(eid)
-            logger.info(
-                "plot_beam_solids: skipping element %d — profile id %d not in beam_profiles",
-                eid,
-                pid,
-            )
-            continue
-
-        try:
-            elem_row = elements_by_id.loc[eid]
-        except KeyError:
-            skipped.append(eid)
-            logger.info(
-                "plot_beam_solids: skipping element %d — not in elements_info",
-                eid,
-            )
-            continue
-
-        node_list = elem_row["node_list"]
-        if len(node_list) != 2:
-            # Beam profile assignments shouldn't exist for non-line
-            # elements, but guard anyway.
-            skipped.append(eid)
-            logger.info(
-                "plot_beam_solids: skipping element %d — expected 2-node line element, got %d nodes",
-                eid,
-                len(node_list),
-            )
-            continue
-        try:
-            n0 = node_coords[int(node_list[0])]
-            n1 = node_coords[int(node_list[1])]
-        except KeyError:
-            skipped.append(eid)
-            logger.info(
-                "plot_beam_solids: skipping element %d — node not in nodes_info",
-                eid,
-            )
-            continue
-
-        R = R_by_id[eid]
-        offset_xy = section_offsets.get(eid)  # may be None
-        vertices, faces = extrude_beam_geometry(
-            profile,
-            axis_start=n0,
-            axis_end=n1,
-            R=R,
-            section_offset=offset_xy,
-        )
-        all_vertices.append(vertices)
-        all_faces.append(faces + vertex_offset)
-        if edge_color is not None:
-            n_pts = profile.points.shape[0]
-            end1 = vertices[:n_pts]
-            end2 = vertices[n_pts:]
-            all_edge_segs.append(_structural_edge_segments(profile, end1, end2))
-        vertex_offset += vertices.shape[0]
-        profile_ids_used.add(int(pid))
-
-    if not all_vertices:
-        raise ValueError(
-            "Every matched element was skipped; check the logger output "
-            "for individual reasons (no profile, no local axes, etc.)."
-        )
-
-    combined_vertices = np.vstack(all_vertices)
-    combined_faces = np.vstack(all_faces)
-    polygons = combined_vertices[combined_faces]  # (n_faces, 3, 3)
-
-    # Axes creation. The output is inherently 3D — caller's `ax` must be
-    # a 3D axes if supplied, otherwise we make one.
-    if ax is None:
-        import matplotlib.pyplot as plt
-
-        fig = plt.figure()
-        ax = fig.add_subplot(111, projection="3d")
-
-    from mpl_toolkits.mplot3d.art3d import Poly3DCollection
-
-    poly = Poly3DCollection(
-        polygons,
-        facecolors=face_color,
-        edgecolors="none",
-        linewidths=0.0,
+    node_coords = _undeformed_node_coords(dataset)
+    return _render_extruded_beams(
+        dataset,
+        target,
+        node_coords,
+        log_label="plot_beam_solids",
+        ax=ax,
+        face_color=face_color,
+        edge_color=edge_color,
+        linewidth=linewidth,
         alpha=alpha,
+        title=title,
     )
-    ax.add_collection3d(poly)
 
-    if edge_color is not None and all_edge_segs:
-        from mpl_toolkits.mplot3d.art3d import Line3DCollection
 
-        edge_array = np.vstack(all_edge_segs)
-        line_coll = Line3DCollection(
-            edge_array,
-            colors=edge_color,
-            linewidths=linewidth,
-            alpha=1.0,
-        )
-        ax.add_collection3d(line_coll)
+def plot_beam_solids_deformed(
+    dataset: "MPCODataSet",
+    *,
+    model_stage: str,
+    step: int,
+    scale: float = 1.0,
+    element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+    selection_set_id: Union[int, Sequence[int], None] = None,
+    selection_set_name: Union[str, Sequence[str], None] = None,
+    ax: Any = None,
+    face_color: Any = "C0",
+    edge_color: Optional[Any] = "0.25",
+    linewidth: float = 0.6,
+    alpha: float = 0.85,
+    title: Optional[str] = None,
+) -> Tuple[Any, Dict[str, Any]]:
+    """Render beam elements as 3D extruded solids at a deformed configuration.
 
-    # Framing from the combined vertex cloud.
-    from .deformed_shape import _autoscale_axes
+    Same pipeline as :func:`plot_beam_solids`, but the end-node
+    coordinates are ``original + scale * displacement_at_step`` instead
+    of the original ``nodes_info`` coordinates. DISPLACEMENT is fetched
+    once (every node, the requested stage and step) and the deformed
+    map is passed through to the shared extrusion + render backbone.
 
-    _autoscale_axes(ax, combined_vertices, is_3d=True)
+    Note that the element-local rotation matrix is taken from the
+    undeformed ``*LOCAL_AXES`` quaternion. Large rotations of slender
+    beams will look slightly off because we are *not* rotating the
+    cross-section with the deformed tangent; STKO doesn't record the
+    deformed local frame and reconstructing it from displacements is
+    out of scope for this release.
 
-    # Equal-aspect 3D box. matplotlib's default 3D axes use a unit cube
-    # regardless of data extents, which makes beams look squashed when
-    # one dimension dominates. ``set_box_aspect`` accepts the post-pad
-    # span tuple so the visual proportions match the data.
-    spans = np.array(
-        [
-            ax.get_xlim3d(),
-            ax.get_ylim3d(),
-            ax.get_zlim3d(),
-        ],
-        dtype=float,
+    Args:
+        dataset: Source :class:`MPCODataSet`.
+        model_stage: Stage name (e.g. ``"MODEL_STAGE[1]"``).
+        step: Step index inside the stage.
+        scale: Displacement amplification. ``1.0`` is true-to-life; for
+            elastic models 50–1000× is typical.
+        element_ids: Optional explicit element IDs (see
+            :func:`plot_beam_solids` for filter semantics).
+        selection_set_id: Optional selection-set ID (or sequence).
+        selection_set_name: Optional selection-set name (or sequence).
+        ax: Existing 3D matplotlib axes. ``None`` creates a new figure.
+        face_color: Polygon fill color.
+        edge_color: Structural-edge color, or ``None`` to disable.
+        linewidth: Width of structural edges.
+        alpha: Polygon alpha.
+        title: Optional axes title.
+
+    Returns:
+        ``(ax, meta)``. ``meta`` carries the same keys as
+        :func:`plot_beam_solids` plus:
+
+        * ``model_stage`` — the stage rendered.
+        * ``step`` — the step rendered.
+        * ``scale`` — the displacement amplification applied.
+
+    Raises:
+        ValueError: if the cdata sidecar is empty, the filter matches
+            nothing, or the requested step is not present in the
+            DISPLACEMENT result for the chosen stage.
+    """
+    from .deformed_shape import _displacement_at_step
+
+    target = _resolve_target_beam_ids(
+        dataset,
+        element_ids=element_ids,
+        selection_set_id=selection_set_id,
+        selection_set_name=selection_set_name,
     )
-    span_lengths = spans[:, 1] - spans[:, 0]
-    if np.all(span_lengths > 0):
-        ax.set_box_aspect(tuple(span_lengths))
-
-    ax.set_xlabel("x")
-    ax.set_ylabel("y")
-    ax.set_zlabel("z")
-    if title is not None:
-        ax.set_title(title)
-
-    if skipped:
-        warnings.warn(
-            f"[plot_beam_solids] Skipped {len(skipped)} elements "
-            f"(see INFO log for details).",
-            RuntimeWarning,
+    original = _undeformed_node_coords(dataset)
+    if scale == 0.0:
+        # Zero scale collapses to the undeformed configuration; skip the
+        # DISPLACEMENT fetch entirely so the function works on datasets
+        # that don't record displacements.
+        deformed = original
+    else:
+        disp = _displacement_at_step(
+            dataset, model_stage=model_stage, step=int(step)
         )
+        deformed = {}
+        for nid, xyz in original.items():
+            d = disp.get(nid)
+            deformed[nid] = xyz + float(scale) * d if d is not None else xyz.copy()
 
-    meta: Dict[str, Any] = {
-        "element_count": len(all_vertices),
-        "triangle_count": int(combined_faces.shape[0]),
-        "skipped_elements": skipped,
-        "profile_ids": sorted(profile_ids_used),
-        "is_3d": True,
-    }
+    ax, meta = _render_extruded_beams(
+        dataset,
+        target,
+        deformed,
+        log_label="plot_beam_solids_deformed",
+        ax=ax,
+        face_color=face_color,
+        edge_color=edge_color,
+        linewidth=linewidth,
+        alpha=alpha,
+        title=title,
+    )
+    meta["model_stage"] = model_stage
+    meta["step"] = int(step)
+    meta["scale"] = float(scale)
     return ax, meta
 
 
-__all__ = ["extrude_beam_geometry", "plot_beam_solids"]
+__all__ = [
+    "extrude_beam_geometry",
+    "plot_beam_solids",
+    "plot_beam_solids_deformed",
+]

--- a/src/STKO_to_python/plotting/plot.py
+++ b/src/STKO_to_python/plotting/plot.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
 import numpy as np
 import matplotlib.pyplot as plt
 
-from .beam_solid import plot_beam_solids
+from .beam_solid import plot_beam_solids, plot_beam_solids_deformed
 from .deformed_shape import plot_deformed_shape, plot_undeformed_shape
 from .mesh import plot_mesh, plot_mesh_with_contour
 
@@ -305,6 +305,62 @@ class Plot:
         """
         return plot_beam_solids(
             self._dataset,
+            element_ids=element_ids,
+            selection_set_id=selection_set_id,
+            selection_set_name=selection_set_name,
+            ax=ax,
+            face_color=face_color,
+            edge_color=edge_color,
+            linewidth=linewidth,
+            alpha=alpha,
+            title=title,
+        )
+
+    def beam_solids_deformed(
+        self,
+        *,
+        model_stage: str,
+        step: int,
+        scale: float = 1.0,
+        element_ids: Union[int, Sequence[int], np.ndarray, None] = None,
+        selection_set_id: Union[int, Sequence[int], None] = None,
+        selection_set_name: Union[str, Sequence[str], None] = None,
+        ax: Any = None,
+        face_color: Any = "C0",
+        edge_color: Optional[Any] = "0.25",
+        linewidth: float = 0.6,
+        alpha: float = 0.85,
+        title: Optional[str] = None,
+    ) -> Tuple[Any, dict]:
+        """Render beam elements as 3D extruded solids at a deformed step.
+
+        Same pipeline as :meth:`beam_solids` with end-node coordinates
+        replaced by ``original + scale * displacement_at_step``. The
+        cross-section's element-local frame is taken from the
+        undeformed ``*LOCAL_AXES`` quaternion (STKO does not record a
+        deformed local frame), so large rotations on slender beams may
+        look slightly off; this is acceptable for visualization but
+        not for downstream geometry consumers.
+
+        See
+        :func:`STKO_to_python.plotting.beam_solid.plot_beam_solids_deformed`
+        for the full parameter list. ``meta`` carries the same keys as
+        :meth:`beam_solids` plus ``model_stage``, ``step``, and
+        ``scale``.
+
+        Examples
+        --------
+        First-mode shape at peak displacement, amplified 200×::
+
+            ax, meta = ds.plot.beam_solids_deformed(
+                model_stage="MODEL_STAGE[1]", step=peak_step, scale=200.0,
+            )
+        """
+        return plot_beam_solids_deformed(
+            self._dataset,
+            model_stage=model_stage,
+            step=step,
+            scale=scale,
             element_ids=element_ids,
             selection_set_id=selection_set_id,
             selection_set_name=selection_set_name,

--- a/tests/integration/test_beam_solids.py
+++ b/tests/integration/test_beam_solids.py
@@ -129,3 +129,127 @@ def test_beam_solids_quad_frame_passthrough_to_user_3d_axes(
         assert ax is user_ax
     finally:
         plt.close("all")
+
+
+# ---------------------------------------------------------------------- #
+# Deformed variant
+# ---------------------------------------------------------------------- #
+def test_beam_solids_deformed_elastic_frame_meta(elastic_frame_dir: Path) -> None:
+    """Same triangle counts as the undeformed render; meta carries
+    the stage/step/scale annotations.
+    """
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.beam_solids_deformed(
+            model_stage="MODEL_STAGE[1]", step=5, scale=100.0,
+        )
+        assert ax is not None
+        assert meta["element_count"] == 3
+        assert meta["triangle_count"] == 3 * (2 * 2 + 2 * 4)
+        assert meta["model_stage"] == "MODEL_STAGE[1]"
+        assert meta["step"] == 5
+        assert meta["scale"] == 100.0
+        assert meta["is_3d"] is True
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_deformed_scale_zero_matches_undeformed(
+    elastic_frame_dir: Path,
+) -> None:
+    """scale=0 must collapse to the undeformed configuration — the
+    DISPLACEMENT fetch is skipped entirely so this also works on
+    datasets that didn't record displacement (covered indirectly here
+    by skipping the fetch path).
+    """
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        ax_und, meta_und = ds.plot.beam_solids()
+        plt.close("all")
+        ax_zero, meta_zero = ds.plot.beam_solids_deformed(
+            model_stage="MODEL_STAGE[1]", step=5, scale=0.0,
+        )
+        # Triangle counts identical; vertex positions identical (the
+        # latter is harder to check without inspecting collections, but
+        # equal triangle counts at the same target ids is the structural
+        # equivalent).
+        assert meta_und["triangle_count"] == meta_zero["triangle_count"]
+        assert meta_und["element_count"] == meta_zero["element_count"]
+        assert meta_zero["scale"] == 0.0
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_deformed_axis_limits_track_scale(
+    elastic_frame_dir: Path,
+    monkeypatch,
+) -> None:
+    """With a known per-node displacement, the deformed render's axis
+    extent must shift by ``scale * displacement`` along the
+    corresponding axis.
+
+    Real fixtures have small displacements relative to the frame size,
+    so we mock ``_displacement_at_step`` to inject a large shift in a
+    single direction. This pins the wiring: the scaled displacement
+    flows from the helper into the renderer's vertex computation.
+    """
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        # Inject a y-direction shift big enough to escape the autoscale
+        # pad (5% of the ~5000 mm span ≈ 250 mm) at scale=1.
+        injected_disp = {
+            int(nid): np.array([0.0, 1000.0, 0.0], dtype=float)
+            for nid in ds.nodes_info["dataframe"]["node_id"]
+        }
+        monkeypatch.setattr(
+            "STKO_to_python.plotting.deformed_shape._displacement_at_step",
+            lambda dataset, *, model_stage, step: injected_disp,
+        )
+
+        scale = 2.0  # 2 * 1000 mm = 2000 mm shift along y
+        ax_und, _ = ds.plot.beam_solids()
+        und_y_center = sum(ax_und.get_ylim3d()) / 2.0
+        plt.close("all")
+
+        ax_def, _ = ds.plot.beam_solids_deformed(
+            model_stage="MODEL_STAGE[1]", step=5, scale=scale,
+        )
+        def_y_center = sum(ax_def.get_ylim3d()) / 2.0
+
+        # Every node shifted by (0, 1000, 0), so the data centroid in y
+        # shifts by scale * 1000. The axis y-center should mirror that.
+        np.testing.assert_allclose(
+            def_y_center - und_y_center,
+            scale * 1000.0,
+            rtol=0.05,  # autoscale pad slack
+        )
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_deformed_invalid_step_raises(
+    elastic_frame_dir: Path,
+) -> None:
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        with pytest.raises(ValueError, match="step="):
+            ds.plot.beam_solids_deformed(
+                model_stage="MODEL_STAGE[1]", step=99999, scale=1.0,
+            )
+    finally:
+        plt.close("all")
+
+
+def test_beam_solids_deformed_quad_frame_only_beams(
+    quad_frame_dir: Path,
+) -> None:
+    """Shells must still be filtered out in the deformed render."""
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.beam_solids_deformed(
+            model_stage="MODEL_STAGE[1]", step=2, scale=50.0,
+        )
+        assert meta["element_count"] == 75
+        assert meta["triangle_count"] == 75 * (2 * 2 + 2 * 4)
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary

Final PR in the 3D beam visualization arc (after [#69](https://github.com/nmorabowen/STKO_to_python/pull/69) and [#70](https://github.com/nmorabowen/STKO_to_python/pull/70)).

- **`ds.plot.beam_solids_deformed(model_stage, step, scale=1.0, ...)`** — deformed twin of `ds.plot.beam_solids`. Fetches `DISPLACEMENT` at the requested step, shifts every end node by `scale * disp`, and feeds the displaced coordinates through the same extrusion pipeline. `meta` carries `model_stage`, `step`, and `scale` on top of the standard keys. `scale=0` collapses to the undeformed configuration without fetching displacements (useful for code paths that toggle the mode behind a flag).
- Refactor: extracted `_resolve_target_beam_ids` and `_render_extruded_beams` shared helpers from `plot_beam_solids`. The undeformed and deformed public functions now both build their `node_coords` mapping and delegate; downstream pipeline (eligibility filter, vectorized rotation lookup, per-element extrusion, `Poly3DCollection` + `Line3DCollection` assembly, autoscale + box-aspect) is shared.
- **Caveat documented in the docstring and cookbook**: the cross-section's element-local frame uses the undeformed `*LOCAL_AXES` quaternion. STKO does not record a deformed local frame, so translations are exact but large rotations on slender members can show a slightly off section orientation. Acceptable for visualization; not recommended for downstream geometry consumers.

Cookbook recipe 09 gains a new section "Render the deformed configuration" covering scale selection (elastic frames need 100–2000× to be visible) and the undeformed-local-frame caveat.

MINOR-level change per [CLAUDE.md versioning policy](CLAUDE.md#versioning-policy) — new public API on the plot facade.

## Visual sanity check

`elasticFrame_mesh_results` deformed at `MODEL_STAGE[2]` step 9, scale=2000 — columns visibly bend at the top, beam sags slightly under lateral load:

![deformed beams](https://github.com/user-attachments/placeholder.png)

(PNG generated locally; matplotlib backend `Agg`; not committed.)

## Test plan

- [x] `pytest tests/` — **822 passed, 34 fixture-skipped** (was 817 + 5 new deformed tests).
- [x] `mkdocs build --strict` — clean.
- [x] New regression tests in [tests/integration/test_beam_solids.py](tests/integration/test_beam_solids.py):
  - `test_beam_solids_deformed_elastic_frame_meta` — meta carries `model_stage` / `step` / `scale`; triangle count matches the undeformed render.
  - `test_beam_solids_deformed_scale_zero_matches_undeformed` — `scale=0` produces the same shape as `beam_solids()`.
  - `test_beam_solids_deformed_axis_limits_track_scale` — monkeypatches `_displacement_at_step` to inject a known 1000-mm y-shift; verifies the rendered axis y-center moves by `scale * 1000` (proves the scaled displacement actually flows into the rendered vertices, independent of the fixture's real displacement magnitude).
  - `test_beam_solids_deformed_invalid_step_raises` — bad step → `ValueError("step=...")`.
  - `test_beam_solids_deformed_quad_frame_only_beams` — shells still filtered out in the deformed render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)