### PR TITLE
Document MPCODataSet context-manager support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ## [Unreleased]
 
+### Documentation
+
+- `docs/MPCODataSet.md` gains a "Resource management" section showing
+  the `with MPCODataSet(...) as ds:` pattern, when it's worth reaching
+  for, and how `ds.clear_result_caches()` fits as a finer-grained
+  alternative. The context-manager feature already existed (since the
+  partition-pool work in v1.4.x) but wasn't surfaced anywhere users
+  would notice it.
+- `examples/usage_tour.py` gains a new section 15 demonstrating the
+  context-manager form end-to-end with cache-clearing observable
+  through `_nodal_query_engine.cached_result_count` before and after
+  `__exit__`. Runs against the elasticFrame fixture; no behavior
+  change.
+- `__enter__` / `__exit__` docstrings on `MPCODataSet` updated to
+  describe what they do today (close pool + drop engine caches)
+  instead of the historical "Phase 0 stub" placeholder. Class-level
+  context-manager-support paragraph rewritten accordingly.
+
 ### Added (internal)
 
 - `bench/test_construction_bench.py` — three new pytest-benchmark

--- a/docs/MPCODataSet.md
+++ b/docs/MPCODataSet.md
@@ -267,6 +267,58 @@ nr = ds.nodes.get_nodal_results(
 
 Name resolution is case-insensitive. If a name is ambiguous (matches multiple IDs), an error is raised suggesting you use the ID instead.
 
+## Resource management
+
+`MPCODataSet` supports the `with` statement. `__enter__` returns the
+dataset; `__exit__` closes every pooled HDF5 handle and drops the
+nodal / element query-engine LRU caches. Existing code that does not
+use `with` keeps working unchanged — the constructor still opens
+files lazily through the partition pool — but the explicit form is
+useful when you need a deterministic teardown.
+
+```python
+from STKO_to_python import MPCODataSet
+
+with MPCODataSet(r"C:\results\building", "mpco", name="Building") as ds:
+    nr = ds.nodes.get_nodal_results(
+        results_name="DISPLACEMENT",
+        selection_set_name="ControlPoints",
+    )
+    nr.save_pickle("disp.pkl")
+# ds is now closed: partition handles released, engine caches cleared.
+```
+
+When to reach for `with`:
+
+- **Batch scripts that open many datasets in sequence.** Each `ds` is
+  scoped to its iteration; HDF5 handles aren't kept open across the
+  whole run.
+- **Pipelines that hand off the .mpco files to another process.**
+  Closing the partition pool before that process rewrites the file
+  avoids reading a stale view on the next open.
+- **Memory-tight environments.** The query-engine LRU keeps up to 32
+  result frames per engine; releasing them at scope exit reclaims
+  memory promptly.
+
+For finer-grained control without tearing down the dataset, call
+`ds.clear_result_caches()` directly — it drops only the engine
+caches, leaving the partition pool open for the next query:
+
+```python
+ds = MPCODataSet(r"C:\results\building", "mpco")
+nr = ds.nodes.get_nodal_results(...)
+# ... heavy aggregation work ...
+ds.clear_result_caches()   # free the cached DataFrames
+# ... continue using ds ...
+```
+
+Long-lived notebook sessions typically don't need `with` — the
+process exits eventually and the OS reclaims everything. The
+performance bench shows that opening + closing the partition pool
+costs a few ms per partition, so wrapping every cell in `with` would
+add overhead with no benefit. Use it where the resource-management
+semantics matter.
+
 ## Notes
 
 - The dataset uses a composition pattern: `ds.nodes`, `ds.elements`, `ds.model_info`, `ds.cdata`, `ds.plot`, and `ds.info` are internal components. The public API is through `ds.nodes.get_nodal_results()` and `ds.elements.get_element_results()`.

--- a/examples/usage_tour.py
+++ b/examples/usage_tour.py
@@ -21,6 +21,7 @@ Covers:
    12. Integration-point extraction (at_ip, gp_xi, physical_x).
    13. Dataset introspection print helpers.
    14. Element result discovery workflow (full pattern).
+   15. The ``with MPCODataSet(...) as ds:`` context-manager form.
 
 Run with::
 
@@ -337,6 +338,40 @@ def section_14_print_helpers(ds: MPCODataSet) -> None:
     print("ds.print_selection_set_info()   -> named selection sets from .cdata")
 
 
+def section_15_context_manager(dataset_dir: Path, recorder: str) -> None:
+    """Demonstrate the ``with MPCODataSet(...) as ds:`` form.
+
+    Closes pooled HDF5 handles and drops the query-engine LRU caches
+    deterministically at scope exit. Useful for batch scripts that
+    open many datasets in sequence, or when another process is about
+    to rewrite the .mpco files.
+    """
+    section("15. Context-manager form (with MPCODataSet(...) as ds:)")
+
+    with MPCODataSet(str(dataset_dir), recorder, verbose=False) as ds:
+        # Inside the with-block, ds behaves identically to a bare
+        # MPCODataSet — same attributes, same methods.
+        nr = ds.nodes.get_nodal_results(
+            results_name="DISPLACEMENT",
+            model_stage=ds.model_stages[0],
+            node_ids=ds.nodes_info["dataframe"]["node_id"].head(2).tolist(),
+        )
+        print(f"inside `with`: fetched {nr.df.shape[0]} rows")
+        # The engine has one cached result now; __exit__ will clear it.
+        print(
+            "engine cache before exit: "
+            f"{ds._nodal_query_engine.cached_result_count} entry"
+        )
+
+    # __exit__ has run by this point: pool handles closed, LRU dropped.
+    print(
+        "engine cache after exit:  "
+        f"{ds._nodal_query_engine.cached_result_count} entries"
+    )
+    print("ds is still usable (re-opens partitions on next fetch), but")
+    print("the deterministic teardown is the point of the `with` form.")
+
+
 # ---------------------------------------------------------------------- #
 # Entry point
 # ---------------------------------------------------------------------- #
@@ -358,6 +393,7 @@ def run(dataset_dir: Path, recorder: str) -> None:
     section_12_canonical_names(ds)
     section_13_integration_points(ds)
     section_14_print_helpers(ds)
+    section_15_context_manager(dataset_dir, recorder)
 
     print()
     print("Tour complete.")

--- a/src/STKO_to_python/core/dataset.py
+++ b/src/STKO_to_python/core/dataset.py
@@ -57,9 +57,13 @@ class MPCODataSet:
     Context-manager support
     -----------------------
     ``MPCODataSet`` supports the ``with`` statement. ``__enter__`` returns
-    the dataset; ``__exit__`` is a no-op today but will close pooled HDF5
-    handles once the partition pool lands in Phase 1 of the refactor.
-    Existing code that does not use ``with`` keeps working unchanged.
+    the dataset; ``__exit__`` closes every pooled HDF5 handle via
+    :meth:`Hdf5PartitionPool.close_all` and drops the nodal / element
+    query-engine LRU caches. Use ``with`` for scripts that open many
+    datasets in sequence or that need a deterministic teardown before
+    another process rewrites the ``.mpco`` files. Notebooks that hold a
+    long-lived dataset can keep using the bare-constructor form;
+    existing code that does not use ``with`` keeps working unchanged.
 
     Upon initialization, this class automatically loads directory information,
     extracts partitions, model stages, results names, and other essential dataset
@@ -399,19 +403,27 @@ class MPCODataSet:
     def __enter__(self) -> "MPCODataSet":
         """Enter the runtime context; returns ``self``.
 
-        Phase 0 stub: no resources are held yet. When the partition pool
-        lands in Phase 1, ``__exit__`` will close pooled HDF5 handles.
+        Pairs with :meth:`__exit__` so that ``with MPCODataSet(...) as
+        ds:`` deterministically closes pooled HDF5 handles and drops
+        cached results at scope exit. Notebooks that hold a long-lived
+        dataset can keep using the bare-constructor form; the context
+        manager is most useful in scripts that open many datasets in
+        sequence or that need a clean teardown before another process
+        rewrites the ``.mpco`` files.
         """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Exit the runtime context.
 
-        Closes every handle held by the partition pool. Safe to call
-        even when ``pool_size=0`` (the legacy default) — the pool holds
-        no handles in that configuration, so ``close_all()`` is a no-op.
-        Returning ``None`` (implicitly) means exceptions raised inside
-        the ``with`` block propagate unchanged.
+        Closes every handle held by the partition pool and drops the
+        nodal / element query-engine LRU caches (which may hold
+        DataFrames keyed on HDF5 reads that are now stale). Safe to
+        call even when ``pool_size=0`` (the open-per-query mode) —
+        the pool holds no handles in that configuration, so
+        ``close_all()`` is a no-op. Returning ``None`` (implicitly)
+        means exceptions raised inside the ``with`` block propagate
+        unchanged.
         """
         pool = getattr(self, "_pool", None)
         if pool is not None:


### PR DESCRIPTION
## Summary

The `with MPCODataSet(...) as ds:` form has been working since the partition-pool refactor landed (v1.4.x), but it wasn't surfaced anywhere users would notice. Closes the §6 still-open "context-manager adoption" item from [docs/architecture-refactor-proposal.md](docs/architecture-refactor-proposal.md#still-open).

- **[docs/MPCODataSet.md](docs/MPCODataSet.md)** — new "Resource management" section covers the pattern, when it's worth reaching for (batch scripts, pipelines that hand .mpco files to other processes, memory-tight envs), and how `ds.clear_result_caches()` fits as a finer-grained alternative that leaves the partition pool open.
- **[examples/usage_tour.py](examples/usage_tour.py)** — new section 15 demonstrates the context-manager form end-to-end, with the cache-clearing behavior visibly verified by reading `_nodal_query_engine.cached_result_count` before and after `__exit__`.
- **[src/STKO_to_python/core/dataset.py](src/STKO_to_python/core/dataset.py)** — `__enter__` / `__exit__` docstrings updated to describe what they do today (close pool + drop engine caches) instead of the historical "Phase 0 stub" placeholder. Class-level context-manager-support paragraph rewritten accordingly.

No code-path changes. PATCH-level per [CLAUDE.md versioning policy](CLAUDE.md#versioning-policy) — docs + docstring polish.

## Test plan

- [x] `pytest tests/` — **822 passed, 34 fixture-skipped** (unchanged).
- [x] `mkdocs build --strict` — clean.
- [x] `python examples/usage_tour.py` runs cleanly through section 15 and reports `engine cache before exit: 1 entry / after exit: 0 entries` — confirms the `__exit__` cache-clearing behavior the docs describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)