### PR TITLE
Add shell section-cut kernel and bounding-polygon support — v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,96 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-05-12
+
+Extends the v1.5.0 section-cut subpackage with the **shell kernel**
+and an optional **bounding polygon** on the cut plane. Section cuts
+through models that mix beams and shells now produce a single
+combined resultant; cuts through analyses where the recorded
+selection sets don't pre-filter to a structural sub-region can be
+narrowed via a convex polygon on the cut plane.
+
+### Added
+
+- **Shell section-cut kernel** — `compute_shell_cut` integrates
+  `section.force` (8 components per IP — `Fxx, Fyy, Fxy, Mxx, Myy,
+  Mxy, Vxz, Vyz`) along the chord at which the cut plane crosses
+  each shell midsurface. 2-point Gauss-Legendre line quadrature
+  along the chord, bilinear sampling between IPs for `ASDShellQ4`,
+  linear sampling for `ASDShellT3`. Rotates element-local traction
+  to global via `cdata.rotation_matrix(eid)`. Layered-shell
+  variants are transparent (`section.force` is already through-
+  thickness-integrated regardless of layer count).
+- **Shared-edge resolution** — when a cut plane lands exactly on
+  the shared edge between two adjacent shells, `find_shell_intersections`
+  applies a side-aware geometric filter: only the shell whose interior
+  lies on the **discarded** side contributes. Avoids the double-count
+  that the naive geometry pipeline produced on cuts at mesh-row
+  elevations (verified on Test_NLShell's z=870 T3/Q4 interface).
+- **Bounding polygon on the cut plane** — `SectionCutSpec` gains an
+  optional `bounding_polygon=` field, a convex polygon on the cut
+  plane restricting the cut to elements whose intersection falls
+  inside it. Validation at construction rejects off-plane vertices,
+  degenerate polygons, fewer than three vertices, and non-convex
+  shapes. Threaded through `MPCODataSet.section_cut(...,
+  bounding_polygon=...)`.
+- **`SectionCut.compute` composition** — runs the beam and shell
+  kernels in one pass, shares a `PolygonClipper` so the plane basis
+  isn't recomputed, and aggregates `(F, M)` about a mixed centroid
+  (mean of beam intersection points and shell chord midpoints). New
+  `shell_intersections`, `per_shell_F`, `per_shell_M_at_midpoint`
+  fields on the result; `contributing_element_ids` walks both
+  kernels.
+
+### Added (internal)
+
+- `STKO_to_python.cuts.geometry` — plane-basis projection,
+  shoelace-signed-area, inward-edge-normal computation, Cyrus-Beck
+  segment clipping, point-in-polygon test, and `PolygonClipper` (a
+  pre-built struct of plane basis + 2-D polygon for reuse across
+  the kernels). All testable without an `.mpco` fixture.
+- `STKO_to_python.cuts.kernels.shell` — `SHELL_ELEMENT_CLASSES`
+  registry, `ShellIntersection` record, `find_shell_intersections`,
+  `compute_shell_cut`, `ShellCutResult`. Internal helpers cover
+  bilinear quad-IP / linear tri-IP sampling, inverse shape-function
+  maps for ASDShellQ4 (Newton on a planar 2-D embedding) and
+  ASDShellT3, midsurface-normal computation, and cut-normal
+  orientation that resolves both normal cuts and edge-coincident
+  cuts.
+
+### Test coverage
+
+- `tests/unit/cuts/test_geometry.py` — 30 tests for plane-basis
+  orthonormality, batch projection, signed-area and convexity
+  predicates, inward-edge-normal orientation (CCW + CW), point-in-
+  polygon with edge / vertex / exterior cases, and Cyrus-Beck
+  clipping covering segment-through-polygon, fully-inside, fully-
+  outside, starting-inside, parallel-to-edge, and grazing-edge
+  geometries. End-to-end `PolygonClipper` smoke on horizontal and
+  oblique planes.
+- `tests/unit/cuts/test_shell_kernel.py` — 29 tests split into
+  pure-math (bilinear/linear sampling weight identities, inverse
+  shape-function helpers, `_sample_shell_section_force` recovers
+  IP values at the IP coords) and real-fixture
+  (`Test_NLShell`) groups. Real-fixture coverage exercises the
+  registry, the geometry phase, end-to-end consistency (`Newton's
+  3rd law` residual = 0 at z=2500 across all three model stages),
+  side-flip equivalence, and the shared-edge side-aware filter at
+  z=870 (positive matches just-below T3, negative matches just-
+  above Q4, no double-count).
+- `tests/unit/cuts/test_bounding_polygon.py` — 10 integration
+  tests: half-plate beam cut returns half the gravity force
+  (5000 → 2500 against the `elasticFrame_mesh_displacementBased`
+  fixture), shell chord clipping at the polygon boundary on
+  `Test_NLShell`, empty-polygon edge cases, the `ds.section_cut(...,
+  bounding_polygon=...)` inline form, and the rejection rule that
+  bans mixing `spec=` with inline kwargs.
+- `tests/unit/cuts/test_specs.py` gains 11 tests covering the
+  `bounding_polygon` validation contract (≥3 vertices, on-plane
+  within tol, non-degenerate area, convex), `ndarray` coercion,
+  CW polygon acceptance, hash / equality semantics, and pickle
+  round-trip.
+
 ### Documentation
 
 - `docs/MPCODataSet.md` gains a "Resource management" section showing
@@ -30,7 +120,7 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
   instead of the historical "Phase 0 stub" placeholder. Class-level
   context-manager-support paragraph rewritten accordingly.
 
-### Added (internal)
+### Added (internal — bench)
 
 - `bench/test_construction_bench.py` — three new pytest-benchmark
   cases isolating `MPCODataSet.__init__` from the first fetch:
@@ -44,6 +134,17 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
   per-partition incremental cost (~3 ms) is now a recorded data
   point so future refactors that change construction can be
   evaluated against a known reference.
+
+### Out of scope (v2.0 candidates)
+
+- Solid (continuum) section-cut kernel — surface integration over
+  the polygon clipped from each crossing element's volume.
+- Non-convex `bounding_polygon` — would need general clipping
+  (Sutherland-Hodgman) instead of the convex-only Cyrus-Beck.
+- Bounding half-spaces (combine multiple planes) as an alternative
+  to a polygon.
+- Per-layer / per-fiber breakdown of shell cuts via
+  `material.fiber.stress`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "STKO_to_python"
-version = "1.5.0"
+version = "1.6.0"
 description = "STKO tools for Python"
 readme = "README.md"
 authors = [

--- a/src/STKO_to_python/core/dataset.py
+++ b/src/STKO_to_python/core/dataset.py
@@ -304,6 +304,7 @@ class MPCODataSet:
         side: str = "positive",
         label=None,
         name=None,
+        bounding_polygon=None,
     ):
         """Compute a section cut against this dataset.
 
@@ -315,6 +316,12 @@ class MPCODataSet:
           :class:`~STKO_to_python.cuts.SectionCutSpec` via ``spec``.
           ``plane`` and the filter kwargs must be omitted in that case.
 
+        ``bounding_polygon`` (inline form only) is an optional convex
+        polygon on the cut plane that restricts the cut to the region
+        inside it — handy when the recorded selection sets don't
+        pre-filter to a structural sub-region. See
+        :class:`SectionCutSpec` for the validation rules.
+
         Returns a :class:`~STKO_to_python.cuts.SectionCut` carrying the
         ``(F, M)`` resultant time series, intersection records, and the
         validator methods (:meth:`SectionCut.consistency_check`,
@@ -324,14 +331,25 @@ class MPCODataSet:
         from ..cuts.specs import SectionCutSpec
 
         if spec is not None:
-            if any(
-                v is not None
-                for v in (plane, selection_set_name, selection_set_id, element_ids, label, name)
-            ) or side != "positive":
+            if (
+                any(
+                    v is not None
+                    for v in (
+                        plane,
+                        selection_set_name,
+                        selection_set_id,
+                        element_ids,
+                        label,
+                        name,
+                        bounding_polygon,
+                    )
+                )
+                or side != "positive"
+            ):
                 raise ValueError(
                     "When 'spec' is provided, pass it alone — the inline "
-                    "kwargs (plane/selection_set_*/element_ids/side/label/name) "
-                    "must be omitted."
+                    "kwargs (plane/selection_set_*/element_ids/side/label/"
+                    "name/bounding_polygon) must be omitted."
                 )
             if not isinstance(spec, SectionCutSpec):
                 raise TypeError(
@@ -351,6 +369,7 @@ class MPCODataSet:
             side=side,
             label=label,
             name=name,
+            bounding_polygon=bounding_polygon,
         )
         return SectionCut.compute(new_spec, self, model_stage=model_stage)
 
@@ -373,7 +392,9 @@ class MPCODataSet:
         :meth:`SectionSweep.envelope` and a ``.plot`` namespace for
         profiles and heatmaps.
 
-        For per-plane filters, build the specs yourself and use
+        For per-plane filters or per-plane ``bounding_polygon``s (the
+        polygon must lie on each plane, so it's spec-bound rather than
+        sweep-bound), build the specs yourself and pass them to
         :meth:`SectionSweep.from_specs`.
         """
         from ..cuts.sweep import SectionSweep

--- a/src/STKO_to_python/cuts/geometry.py
+++ b/src/STKO_to_python/cuts/geometry.py
@@ -1,0 +1,332 @@
+"""Plane-coplanar 2D geometry helpers for bounding-polygon clipping.
+
+A :class:`~.specs.SectionCutSpec` may carry an optional
+``bounding_polygon`` — a convex polygon lying on the cut plane that
+restricts the cut to the region inside the polygon. The clipping math
+is most cleanly expressed in 2D, so this module:
+
+- builds an orthonormal basis on the plane,
+- projects coplanar 3-D points to 2-D plane coordinates,
+- clips a segment against a convex polygon (Cyrus-Beck), and
+- tests whether a point lies inside a convex polygon.
+
+The helpers are internal — they're called by the kernels through
+:func:`prepare_clipper`, which packages the plane basis + 2-D polygon
+into a small struct so we don't recompute the projection for every
+beam / shell intersection.
+
+Convex-polygon assumption
+-------------------------
+``bounding_polygon`` is validated as convex at :class:`SectionCutSpec`
+construction. The clipper here exploits that: each polygon edge defines
+a half-plane and the polygon is the intersection of all of them, so a
+segment-vs-polygon clip reduces to two scalar parameter bounds (Cyrus-
+Beck). Non-convex polygons would need general line-clipping (e.g.
+Sutherland-Hodgman) and are out of scope for v1.6.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .plane import Plane
+
+
+_TOL_DEFAULT = 1e-9
+
+
+# ---------------------------------------------------------------------- #
+# Plane basis + projection
+# ---------------------------------------------------------------------- #
+def _plane_basis(plane: "Plane") -> tuple[np.ndarray, np.ndarray]:
+    """Return an orthonormal in-plane basis ``(e1, e2)`` for ``plane``.
+
+    ``e1`` is picked deterministically from the global axis least
+    parallel to the plane normal (so the basis is repeatable for a
+    given plane). ``e2 = normal × e1`` so ``(e1, e2, normal)`` forms a
+    right-handed frame.
+    """
+    n = plane.normal_arr
+    # Pick the global axis with smallest |component along n|; that axis
+    # is the "most perpendicular" to the normal and yields a numerically
+    # stable cross product.
+    a = np.eye(3)[int(np.argmin(np.abs(n)))]
+    e1 = np.cross(n, a)
+    e1 /= np.linalg.norm(e1)
+    e2 = np.cross(n, e1)
+    # Normalise defensively; n is already unit but cross with a unit
+    # vector might pick up roundoff.
+    e2 /= np.linalg.norm(e2)
+    return e1, e2
+
+
+def _project_to_plane_basis(
+    points_3d: np.ndarray,
+    plane: "Plane",
+    *,
+    basis: tuple[np.ndarray, np.ndarray] | None = None,
+) -> np.ndarray:
+    """Project ``points_3d`` onto the plane's 2-D basis.
+
+    Parameters
+    ----------
+    points_3d : ``(N, 3)`` or ``(3,)`` array
+        Points assumed to lie on (or very near) ``plane``.
+    plane : :class:`Plane`
+        The reference plane.
+    basis : optional pre-computed ``(e1, e2)``
+        Pass the result of :func:`_plane_basis` when projecting many
+        batches against the same plane to avoid recomputation.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(N, 2)`` or ``(2,)``. The plane's anchor point projects
+        to the origin of the 2-D frame.
+    """
+    pts = np.asarray(points_3d, dtype=float)
+    scalar = pts.ndim == 1
+    if scalar:
+        pts = pts[None, :]
+    if pts.ndim != 2 or pts.shape[1] != 3:
+        raise ValueError(
+            f"points must be shape (3,) or (N, 3), got {pts.shape}."
+        )
+    e1, e2 = basis if basis is not None else _plane_basis(plane)
+    rel = pts - plane.point_arr
+    u = rel @ e1
+    v = rel @ e2
+    out = np.stack([u, v], axis=1)
+    return out[0] if scalar else out
+
+
+# ---------------------------------------------------------------------- #
+# Polygon utilities
+# ---------------------------------------------------------------------- #
+def _polygon_signed_area_2d(polygon_2d: np.ndarray) -> float:
+    """Signed area of a 2-D polygon via the shoelace formula.
+
+    Positive when vertices are CCW, negative when CW. Used to:
+
+    - detect degenerate polygons (zero area),
+    - normalise edge orientation in :func:`_polygon_edge_normals` so
+      every "inward" normal points consistently inward.
+    """
+    x = polygon_2d[:, 0]
+    y = polygon_2d[:, 1]
+    return 0.5 * float(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+
+
+def _polygon_edge_normals(polygon_2d: np.ndarray) -> np.ndarray:
+    """Return the inward unit normal of each edge of a 2-D convex polygon.
+
+    For a CCW polygon (signed area > 0), the inside lies to the LEFT of
+    each edge's walking direction; left-perpendicular ``(-dy, dx)`` of
+    edge ``v_i → v_{i+1}`` is the inward normal. For CW (signed area
+    < 0) it's the opposite (right-perpendicular). Edge ``i`` connects
+    ``polygon_2d[i]`` to ``polygon_2d[(i+1) % n]``; the returned normal
+    is at the same index.
+    """
+    edges = np.roll(polygon_2d, -1, axis=0) - polygon_2d  # (n, 2)
+    # Left-perpendicular = (-dy, dx); rotates the walking direction 90°
+    # counter-clockwise. For a CCW polygon, that's the inward direction.
+    left_perp = np.stack([-edges[:, 1], edges[:, 0]], axis=1)
+    norms = np.linalg.norm(left_perp, axis=1, keepdims=True)
+    # Avoid divide-by-zero for zero-length edges; the polygon validation
+    # already rejects those, so this is just defensive.
+    norms = np.where(norms < 1e-300, 1.0, norms)
+    inward = left_perp / norms
+    # If the polygon is CW (negative signed area), the left-perpendicular
+    # points outward — flip.
+    if _polygon_signed_area_2d(polygon_2d) < 0:
+        inward = -inward
+    return inward
+
+
+def _clip_point_inside_2d(
+    point_2d: np.ndarray,
+    polygon_2d: np.ndarray,
+    *,
+    tol: float = _TOL_DEFAULT,
+) -> bool:
+    """Is ``point_2d`` inside the convex polygon (within ``tol``)?
+
+    Uses the half-plane test: the point is inside iff its signed
+    distance from every inward-oriented edge is ``>= -tol``. A point
+    exactly on an edge counts as inside.
+    """
+    normals = _polygon_edge_normals(polygon_2d)  # (n, 2)
+    rel = point_2d[None, :] - polygon_2d        # (n, 2)
+    # Signed distance from each edge: rel · inward_normal.
+    d = np.einsum("ij,ij->i", rel, normals)
+    return bool(np.all(d >= -tol))
+
+
+def _clip_segment_against_convex_polygon_2d(
+    p0: np.ndarray,
+    p1: np.ndarray,
+    polygon_2d: np.ndarray,
+    *,
+    tol: float = _TOL_DEFAULT,
+) -> tuple[np.ndarray, np.ndarray, float, float] | None:
+    """Cyrus-Beck clip of segment ``p0 → p1`` against a convex polygon.
+
+    Parameters
+    ----------
+    p0, p1 : ``(2,)`` arrays
+        Segment endpoints in plane-2D coords.
+    polygon_2d : ``(M, 2)`` array
+        Convex polygon vertices in plane-2D coords.
+
+    Returns
+    -------
+    (q0, q1, t0, t1) or None
+        Clipped endpoints and the parameter interval
+        ``q = p0 + t * (p1 - p0)``. ``None`` if the segment misses
+        the polygon entirely.
+
+    Algorithm
+    ---------
+    For each polygon edge with inward normal ``n_e`` and a point
+    ``v_e`` on it, define ``f(t) = n_e · (p_t - v_e)`` where
+    ``p_t = p0 + t * (p1 - p0)``. ``f(t) >= 0`` means ``p_t`` is on
+    the inside half-plane of that edge. The segment is inside the
+    polygon iff every edge's ``f(t) >= 0``; intersect those intervals
+    in ``t`` to find the clipped sub-segment.
+    """
+    direction = p1 - p0
+    normals = _polygon_edge_normals(polygon_2d)
+    t_enter = 0.0
+    t_exit = 1.0
+    n_edges = polygon_2d.shape[0]
+    for i in range(n_edges):
+        n_e = normals[i]
+        v_e = polygon_2d[i]
+        # f(t) = n · (p0 - v) + t * (n · direction)
+        c = float(np.dot(n_e, p0 - v_e))
+        d = float(np.dot(n_e, direction))
+        if abs(d) < tol:
+            # Segment is parallel to this edge. If currently outside
+            # this half-plane, the segment never enters.
+            if c < -tol:
+                return None
+            continue
+        t_cross = -c / d
+        if d > 0:
+            # f increases with t → entering this half-plane at t_cross.
+            if t_cross > t_enter:
+                t_enter = t_cross
+        else:
+            # f decreases with t → leaving this half-plane at t_cross.
+            if t_cross < t_exit:
+                t_exit = t_cross
+        if t_enter > t_exit + tol:
+            return None
+    if t_exit - t_enter <= tol:
+        return None
+    q0 = p0 + t_enter * direction
+    q1 = p0 + t_exit * direction
+    return q0, q1, t_enter, t_exit
+
+
+# ---------------------------------------------------------------------- #
+# Public packaging used by kernels
+# ---------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class PolygonClipper:
+    """Pre-computed plane basis + 2-D polygon, reused across many cuts.
+
+    Built once per :class:`SectionCutSpec` by :func:`prepare_clipper`
+    and consumed by the beam and shell kernels.
+    """
+    plane: "Plane"
+    e1: np.ndarray  # (3,) in-plane axis 1
+    e2: np.ndarray  # (3,) in-plane axis 2
+    polygon_2d: np.ndarray  # (M, 2)
+
+    def point_inside(self, point_3d: np.ndarray, *, tol: float = _TOL_DEFAULT) -> bool:
+        """Whether a coplanar 3-D point lies inside the polygon."""
+        p2 = _project_to_plane_basis(point_3d, self.plane, basis=(self.e1, self.e2))
+        return _clip_point_inside_2d(p2, self.polygon_2d, tol=tol)
+
+    def clip_segment(
+        self,
+        p0_3d: np.ndarray,
+        p1_3d: np.ndarray,
+        *,
+        tol: float = _TOL_DEFAULT,
+    ) -> tuple[np.ndarray, np.ndarray, float, float] | None:
+        """Clip a coplanar 3-D segment against the polygon.
+
+        Returns
+        -------
+        (q0_3d, q1_3d, t_enter, t_exit) or None
+            Clipped endpoints in 3-D (re-embedded into the plane) and
+            the parameter interval ``q = p0 + t * (p1 - p0)``. ``None``
+            if the segment misses the polygon.
+        """
+        p0_2d = _project_to_plane_basis(p0_3d, self.plane, basis=(self.e1, self.e2))
+        p1_2d = _project_to_plane_basis(p1_3d, self.plane, basis=(self.e1, self.e2))
+        clipped = _clip_segment_against_convex_polygon_2d(
+            p0_2d, p1_2d, self.polygon_2d, tol=tol
+        )
+        if clipped is None:
+            return None
+        _, _, t_enter, t_exit = clipped
+        # Re-embed into 3-D from the original 3-D endpoints (don't
+        # round-trip through 2-D coords — that would accumulate
+        # projection error).
+        direction = np.asarray(p1_3d, dtype=float) - np.asarray(p0_3d, dtype=float)
+        q0_3d = np.asarray(p0_3d, dtype=float) + t_enter * direction
+        q1_3d = np.asarray(p0_3d, dtype=float) + t_exit * direction
+        return q0_3d, q1_3d, t_enter, t_exit
+
+
+def prepare_clipper(plane: "Plane", polygon_3d: Sequence[Sequence[float]]) -> PolygonClipper:
+    """Build a :class:`PolygonClipper` for a (plane, polygon) pair.
+
+    The polygon's vertices must already lie on the plane — validated
+    on :class:`SectionCutSpec` construction. We compute the plane basis
+    once and project the polygon to 2-D once; per-intersection clipping
+    then operates in cached 2-D coords.
+    """
+    e1, e2 = _plane_basis(plane)
+    polygon_2d = _project_to_plane_basis(
+        np.asarray(polygon_3d, dtype=float), plane, basis=(e1, e2),
+    )
+    return PolygonClipper(
+        plane=plane, e1=e1, e2=e2, polygon_2d=polygon_2d,
+    )
+
+
+def is_convex_2d(polygon_2d: np.ndarray, *, tol: float = 1e-9) -> bool:
+    """Check whether a 2-D polygon is convex.
+
+    A polygon is convex iff every consecutive cross product of edge
+    vectors has the same sign (all ``>= 0`` for CCW, all ``<= 0`` for
+    CW). Treats vertices that are exactly collinear (cross within
+    ``tol``) as non-degenerate so a polygon with three collinear
+    consecutive vertices passes — useful when STKO geometry exports
+    redundant midpoints.
+    """
+    n = polygon_2d.shape[0]
+    if n < 3:
+        return False
+    sign = 0
+    for i in range(n):
+        a = polygon_2d[i]
+        b = polygon_2d[(i + 1) % n]
+        c = polygon_2d[(i + 2) % n]
+        cross = (b[0] - a[0]) * (c[1] - b[1]) - (b[1] - a[1]) * (c[0] - b[0])
+        if cross > tol:
+            if sign < 0:
+                return False
+            sign = 1
+        elif cross < -tol:
+            if sign > 0:
+                return False
+            sign = -1
+    return True

--- a/src/STKO_to_python/cuts/kernels/__init__.py
+++ b/src/STKO_to_python/cuts/kernels/__init__.py
@@ -11,6 +11,13 @@ from __future__ import annotations
 
 from .beam import BEAM_ELEMENT_CLASSES, BeamIntersection, find_beam_intersections
 from .beam_resultant import BeamCutResult, compute_beam_cut
+from .shell import (
+    SHELL_ELEMENT_CLASSES,
+    ShellCutResult,
+    ShellIntersection,
+    compute_shell_cut,
+    find_shell_intersections,
+)
 
 __all__ = [
     "BEAM_ELEMENT_CLASSES",
@@ -18,4 +25,9 @@ __all__ = [
     "find_beam_intersections",
     "BeamCutResult",
     "compute_beam_cut",
+    "SHELL_ELEMENT_CLASSES",
+    "ShellIntersection",
+    "find_shell_intersections",
+    "ShellCutResult",
+    "compute_shell_cut",
 ]

--- a/src/STKO_to_python/cuts/kernels/beam.py
+++ b/src/STKO_to_python/cuts/kernels/beam.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    from ..geometry import PolygonClipper
     from ..specs import SectionCutSpec
     from ...core.dataset import MPCODataSet
 
@@ -94,6 +95,8 @@ def _strip_class_tag(decorated: str) -> str:
 def find_beam_intersections(
     dataset: "MPCODataSet",
     spec: "SectionCutSpec",
+    *,
+    clipper: "PolygonClipper | None" = None,
 ) -> list[BeamIntersection]:
     """Find intersections between ``spec.plane`` and every beam in the filter.
 
@@ -108,6 +111,8 @@ def find_beam_intersections(
     - It lies parallel within numerical tolerance (e.g. a horizontal
       beam exactly on a horizontal cut).
     - Its connectivity has anything other than two nodes.
+    - The intersection point lies outside ``spec.bounding_polygon``
+      (when one is provided via ``clipper``).
 
     Returns
     -------
@@ -154,6 +159,8 @@ def find_beam_intersections(
         if hit is None:
             continue
         point, t = hit
+        if clipper is not None and not clipper.point_inside(np.asarray(point, dtype=float)):
+            continue
         xi = 2.0 * t - 1.0
         out.append(
             BeamIntersection(

--- a/src/STKO_to_python/cuts/kernels/beam_resultant.py
+++ b/src/STKO_to_python/cuts/kernels/beam_resultant.py
@@ -43,6 +43,7 @@ import numpy as np
 from .beam import BEAM_ELEMENT_CLASSES, BeamIntersection, _strip_class_tag, find_beam_intersections
 
 if TYPE_CHECKING:
+    from ..geometry import PolygonClipper
     from ..specs import SectionCutSpec
     from ...core.dataset import MPCODataSet
 
@@ -101,6 +102,7 @@ def compute_beam_cut(
     spec: "SectionCutSpec",
     *,
     model_stage: str,
+    clipper: "PolygonClipper | None" = None,
 ) -> BeamCutResult:
     """Compute the (F, M) resultant of a section cut through beams.
 
@@ -112,6 +114,12 @@ def compute_beam_cut(
         Cut specification (plane + filter + side).
     model_stage:
         Model stage to read from (e.g. ``"MODEL_STAGE[1]"``).
+    clipper:
+        Optional pre-built :class:`~..geometry.PolygonClipper`. When the
+        caller composes the beam + shell kernels together (via
+        :class:`SectionCut`) it builds this once and threads it through
+        both so the plane basis isn't recomputed. If ``None`` and
+        ``spec.bounding_polygon`` is set, a clipper is built here.
 
     Returns
     -------
@@ -119,8 +127,11 @@ def compute_beam_cut(
         Empty result (``F``/``M`` shape ``(0, 3)``) when no beam in the
         filter crosses the plane.
     """
+    if clipper is None and spec.bounding_polygon is not None:
+        from ..geometry import prepare_clipper
+        clipper = prepare_clipper(spec.plane, spec.bounding_polygon)
     intersections = _deduplicate_at_node_intersections(
-        find_beam_intersections(dataset, spec)
+        find_beam_intersections(dataset, spec, clipper=clipper)
     )
 
     # 2. Group by element type so we can batch a single result fetch per type.

--- a/src/STKO_to_python/cuts/kernels/shell.py
+++ b/src/STKO_to_python/cuts/kernels/shell.py
@@ -1,0 +1,797 @@
+"""Shell section-cut kernel — geometry + resultant.
+
+The shell kernel mirrors the beam kernel in shape:
+
+- a registry of shell classes the kernel knows how to handle,
+- a ``ShellIntersection`` record per shell whose midsurface a plane
+  crosses (the chord plus enough metadata to interpolate),
+- a ``find_shell_intersections`` step that computes those records,
+- a ``compute_shell_cut`` step that reads ``section.force``, integrates
+  the line traction over each chord, and aggregates ``(F, M)``.
+
+Why the chord integration matters
+---------------------------------
+OpenSees shells record ``section.force`` per integration point in
+element-local axes — eight components per IP:
+``Fxx, Fyy, Fxy, Mxx, Myy, Mxy, Vxz, Vyz`` — and each component is a
+**force / moment per unit length of the midsurface line**. The cut
+through one shell produces a chord along that line; the cut resultant
+contribution is therefore a true ``∫`` over the chord, not the
+discrete IP-point evaluation used by beams. We use Gauss-Legendre
+quadrature along the chord; section forces are usually linear (for
+elastic / bilinear sections) or low-order over a single shell element,
+so 2-point quadrature is sufficient in practice.
+
+Layered shells are transparent
+------------------------------
+``section.force`` is already through-thickness-integrated by the shell
+formulation regardless of layer count (the section is the same
+abstraction whether it's an ``ElasticMembranePlateSection`` or a
+``LayeredShell`` with many fibers). The per-layer breakdown via
+``material.fiber.stress`` is a v2 feature; this kernel only reads
+``section.force``.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..specs import SectionCutSpec
+    from ..geometry import PolygonClipper
+    from ...core.dataset import MPCODataSet
+
+
+# Shell element classes this kernel can handle. The MPCO element index
+# carries decorated names like ``"203-ASDShellQ4"``; we strip the
+# ``<tag>-`` prefix before matching, so both decorated and base names
+# resolve. ``LayeredShell``-equipped variants (``ASDShellQ4`` /
+# ``ASDShellT3`` with a ``LayeredShell`` section) are not distinct
+# element classes — they're the same elements with a richer section,
+# and ``section.force`` is identical in shape.
+SHELL_ELEMENT_CLASSES: tuple[str, ...] = (
+    "ASDShellQ4",
+    "ASDShellT3",
+    "ShellMITC4",
+    "ShellNLDKGQ",
+    "ShellNLDKGT",
+    "ShellDKGQ",
+    "ShellDKGT",
+)
+
+
+_TAG_PREFIX_RE = re.compile(r"^\d+-")
+
+
+def _strip_class_tag(decorated: str) -> str:
+    """``'203-ASDShellQ4' -> 'ASDShellQ4'``; idempotent on plain names."""
+    return _TAG_PREFIX_RE.sub("", str(decorated))
+
+
+# ---------------------------------------------------------------------- #
+# Geometry record
+# ---------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ShellIntersection:
+    """A single shell midsurface crossing the cut plane.
+
+    Attributes
+    ----------
+    element_id : int
+    element_type : str
+        Decorated type string (e.g. ``"203-ASDShellQ4"``).
+    chord_endpoints_global : tuple of two ``(3,)`` tuples
+        The two physical-space endpoints of the chord, in global coords.
+    chord_param_natural : tuple of two ``(2,)`` tuples
+        The chord endpoints in element natural coords ``(ξ, η)`` — these
+        feed the shape-function-based sampling along the chord.
+    midsurface_polygon_global : ``(n_nodes, 3)`` ndarray
+        Element nodes in global coords, ordered as the connectivity.
+    node_ids : tuple of int
+    """
+
+    element_id: int
+    element_type: str
+    chord_endpoints_global: tuple[tuple[float, float, float], tuple[float, float, float]]
+    chord_param_natural: tuple[tuple[float, float], tuple[float, float]]
+    midsurface_polygon_global: np.ndarray = field(repr=False)
+    node_ids: tuple[int, ...]
+
+    @property
+    def chord_endpoints_arr(self) -> np.ndarray:
+        return np.asarray(self.chord_endpoints_global, dtype=float)
+
+    @property
+    def chord_midpoint(self) -> np.ndarray:
+        """Physical midpoint of the chord — used as the reference point
+        for the per-element moment (the analogue of ``point_arr`` on a
+        :class:`BeamIntersection`)."""
+        p = self.chord_endpoints_arr
+        return 0.5 * (p[0] + p[1])
+
+    @property
+    def chord_length(self) -> float:
+        p = self.chord_endpoints_arr
+        return float(np.linalg.norm(p[1] - p[0]))
+
+
+# ---------------------------------------------------------------------- #
+# Inverse shape-function maps — (chord 3-D endpoint) → (ξ, η)
+# ---------------------------------------------------------------------- #
+def _invert_quad_bilinear(
+    p: np.ndarray, verts: np.ndarray, *, max_iter: int = 25, tol: float = 1e-10,
+) -> np.ndarray:
+    """Invert the bilinear quad map ``x(ξ, η) → physical`` for one point.
+
+    Newton iteration starting at ``(ξ, η) = (0, 0)``. ``verts`` is
+    ``(4, 3)`` in OpenSees ASDShellQ4 node order:
+
+        node 1 ↔ (ξ, η) = (-1, -1)
+        node 2 ↔ (+1, -1)
+        node 3 ↔ (+1, +1)
+        node 4 ↔ (-1, +1)
+
+    For a planar quad the Newton step converges in 1-2 iterations; for
+    a warped quad we tolerate up to ``max_iter``. The chord endpoint
+    must lie on the midsurface; if Newton fails to converge we raise
+    rather than return a meaningless point so the kernel can be
+    debugged loudly.
+    """
+    # Quad shape functions and derivatives in ξ, η (see
+    # STKO_to_python.format.shape_functions)
+    def shape(xi: float, eta: float) -> np.ndarray:
+        return 0.25 * np.array(
+            [(1 - xi) * (1 - eta),
+             (1 + xi) * (1 - eta),
+             (1 + xi) * (1 + eta),
+             (1 - xi) * (1 + eta)]
+        )
+
+    def shape_grad(xi: float, eta: float) -> np.ndarray:
+        # 4 nodes × 2 parametric directions
+        return 0.25 * np.array([
+            [-(1 - eta), -(1 - xi)],
+            [ (1 - eta), -(1 + xi)],
+            [ (1 + eta),  (1 + xi)],
+            [-(1 + eta),  (1 - xi)],
+        ])
+
+    # Use the shell midsurface plane's 2-D coords for the Newton solve.
+    # That keeps the residual a clean 2-vector (and the Jacobian 2×2)
+    # rather than fighting an under-determined 3-vector residual on a
+    # 2-DoF unknown.
+    centroid = verts.mean(axis=0)
+    rel = verts - centroid
+    # Two largest singular vectors of the vertex offsets span the
+    # midsurface plane.
+    u_svd, _, _ = np.linalg.svd(rel, full_matrices=False)
+    # ``u_svd`` shape ``(4, k)`` where k = min(4, 3) = 3; the first two
+    # left singular vectors are the in-plane basis weights, but we want
+    # the in-plane physical directions — take the right singular
+    # vectors instead.
+    _, _, vh_svd = np.linalg.svd(rel, full_matrices=False)
+    e1 = vh_svd[0]
+    e2 = vh_svd[1]
+    verts_2d = np.column_stack([rel @ e1, rel @ e2])
+    p_2d = np.array([(p - centroid) @ e1, (p - centroid) @ e2])
+
+    xi, eta = 0.0, 0.0
+    for _ in range(max_iter):
+        N = shape(xi, eta)
+        # Position in 2D: x(ξ, η) = sum N_i * verts_2d_i
+        x_curr = N @ verts_2d  # (2,)
+        residual = x_curr - p_2d
+        if np.linalg.norm(residual) < tol:
+            return np.array([xi, eta])
+        dN = shape_grad(xi, eta)  # (4, 2)
+        J = verts_2d.T @ dN       # (2, 2) — ∂x/∂(ξ, η)
+        try:
+            step = np.linalg.solve(J, residual)
+        except np.linalg.LinAlgError as exc:
+            raise RuntimeError(
+                f"Singular Jacobian inverting quad bilinear at "
+                f"(ξ, η) = ({xi}, {eta})."
+            ) from exc
+        xi -= float(step[0])
+        eta -= float(step[1])
+    raise RuntimeError(
+        f"Bilinear inversion did not converge after {max_iter} iterations "
+        f"(final residual {np.linalg.norm(residual)}, p={p.tolist()})."
+    )
+
+
+def _invert_tri_linear(p: np.ndarray, verts: np.ndarray) -> np.ndarray:
+    """Invert the linear-triangle map for one point.
+
+    Returns ``(ξ, η)`` on the unit triangle (vertices at (0, 0), (1, 0),
+    (0, 1)). For a planar tri the inversion is exact:
+
+        x(ξ, η) = v0 * (1 - ξ - η) + v1 * ξ + v2 * η
+                = v0 + (v1 - v0) * ξ + (v2 - v0) * η
+
+    Solve the 2-D linear system in the triangle's own plane.
+    """
+    v0, v1, v2 = verts
+    e1 = v1 - v0
+    e2 = v2 - v0
+    rel = p - v0
+    # Build a 2-D basis on the triangle plane and project.
+    n = np.cross(e1, e2)
+    n_norm = float(np.linalg.norm(n))
+    if n_norm < 1e-30:
+        raise RuntimeError("Degenerate (collinear) triangle vertices.")
+    e_a = e1 / np.linalg.norm(e1)
+    e_b = np.cross(n / n_norm, e_a)
+    rel_2d = np.array([rel @ e_a, rel @ e_b])
+    A = np.column_stack([
+        np.array([e1 @ e_a, e1 @ e_b]),
+        np.array([e2 @ e_a, e2 @ e_b]),
+    ])
+    sol = np.linalg.solve(A, rel_2d)
+    return sol  # (ξ, η)
+
+
+def _natural_coords_of_chord(
+    chord_global: np.ndarray, midsurface_verts: np.ndarray, base_type: str,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Compute element natural coords ``(ξ, η)`` for the two chord
+    endpoints, dispatching on element class.
+
+    ASDShellQ4: bilinear inversion (Newton). ASDShellT3 / generic
+    triangular shell: linear inversion (closed form). Other classes
+    that ship 4-node quads / 3-node tris reuse the same inversions.
+    """
+    a = chord_global[0]
+    b = chord_global[1]
+    if midsurface_verts.shape[0] == 4:
+        xi_a = _invert_quad_bilinear(a, midsurface_verts)
+        xi_b = _invert_quad_bilinear(b, midsurface_verts)
+    elif midsurface_verts.shape[0] == 3:
+        xi_a = _invert_tri_linear(a, midsurface_verts)
+        xi_b = _invert_tri_linear(b, midsurface_verts)
+    else:
+        raise NotImplementedError(
+            f"Shell class {base_type!r} has {midsurface_verts.shape[0]} "
+            "nodes; only 3- and 4-node midsurfaces are supported in v1.6."
+        )
+    return (
+        (float(xi_a[0]), float(xi_a[1])),
+        (float(xi_b[0]), float(xi_b[1])),
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Geometry phase
+# ---------------------------------------------------------------------- #
+def find_shell_intersections(
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    *,
+    clipper: "PolygonClipper | None" = None,
+) -> list[ShellIntersection]:
+    """Find intersections between ``spec.plane`` and every shell in the filter.
+
+    A shell is skipped without warning when:
+
+    - its midsurface lies parallel to the cut plane within numerical
+      tolerance,
+    - the intersection chord has zero length (the plane grazes a
+      vertex only),
+    - the spec carries a ``bounding_polygon`` and the chord is fully
+      outside the polygon — in that case the chord is clipped against
+      the polygon and only the in-polygon portion is recorded.
+
+    Parameters
+    ----------
+    clipper : :class:`PolygonClipper`, optional
+        Pre-built clipper for ``spec.bounding_polygon``. The caller
+        builds this once per cut and threads it through to both the
+        beam and shell phases so the plane basis isn't recomputed.
+    """
+    candidate_ids = dataset._selection_resolver.resolve_elements(
+        names=spec.selection_set_name,
+        ids=spec.selection_set_id,
+        explicit_ids=spec.element_ids,
+    )
+    candidate_set = {int(x) for x in candidate_ids}
+
+    df_elems = dataset.elements_info["dataframe"]
+    df_nodes = dataset.nodes_info["dataframe"]
+    node_coord: dict[int, tuple[float, float, float]] = {
+        int(r.node_id): (float(r.x), float(r.y), float(r.z))
+        for r in df_nodes.itertuples(index=False)
+    }
+
+    shell_set = set(SHELL_ELEMENT_CLASSES)
+    is_shell = df_elems["element_type"].map(
+        lambda s: _strip_class_tag(s) in shell_set
+    )
+    in_filter = df_elems["element_id"].isin(candidate_set)
+    shell_rows = df_elems[is_shell & in_filter]
+
+    plane = spec.plane
+    out: list[ShellIntersection] = []
+    for row in shell_rows.itertuples(index=False):
+        node_list = row.node_list
+        n_nodes = len(node_list)
+        if n_nodes not in (3, 4):
+            # v1.6 supports tri3 + quad4 only; higher-order shells skip.
+            continue
+        coords = np.array(
+            [node_coord[int(nid)] for nid in node_list if int(nid) in node_coord],
+            dtype=float,
+        )
+        if coords.shape[0] != n_nodes:
+            continue
+        # Side-aware shared-edge rule: when two adjacent shells share
+        # an edge that lies on the cut plane, both report that edge as
+        # a chord. Keeping both double-counts. Per the standard cut
+        # convention, the cut traction comes from the DISCARDED side —
+        # so for each shell skip it when its interior is entirely on
+        # the kept side (no vertex strictly on the discarded side).
+        d_signed = (coords - np.asarray(plane.point, dtype=float)) @ spec.signed_normal
+        tol_d = 1e-9
+        has_discarded = bool(np.any(d_signed < -tol_d))
+        if not has_discarded:
+            # Interior on the kept side or entirely on the plane —
+            # the neighbouring shell on the discarded side will report
+            # the chord. Skipping here avoids the double-count.
+            continue
+        chord = plane.intersect_polygon(coords)
+        if chord is None:
+            continue
+        p0, p1 = chord
+        if np.linalg.norm(p1 - p0) < 1e-12:
+            continue
+        chord_arr = np.stack([p0, p1])
+
+        # Apply bounding-polygon clipping in 2-D plane coords.
+        if clipper is not None:
+            clipped = clipper.clip_segment(p0, p1)
+            if clipped is None:
+                continue
+            q0, q1, _, _ = clipped
+            chord_arr = np.stack([q0, q1])
+
+        base_type = _strip_class_tag(row.element_type)
+        xi_a, xi_b = _natural_coords_of_chord(chord_arr, coords, base_type)
+        out.append(
+            ShellIntersection(
+                element_id=int(row.element_id),
+                element_type=str(row.element_type),
+                chord_endpoints_global=(
+                    (float(chord_arr[0, 0]), float(chord_arr[0, 1]), float(chord_arr[0, 2])),
+                    (float(chord_arr[1, 0]), float(chord_arr[1, 1]), float(chord_arr[1, 2])),
+                ),
+                chord_param_natural=(xi_a, xi_b),
+                midsurface_polygon_global=coords,
+                node_ids=tuple(int(nid) for nid in node_list),
+            )
+        )
+    out.sort(key=lambda s: s.element_id)
+    return out
+
+
+# ---------------------------------------------------------------------- #
+# Section-force layout
+# ---------------------------------------------------------------------- #
+# Index of each shell ``section.force`` shortname in the 8-vector we
+# carry through the math. Eight components per IP — STKO records all of
+# them for the standard ASDShell sections. Missing components default
+# to zero (e.g., a membrane-only formulation that omits Mxx).
+_SHELL_SECTION_POSITIONS: dict[str, int] = {
+    "Fxx": 0,  # in-plane normal force per unit length, local x
+    "Fyy": 1,  # in-plane normal force per unit length, local y
+    "Fxy": 2,  # in-plane shear per unit length
+    "Mxx": 3,  # bending moment per unit length, about local x
+    "Myy": 4,  # bending moment per unit length, about local y
+    "Mxy": 5,  # twisting moment per unit length
+    "Vxz": 6,  # transverse (through-thickness) shear, local x face
+    "Vyz": 7,  # transverse shear, local y face
+}
+
+
+def _read_shell_section_force_array(rows, n_ip: int) -> np.ndarray:
+    """Extract a ``(n_steps, n_ip, 8)`` array from a shell section.force
+    DataFrame.
+
+    Columns are ``<shortname>_ip<k>``. Missing components default to
+    zero — useful for partial recorders or non-standard shells that
+    omit bending / shear terms.
+    """
+    n_steps = rows.shape[0]
+    out = np.zeros((n_steps, n_ip, 8), dtype=float)
+    available = set(rows.columns)
+    for k in range(n_ip):
+        for shortname, pos in _SHELL_SECTION_POSITIONS.items():
+            col = f"{shortname}_ip{k}"
+            if col in available:
+                out[:, k, pos] = rows[col].to_numpy(dtype=float)
+    return out
+
+
+# ---------------------------------------------------------------------- #
+# Quad / tri sampling weights from IP values to an arbitrary (ξ, η)
+# ---------------------------------------------------------------------- #
+_QUAD_GAUSS_S = 1.0 / np.sqrt(3.0)  # IP coord magnitude for 2×2 Gauss
+
+
+def _quad_ip_weights(xi: float, eta: float) -> np.ndarray:
+    """Bilinear interpolation weights from the 4 Gauss-Legendre 2×2 IPs
+    of ASDShellQ4 to an arbitrary ``(ξ, η)``.
+
+    The IPs sit at ``(±s, ±s)`` with ``s = 1/√3``, ordered ξ-fastest:
+
+        IP 0 ↔ (-s, -s)
+        IP 1 ↔ (+s, -s)
+        IP 2 ↔ (-s, +s)
+        IP 3 ↔ (+s, +s)
+
+    Mapping ``ξ → ξ_local = ξ / s`` puts the IPs at the corners of an
+    auxiliary unit square; bilinear interpolation on that square gives
+    the weights below. Extrapolates linearly for chord points beyond
+    the IP envelope (typical when a quad has IPs at ``±1/√3`` but the
+    cut passes near the element edge at ``ξ = ±1``).
+    """
+    xi_local = xi / _QUAD_GAUSS_S
+    eta_local = eta / _QUAD_GAUSS_S
+    return 0.25 * np.array([
+        (1 - xi_local) * (1 - eta_local),
+        (1 + xi_local) * (1 - eta_local),
+        (1 - xi_local) * (1 + eta_local),
+        (1 + xi_local) * (1 + eta_local),
+    ])
+
+
+def _tri_ip_weights(xi: float, eta: float) -> np.ndarray:
+    """Linear interpolation weights from the 3 Gauss IPs of ASDShellT3
+    to an arbitrary ``(ξ, η)`` on the unit triangle.
+
+    The IPs sit at ``(1/6, 1/6), (2/3, 1/6), (1/6, 2/3)``. Solving the
+    inverse-linear system gives the weight set used below — verified
+    by partition-of-unity at the centroid and unit response at each IP.
+    """
+    return np.array([
+        5.0 / 3.0 - 2.0 * xi - 2.0 * eta,
+        -1.0 / 3.0 + 2.0 * xi,
+        -1.0 / 3.0 + 2.0 * eta,
+    ])
+
+
+def _sample_shell_section_force(
+    section_force: np.ndarray, xi: float, eta: float, base_type: str,
+) -> np.ndarray:
+    """Sample ``section.force`` at arbitrary natural coords on a shell.
+
+    Returns ``(n_steps, 8)``. Dispatches to bilinear (quads) or linear
+    (tris) interpolation depending on the element class. The choice
+    follows the IP layout that
+    :mod:`STKO_to_python.format.gauss_points` declares for each class.
+    """
+    n_ip = section_force.shape[1]
+    if n_ip == 4 and "Q4" in base_type:
+        w = _quad_ip_weights(xi, eta)
+    elif n_ip == 3 and "T3" in base_type:
+        w = _tri_ip_weights(xi, eta)
+    elif n_ip == 1:
+        # 1-IP shell: just broadcast the single IP value.
+        return section_force[:, 0, :].copy()
+    elif n_ip == 4:
+        w = _quad_ip_weights(xi, eta)
+    elif n_ip == 3:
+        w = _tri_ip_weights(xi, eta)
+    else:
+        raise NotImplementedError(
+            f"Shell {base_type!r} has {n_ip} IPs; only 1/3/4 IPs are "
+            "supported in v1.6."
+        )
+    # (n_steps, n_ip, 8) · (n_ip,) → (n_steps, 8)
+    return np.einsum("sij,i->sj", section_force, w)
+
+
+# ---------------------------------------------------------------------- #
+# Result container
+# ---------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ShellCutResult:
+    """Output of :func:`compute_shell_cut`.
+
+    Attributes
+    ----------
+    F : np.ndarray
+        ``(n_steps, 3)`` — total cut force from shells, global frame.
+    M : np.ndarray
+        ``(n_steps, 3)`` — total cut moment about ``centroid``, global.
+    time : np.ndarray
+        ``(n_steps,)``.
+    centroid : np.ndarray
+        ``(3,)`` — reference point for moments (unweighted mean of the
+        chord midpoints). The composite ``SectionCut`` may reaggregate
+        about a different centroid that also includes beam intersection
+        points.
+    intersections : tuple[ShellIntersection, ...]
+    per_shell_F, per_shell_M_at_midpoint : dict[int, np.ndarray]
+    """
+
+    F: np.ndarray
+    M: np.ndarray
+    time: np.ndarray
+    centroid: np.ndarray
+    intersections: tuple[ShellIntersection, ...]
+    per_shell_F: dict[int, np.ndarray] = field(default_factory=dict)
+    per_shell_M_at_midpoint: dict[int, np.ndarray] = field(default_factory=dict)
+
+    @property
+    def n_steps(self) -> int:
+        return int(self.time.shape[0])
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self.intersections) == 0
+
+
+# ---------------------------------------------------------------------- #
+# Resultant phase
+# ---------------------------------------------------------------------- #
+_GAUSS_LEGENDRE_2 = (
+    np.array([-1.0 / np.sqrt(3.0), 1.0 / np.sqrt(3.0)]),
+    np.array([1.0, 1.0]),
+)
+
+
+def compute_shell_cut(
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    *,
+    model_stage: str,
+    clipper: "PolygonClipper | None" = None,
+) -> ShellCutResult:
+    """Compute the ``(F, M)`` resultant of a section cut through shells.
+
+    Returns an empty result when no shell in the filter crosses the
+    plane (``F.shape == (0, 3)``).
+    """
+    intersections = find_shell_intersections(dataset, spec, clipper=clipper)
+
+    # Group by decorated element type for batched section.force reads.
+    by_type: dict[str, list[ShellIntersection]] = {}
+    for ix in intersections:
+        by_type.setdefault(ix.element_type, []).append(ix)
+
+    per_shell_F: dict[int, np.ndarray] = {}
+    per_shell_M_at_mid: dict[int, np.ndarray] = {}
+    time: np.ndarray | None = None
+
+    for elem_type, sub in by_type.items():
+        eids = [ix.element_id for ix in sub]
+        er = dataset.elements.get_element_results(
+            results_name="section.force",
+            element_type=elem_type,
+            model_stage=model_stage,
+            element_ids=eids,
+        )
+        n_ip = int(er.n_ip) if er.n_ip > 0 else 0
+        if n_ip == 0:
+            raise ValueError(
+                f"Shell {elem_type!r} has no integration points in the "
+                "section.force result. This means the shell class is not "
+                "in the Gauss-point catalog at "
+                "STKO_to_python.format.gauss_points — register it before "
+                "running a section cut on it."
+            )
+        base_type = _strip_class_tag(elem_type)
+        for ix in sub:
+            rows = er.df.xs(ix.element_id, level="element_id")
+            section_force = _read_shell_section_force_array(rows, n_ip)
+            F, M = _shell_cut_per_element(
+                section_force, ix, dataset, spec, base_type,
+            )
+            per_shell_F[ix.element_id] = F
+            per_shell_M_at_mid[ix.element_id] = M
+        if time is None:
+            time = np.asarray(er.time, dtype=float)
+
+    if not intersections or time is None:
+        return ShellCutResult(
+            F=np.zeros((0, 3)),
+            M=np.zeros((0, 3)),
+            time=np.zeros((0,)),
+            centroid=np.zeros(3),
+            intersections=(),
+        )
+
+    centroid = np.mean(
+        np.stack([ix.chord_midpoint for ix in intersections], axis=0), axis=0
+    )
+    F_total = np.zeros((time.shape[0], 3), dtype=float)
+    M_total = np.zeros_like(F_total)
+    for ix in intersections:
+        Fi = per_shell_F[ix.element_id]
+        Mi = per_shell_M_at_mid[ix.element_id]
+        arm = ix.chord_midpoint - centroid
+        F_total += Fi
+        M_total += Mi + np.cross(arm, Fi)
+
+    return ShellCutResult(
+        F=F_total,
+        M=M_total,
+        time=time,
+        centroid=centroid,
+        intersections=tuple(intersections),
+        per_shell_F=per_shell_F,
+        per_shell_M_at_midpoint=per_shell_M_at_mid,
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Per-element kernel
+# ---------------------------------------------------------------------- #
+def _shell_cut_per_element(
+    section_force: np.ndarray,
+    intersection: ShellIntersection,
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    base_type: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Integrate a single shell's traction along its chord.
+
+    Returns ``(F, M)`` shape ``(n_steps, 3)`` each — cut force/moment in
+    **global** frame, with the moment summed about the chord midpoint.
+    The composite cut aggregator transfers moments to a common
+    centroid afterwards.
+    """
+    chord = intersection.chord_endpoints_arr  # (2, 3)
+    L = intersection.chord_length
+    p_mid = intersection.chord_midpoint
+
+    # Cut in-plane normal in global frame.
+    # Construct the shell normal from the midsurface polygon (first
+    # non-collinear cross product), then the chord-perpendicular within
+    # the shell plane is direction × shell_normal.
+    n_shell = _midsurface_normal(intersection.midsurface_polygon_global)
+    chord_dir = chord[1] - chord[0]
+    chord_dir /= np.linalg.norm(chord_dir)
+    n_cut_global = np.cross(chord_dir, n_shell)
+    n_cut_norm = float(np.linalg.norm(n_cut_global))
+    if n_cut_norm < 1e-12:
+        # Shouldn't happen for a real cut (chord direction is by
+        # construction perpendicular to the cut plane normal, which is
+        # in the shell plane only when the shell normal is colinear
+        # with the chord — i.e. the cut plane is tangent to the shell
+        # midsurface, which we treat as a no-op above).
+        return np.zeros((section_force.shape[0], 3)), np.zeros((section_force.shape[0], 3))
+    n_cut_global /= n_cut_norm
+    # Pick the sign so that n_cut_global points from the KEPT side to
+    # the DISCARDED side. Then the traction t = N · n_cut is the force
+    # the discarded side exerts on the kept side — the cut convention.
+    n_cut_global = _orient_cut_normal(
+        n_cut_global, intersection.midsurface_polygon_global, p_mid, spec,
+    )
+
+    # Express the cut normal in element-local coords (the frame the
+    # section forces are recorded in).
+    R = dataset.cdata.rotation_matrix(intersection.element_id)  # local→global
+    n_cut_local = R.T @ n_cut_global  # global→local
+    n_x = float(n_cut_local[0])
+    n_y = float(n_cut_local[1])
+    # Element-local z is the shell normal direction — should be ~0.
+    # We take the in-plane components only; the through-thickness shear
+    # uses (n_x, n_y) directly.
+
+    # Gauss-Legendre 2-pt along the chord.
+    gs, gw = _GAUSS_LEGENDRE_2
+    xi_a, eta_a = intersection.chord_param_natural[0]
+    xi_b, eta_b = intersection.chord_param_natural[1]
+    half_L = 0.5 * L
+
+    n_steps = section_force.shape[0]
+    F_local = np.zeros((n_steps, 3), dtype=float)
+    M_local = np.zeros((n_steps, 3), dtype=float)
+
+    for s, w in zip(gs, gw):
+        alpha = 0.5 * (s + 1.0)  # ∈ [0, 1]
+        xi_g = (1 - alpha) * xi_a + alpha * xi_b
+        eta_g = (1 - alpha) * eta_a + alpha * eta_b
+        sf = _sample_shell_section_force(section_force, xi_g, eta_g, base_type)
+        # sf: (n_steps, 8) in element-local axes, ordered per
+        # _SHELL_SECTION_POSITIONS: Fxx, Fyy, Fxy, Mxx, Myy, Mxy, Vxz, Vyz.
+        Fxx, Fyy, Fxy = sf[:, 0], sf[:, 1], sf[:, 2]
+        Mxx, Myy, Mxy = sf[:, 3], sf[:, 4], sf[:, 5]
+        Vxz, Vyz = sf[:, 6], sf[:, 7]
+        # Traction per unit length on the cut line, element-local:
+        #   force x = Fxx * n_x + Fxy * n_y           (membrane)
+        #   force y = Fxy * n_x + Fyy * n_y           (membrane)
+        #   force z = Vxz * n_x + Vyz * n_y           (through-thickness)
+        # Moment per unit length about element-local axes lying in the
+        # midsurface (no z-axis contribution from section forces):
+        #   moment x = Mxx * n_x + Mxy * n_y
+        #   moment y = Mxy * n_x + Myy * n_y
+        #   moment z = 0
+        f_per_unit_x = Fxx * n_x + Fxy * n_y
+        f_per_unit_y = Fxy * n_x + Fyy * n_y
+        f_per_unit_z = Vxz * n_x + Vyz * n_y
+        m_per_unit_x = Mxx * n_x + Mxy * n_y
+        m_per_unit_y = Mxy * n_x + Myy * n_y
+        weight = w * half_L
+        F_local[:, 0] += weight * f_per_unit_x
+        F_local[:, 1] += weight * f_per_unit_y
+        F_local[:, 2] += weight * f_per_unit_z
+        M_local[:, 0] += weight * m_per_unit_x
+        M_local[:, 1] += weight * m_per_unit_y
+        # m_per_unit_z is identically zero — skip.
+
+    F_global = F_local @ R.T
+    M_global = M_local @ R.T
+    return F_global, M_global
+
+
+def _midsurface_normal(verts: np.ndarray) -> np.ndarray:
+    """Unit normal of a 3- or 4-node midsurface polygon.
+
+    Cross-product of the first two non-degenerate edges. The polygon
+    is assumed to be ordered (CCW or CW); a flipped normal is fine —
+    the side-orientation step :func:`_orient_cut_normal` independently
+    fixes the cut normal's sign.
+    """
+    e1 = verts[1] - verts[0]
+    e2 = verts[2] - verts[0]
+    n = np.cross(e1, e2)
+    n_norm = float(np.linalg.norm(n))
+    if n_norm < 1e-12:
+        # Try the next edge pair — degenerate triangle at this vertex.
+        if verts.shape[0] >= 4:
+            e3 = verts[3] - verts[0]
+            n = np.cross(e1, e3)
+            n_norm = float(np.linalg.norm(n))
+        if n_norm < 1e-12:
+            raise RuntimeError(
+                f"Cannot compute shell midsurface normal — degenerate "
+                f"vertex layout: {verts.tolist()}"
+            )
+    return n / n_norm
+
+
+def _orient_cut_normal(
+    n_cut_global: np.ndarray,
+    midsurface_verts: np.ndarray,
+    p_mid: np.ndarray,
+    spec: "SectionCutSpec",
+) -> np.ndarray:
+    """Choose the sign of ``n_cut_global`` so it points away from the
+    kept side (i.e., toward the discarded side).
+
+    For a normal cut where the polygon crosses the plane interior, the
+    "most-clearly-kept" vertex has ``d > 0`` and ``n_cut`` is flipped
+    if it points toward that vertex. For an edge-coincident cut where
+    the polygon's interior lies entirely on the discarded side (only
+    case admitted by the side-aware filter in
+    :func:`find_shell_intersections`), the polygon's farthest-from-the-
+    plane vertex sits on the discarded side; ``n_cut`` is flipped if
+    it points AWAY from that vertex.
+
+    Both branches yield the same convention: ``n_cut · (kept_side -
+    p_mid) < 0``.
+    """
+    signed_n = spec.signed_normal
+    rel = midsurface_verts - np.asarray(spec.plane.point, dtype=float)
+    d = rel @ signed_n  # (n_nodes,)
+    idx = int(np.argmax(d))
+    if d[idx] > 0.0:
+        # Normal case: there is a strictly-kept vertex. n_cut should
+        # point AWAY from it.
+        offset = midsurface_verts[idx] - p_mid
+        if offset @ n_cut_global > 0:
+            return -n_cut_global
+        return n_cut_global
+    # Edge-coincident case: polygon interior is on the discarded side
+    # (the side-aware filter guarantees at least one vertex has d<0).
+    # Use the most-clearly-discarded vertex; n_cut must point TOWARD
+    # it. Equivalent statement: flip when n_cut points AWAY.
+    idx = int(np.argmin(d))
+    offset = midsurface_verts[idx] - p_mid  # has component on discarded side
+    if offset @ n_cut_global < 0:
+        return -n_cut_global
+    return n_cut_global

--- a/src/STKO_to_python/cuts/section_cut.py
+++ b/src/STKO_to_python/cuts/section_cut.py
@@ -38,6 +38,7 @@ import pandas as pd
 
 from .kernels.beam import BeamIntersection
 from .kernels.beam_resultant import compute_beam_cut
+from .kernels.shell import ShellIntersection, compute_shell_cut
 from .specs import SectionCutSpec
 
 if TYPE_CHECKING:
@@ -84,6 +85,9 @@ class SectionCut:
     intersections: tuple[BeamIntersection, ...]
     per_beam_F: dict[int, np.ndarray] = field(default_factory=dict)
     per_beam_M_at_intersection: dict[int, np.ndarray] = field(default_factory=dict)
+    shell_intersections: tuple[ShellIntersection, ...] = ()
+    per_shell_F: dict[int, np.ndarray] = field(default_factory=dict)
+    per_shell_M_at_midpoint: dict[int, np.ndarray] = field(default_factory=dict)
 
     # ------------------------------------------------------------------ #
     # Construction
@@ -98,20 +102,86 @@ class SectionCut:
     ) -> "SectionCut":
         """Compute the cut against ``dataset`` at ``model_stage``.
 
-        Dispatches to the beam kernel today; the shell and solid kernels
-        will compose into this same return type as they land.
+        Composes the beam and shell kernels and aggregates ``(F, M)``
+        about a shared centroid (the mean of all reference points —
+        beam intersection points and shell chord midpoints). The solid
+        kernel will plug into the same composition in v2.0.
         """
-        beam = compute_beam_cut(dataset, spec, model_stage=model_stage)
+        # Share one PolygonClipper between the two kernels so the plane
+        # basis isn't recomputed twice when bounding_polygon is set.
+        clipper = None
+        if spec.bounding_polygon is not None:
+            from .geometry import prepare_clipper
+            clipper = prepare_clipper(spec.plane, spec.bounding_polygon)
+
+        beam = compute_beam_cut(
+            dataset, spec, model_stage=model_stage, clipper=clipper,
+        )
+        shell = compute_shell_cut(
+            dataset, spec, model_stage=model_stage, clipper=clipper,
+        )
+
+        # Pick a time axis from whichever kernel found something. Beam
+        # and shell readers route through the same broker, so when both
+        # have intersections their time arrays are identical by
+        # construction.
+        if not beam.is_empty:
+            time = beam.time
+        elif not shell.is_empty:
+            time = shell.time
+        else:
+            return cls(
+                spec=spec,
+                model_stage=model_stage,
+                F=np.zeros((0, 3)),
+                M=np.zeros((0, 3)),
+                time=np.zeros((0,)),
+                centroid=np.zeros(3),
+                intersections=(),
+                per_beam_F={},
+                per_beam_M_at_intersection={},
+                shell_intersections=(),
+                per_shell_F={},
+                per_shell_M_at_midpoint={},
+            )
+
+        # Aggregate F + M about the shared centroid of every reference
+        # point in both kernels.
+        ref_points = []
+        for b in beam.intersections:
+            ref_points.append(b.point_arr)
+        for s in shell.intersections:
+            ref_points.append(s.chord_midpoint)
+        centroid = np.mean(np.stack(ref_points, axis=0), axis=0)
+
+        F_total = np.zeros((time.shape[0], 3), dtype=float)
+        M_total = np.zeros_like(F_total)
+        for ix in beam.intersections:
+            Fi = beam.per_beam_F[ix.element_id]
+            Mi = beam.per_beam_M_at_intersection[ix.element_id]
+            arm = ix.point_arr - centroid
+            F_total += Fi
+            M_total += Mi + np.cross(arm, Fi)
+        for ix in shell.intersections:
+            Fi = shell.per_shell_F[ix.element_id]
+            Mi = shell.per_shell_M_at_midpoint[ix.element_id]
+            arm = ix.chord_midpoint - centroid
+            F_total += Fi
+            M_total += Mi + np.cross(arm, Fi)
+
         return cls(
             spec=spec,
             model_stage=model_stage,
-            F=beam.F,
-            M=beam.M,
-            time=beam.time,
-            centroid=beam.centroid,
+            F=F_total,
+            M=M_total,
+            time=time,
+            centroid=centroid,
             intersections=beam.intersections,
             per_beam_F=dict(beam.per_beam_F),
             per_beam_M_at_intersection=dict(beam.per_beam_M_at_intersection),
+            shell_intersections=shell.intersections,
+            per_shell_F=dict(shell.per_shell_F),
+            per_shell_M_at_midpoint=dict(shell.per_shell_M_at_midpoint),
         )
 
     # ------------------------------------------------------------------ #
@@ -136,17 +206,25 @@ class SectionCut:
 
     @property
     def is_empty(self) -> bool:
-        return len(self.intersections) == 0
+        return (
+            len(self.intersections) == 0
+            and len(self.shell_intersections) == 0
+        )
 
     @property
     def contributing_element_ids(self) -> tuple[int, ...]:
-        return tuple(ix.element_id for ix in self.intersections)
+        """All element ids whose contribution the cut sums up — beams
+        first, then shells, each block sorted by element_id."""
+        beam_ids = [ix.element_id for ix in self.intersections]
+        shell_ids = [ix.element_id for ix in self.shell_intersections]
+        return tuple(beam_ids + shell_ids)
 
     def __repr__(self) -> str:
         label = f", label={self.spec.label!r}" if self.spec.label else ""
+        n_total = len(self.intersections) + len(self.shell_intersections)
         return (
             f"SectionCut(stage={self.model_stage!r}, n_steps={self.n_steps}, "
-            f"n_intersections={len(self.intersections)}, "
+            f"n_intersections={n_total}, "
             f"side={self.spec.side!r}{label})"
         )
 

--- a/src/STKO_to_python/cuts/specs.py
+++ b/src/STKO_to_python/cuts/specs.py
@@ -84,6 +84,15 @@ class SectionCutSpec:
         Optional display label used by plotters.
     name:
         Optional human-readable identifier for logs and on-disk caches.
+    bounding_polygon:
+        Optional convex polygon on ``plane`` restricting the cut to
+        elements whose intersection falls inside it. Each vertex is a
+        ``(x, y, z)`` tuple lying on ``plane`` (within tolerance). At
+        least three vertices required. Useful when the recorded
+        selection sets don't pre-filter to the region of interest —
+        e.g. cut just the left half of a wall by passing a polygon on
+        the cut plane covering only that half. Non-convex polygons are
+        not supported in v1.6 (validated away at construction).
     """
 
     plane: Plane
@@ -93,6 +102,7 @@ class SectionCutSpec:
     side: Side = "positive"
     label: str | None = None
     name: str | None = None
+    bounding_polygon: tuple[tuple[float, float, float], ...] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.plane, Plane):
@@ -119,6 +129,10 @@ class SectionCutSpec:
             object.__setattr__(self, "element_ids", tup)
         if self.selection_set_id is not None:
             object.__setattr__(self, "selection_set_id", int(self.selection_set_id))
+        if self.bounding_polygon is not None:
+            poly = _coerce_polygon(self.bounding_polygon)
+            _validate_bounding_polygon(poly, self.plane)
+            object.__setattr__(self, "bounding_polygon", poly)
 
     @property
     def signed_normal(self) -> np.ndarray:
@@ -260,3 +274,73 @@ def _coerce_int_tuple(
         return tuple(int(x) for x in values)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{label} must contain integers: {exc}") from None
+
+
+def _coerce_polygon(
+    values: Iterable[Iterable[float]] | np.ndarray,
+) -> tuple[tuple[float, float, float], ...]:
+    """Normalise a polygon to a hashable ``tuple[tuple[float, float, float], ...]``.
+
+    Accepts any iterable of length-3 iterables or an ``(M, 3)`` ndarray.
+    """
+    arr = np.asarray(list(values), dtype=float)
+    if arr.ndim != 2 or arr.shape[1] != 3:
+        raise ValueError(
+            f"bounding_polygon must be a sequence of (x, y, z) triples or "
+            f"shape (M, 3); got shape {arr.shape}."
+        )
+    return tuple((float(v[0]), float(v[1]), float(v[2])) for v in arr)
+
+
+def _validate_bounding_polygon(
+    polygon: tuple[tuple[float, float, float], ...],
+    plane: Plane,
+    *,
+    tol: float = 1e-6,
+) -> None:
+    """Enforce the v1.6 contract on a ``bounding_polygon``.
+
+    - At least 3 vertices.
+    - All vertices must lie on ``plane`` (signed distance ≤ ``tol``).
+    - Non-degenerate planar area (after projection to the plane basis).
+    - Convex.
+
+    Non-convex polygons / off-plane vertices / degenerate polygons all
+    raise ``ValueError`` here so the misuse surfaces at construction
+    rather than producing silent zero-area cuts downstream.
+    """
+    if len(polygon) < 3:
+        raise ValueError(
+            f"bounding_polygon must have at least 3 vertices; got {len(polygon)}."
+        )
+    arr = np.asarray(polygon, dtype=float)
+    d = plane.signed_distance(arr)
+    if np.any(np.abs(d) > tol):
+        worst = float(np.max(np.abs(d)))
+        raise ValueError(
+            f"bounding_polygon must lie on the cut plane within tol={tol}; "
+            f"worst off-plane distance is {worst}."
+        )
+    # Lazy import — geometry depends on Plane, and Plane depends on
+    # nothing in geometry, so we keep them in different modules and
+    # import the helpers only where needed.
+    from .geometry import (
+        _plane_basis,
+        _polygon_signed_area_2d,
+        _project_to_plane_basis,
+        is_convex_2d,
+    )
+    e1, e2 = _plane_basis(plane)
+    poly_2d = _project_to_plane_basis(arr, plane, basis=(e1, e2))
+    area = abs(_polygon_signed_area_2d(poly_2d))
+    if area < tol:
+        raise ValueError(
+            f"bounding_polygon is degenerate (planar area {area} ≈ 0). "
+            "All vertices may be collinear or coincident."
+        )
+    if not is_convex_2d(poly_2d):
+        raise ValueError(
+            "bounding_polygon must be convex (Cyrus-Beck clipping in "
+            "v1.6 assumes convexity). For non-convex regions, decompose "
+            "into convex sub-polygons and call section_cut() per part."
+        )

--- a/tests/unit/cuts/test_bounding_polygon.py
+++ b/tests/unit/cuts/test_bounding_polygon.py
@@ -1,0 +1,216 @@
+"""Integration tests for the ``bounding_polygon`` feature added in v1.6.
+
+The polygon validation contract lives in ``test_specs.py``; the
+plane-projection + Cyrus-Beck math lives in ``test_geometry.py``. This
+file glues both together against real cut kernels:
+
+- Beam kernel: an intersection point outside the polygon is dropped.
+- Shell kernel: a chord crossing the polygon boundary is clipped.
+- End-to-end: ``dataset.section_cut(plane=..., bounding_polygon=...)``
+  produces the polygon-restricted cut.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.cuts import Plane, SectionCut, SectionCutSpec
+from STKO_to_python.cuts.kernels import (
+    SHELL_ELEMENT_CLASSES,
+    compute_beam_cut,
+    compute_shell_cut,
+    find_beam_intersections,
+    find_shell_intersections,
+)
+
+
+# ---------------------------------------------------------------------- #
+# Beam side — polygon drops out-of-region intersections
+# ---------------------------------------------------------------------- #
+@pytest.fixture
+def beam_ds(elastic_frame_dispbased_dir) -> MPCODataSet:
+    return MPCODataSet(str(elastic_frame_dispbased_dir), "results", verbose=False)
+
+
+class TestBeamBoundingPolygon:
+    """``elasticFrame_mesh_displacementBased_results`` has two columns:
+    one at x=0 and one at x=5000. A bounding polygon over only the
+    left column should keep exactly one intersection at a horizontal
+    cut through both.
+    """
+
+    def test_unbounded_cut_has_two_intersections(self, beam_ds):
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=1500.0), element_ids=all_eids,
+        )
+        ixs = find_beam_intersections(beam_ds, spec)
+        # Two columns crossing.
+        assert len(ixs) == 2
+        xs = sorted(round(ix.point_global[0]) for ix in ixs)
+        assert xs == [0, 5000]
+
+    def test_polygon_keeps_only_left_column(self, beam_ds):
+        # Square polygon covering x ∈ [-500, 500] on the z=1500 plane.
+        # Column at x=5000 falls outside.
+        poly = ((-500, -500, 1500), (500, -500, 1500),
+                (500, 500, 1500), (-500, 500, 1500))
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=1500.0),
+            element_ids=all_eids,
+            bounding_polygon=poly,
+        )
+        cut = SectionCut.compute(spec, beam_ds, model_stage="MODEL_STAGE[1]")
+        # Only the left column survives.
+        assert len(cut.intersections) == 1
+        ix = cut.intersections[0]
+        assert abs(ix.point_global[0]) < 1.0  # x ≈ 0 (left column)
+
+    def test_polygon_outside_both_columns_returns_empty(self, beam_ds):
+        # Polygon at x ∈ [10000, 11000] — neither column is inside.
+        poly = ((10000, -500, 1500), (11000, -500, 1500),
+                (11000, 500, 1500), (10000, 500, 1500))
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=1500.0),
+            element_ids=all_eids,
+            bounding_polygon=poly,
+        )
+        cut = SectionCut.compute(spec, beam_ds, model_stage="MODEL_STAGE[1]")
+        assert cut.is_empty
+        # F and M have correct shape (0, 3).
+        assert cut.F.shape == (0, 3)
+        assert cut.M.shape == (0, 3)
+
+    def test_polygon_halves_the_cut_force(self, beam_ds):
+        """The unbounded cut carries F_z = +5000 (gravity) split
+        equally between the two columns; the half-plate polygon picks
+        up just one — F_z ≈ +2500.
+        """
+        plane = Plane.horizontal(z=1500.0)
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        full = SectionCut.compute(
+            SectionCutSpec(plane=plane, element_ids=all_eids),
+            beam_ds, model_stage="MODEL_STAGE[1]",
+        )
+        poly = ((-500, -500, 1500), (500, -500, 1500),
+                (500, 500, 1500), (-500, 500, 1500))
+        half = SectionCut.compute(
+            SectionCutSpec(plane=plane, element_ids=all_eids, bounding_polygon=poly),
+            beam_ds, model_stage="MODEL_STAGE[1]",
+        )
+        # Step 0 (time=0.1): total F_z = +5000. Each column carries
+        # half by symmetry (top beam mid-load splits equally) →
+        # half cut F_z ≈ +2500.
+        assert full.F[0, 2] == pytest.approx(5000.0, abs=1e-3)
+        assert half.F[0, 2] == pytest.approx(2500.0, abs=1e-3)
+
+
+# ---------------------------------------------------------------------- #
+# Shell side — polygon clips chords
+# ---------------------------------------------------------------------- #
+@pytest.fixture
+def shell_ds(nl_shell_dir) -> MPCODataSet:
+    return MPCODataSet(str(nl_shell_dir), "Results", verbose=False)
+
+
+@pytest.fixture
+def all_shell_eids(shell_ds) -> tuple[int, ...]:
+    df = shell_ds.elements_info["dataframe"]
+    base = {c for c in SHELL_ELEMENT_CLASSES}
+    is_shell = df["element_type"].map(
+        lambda s: any(c == s.split("-", 1)[-1].split("[", 1)[0] for c in base)
+    )
+    return tuple(int(x) for x in df.loc[is_shell, "element_id"].tolist())
+
+
+class TestShellBoundingPolygon:
+    """Cut at z=2500 through the Test_NLShell wall: the wall spans
+    x ∈ [-485, 735]. A polygon over x ∈ [-1000, 0] should clip the
+    chord of each crossing shell to its left portion.
+    """
+
+    def test_unbounded_cut_picks_up_shells(self, shell_ds, all_shell_eids):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0), element_ids=all_shell_eids,
+        )
+        ixs = find_shell_intersections(shell_ds, spec)
+        assert len(ixs) > 0
+
+    def test_polygon_clips_chords(self, shell_ds, all_shell_eids):
+        # Bounding polygon: large square covering only x in [-1000, 0].
+        poly = ((-1000, -1000, 2500), (0, -1000, 2500),
+                (0, 1000, 2500), (-1000, 1000, 2500))
+        full_spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0), element_ids=all_shell_eids,
+        )
+        clipped_spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+            bounding_polygon=poly,
+        )
+        full = SectionCut.compute(full_spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        clipped = SectionCut.compute(clipped_spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        # Every clipped chord's endpoints must have x ≤ 0.
+        for ix in clipped.shell_intersections:
+            for ep in ix.chord_endpoints_global:
+                assert ep[0] <= 1e-6
+        # Reduced extent ⇒ |F| of the clipped cut is no larger than
+        # the full cut — strictly smaller in any meaningful case.
+        assert np.linalg.norm(clipped.F[0]) <= np.linalg.norm(full.F[0]) + 1e-6
+
+    def test_polygon_outside_returns_empty(self, shell_ds, all_shell_eids):
+        # The Test_NLShell wall is at y=0; a polygon at y ∈ [100, 200]
+        # misses every shell.
+        poly = ((-1000, 100, 2500), (1000, 100, 2500),
+                (1000, 200, 2500), (-1000, 200, 2500))
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+            bounding_polygon=poly,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        assert cut.is_empty
+
+
+# ---------------------------------------------------------------------- #
+# Dataset API surface — inline kwarg threads through
+# ---------------------------------------------------------------------- #
+class TestDatasetAPIBoundingPolygon:
+    def test_inline_kwarg(self, beam_ds):
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        cut = beam_ds.section_cut(
+            plane=Plane.horizontal(z=1500.0),
+            element_ids=all_eids,
+            bounding_polygon=(
+                (-500, -500, 1500), (500, -500, 1500),
+                (500, 500, 1500), (-500, 500, 1500),
+            ),
+            model_stage="MODEL_STAGE[1]",
+        )
+        assert len(cut.intersections) == 1
+
+    def test_spec_form_with_polygon(self, beam_ds):
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=1500.0),
+            element_ids=all_eids,
+            bounding_polygon=(
+                (-500, -500, 1500), (500, -500, 1500),
+                (500, 500, 1500), (-500, 500, 1500),
+            ),
+        )
+        cut = beam_ds.section_cut(spec=spec, model_stage="MODEL_STAGE[1]")
+        assert len(cut.intersections) == 1
+
+    def test_spec_and_inline_polygon_raises(self, beam_ds):
+        all_eids = tuple(beam_ds.elements_info["dataframe"]["element_id"].tolist())
+        spec = SectionCutSpec(plane=Plane.horizontal(z=1500.0), element_ids=all_eids)
+        with pytest.raises(ValueError, match="spec.*alone"):
+            beam_ds.section_cut(
+                spec=spec,
+                bounding_polygon=((0, 0, 1500), (1, 0, 1500), (0, 1, 1500)),
+                model_stage="MODEL_STAGE[1]",
+            )

--- a/tests/unit/cuts/test_geometry.py
+++ b/tests/unit/cuts/test_geometry.py
@@ -1,0 +1,291 @@
+"""Unit tests for STKO_to_python.cuts.geometry — plane projection +
+Cyrus-Beck convex-polygon clipping.
+
+These helpers underpin the ``bounding_polygon`` feature added in v1.6.
+They run without any .mpco fixture — purely synthetic geometry.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.cuts import Plane
+from STKO_to_python.cuts.geometry import (
+    PolygonClipper,
+    _clip_point_inside_2d,
+    _clip_segment_against_convex_polygon_2d,
+    _plane_basis,
+    _polygon_edge_normals,
+    _polygon_signed_area_2d,
+    _project_to_plane_basis,
+    is_convex_2d,
+    prepare_clipper,
+)
+
+
+# ---------------------------------------------------------------------- #
+# Plane basis + projection
+# ---------------------------------------------------------------------- #
+class TestPlaneBasis:
+    def test_orthonormality_horizontal(self):
+        plane = Plane.horizontal(z=0.0)
+        e1, e2 = _plane_basis(plane)
+        # Orthogonal to normal and to each other.
+        assert abs(e1 @ plane.normal_arr) < 1e-12
+        assert abs(e2 @ plane.normal_arr) < 1e-12
+        assert abs(e1 @ e2) < 1e-12
+        # Unit length.
+        assert abs(np.linalg.norm(e1) - 1.0) < 1e-12
+        assert abs(np.linalg.norm(e2) - 1.0) < 1e-12
+
+    def test_orthonormality_oblique(self):
+        plane = Plane.from_three_points((0, 0, 0), (1, 1, 0), (1, 0, 1))
+        e1, e2 = _plane_basis(plane)
+        assert abs(e1 @ plane.normal_arr) < 1e-12
+        assert abs(e2 @ plane.normal_arr) < 1e-12
+        assert abs(e1 @ e2) < 1e-12
+
+    def test_basis_deterministic(self):
+        # Same plane should yield the same basis on repeat call.
+        plane = Plane.horizontal(z=2.5)
+        b1 = _plane_basis(plane)
+        b2 = _plane_basis(plane)
+        np.testing.assert_array_equal(b1[0], b2[0])
+        np.testing.assert_array_equal(b1[1], b2[1])
+
+
+class TestProjectToPlaneBasis:
+    def test_anchor_projects_to_origin(self):
+        plane = Plane.horizontal(z=5.0)
+        anchor_3d = np.array(plane.point)
+        pt_2d = _project_to_plane_basis(anchor_3d, plane)
+        np.testing.assert_allclose(pt_2d, [0.0, 0.0], atol=1e-12)
+
+    def test_batch_shape_preserved(self):
+        plane = Plane.horizontal(z=0.0)
+        pts = np.array([[1, 0, 0], [2, 3, 0], [-1, -2, 0]], dtype=float)
+        proj = _project_to_plane_basis(pts, plane)
+        assert proj.shape == (3, 2)
+
+    def test_scalar_input_returns_1d(self):
+        plane = Plane.horizontal(z=0.0)
+        single = _project_to_plane_basis(np.array([1.0, 2.0, 0.0]), plane)
+        assert single.shape == (2,)
+
+    def test_distances_preserved(self):
+        # Projection must be isometric on the plane.
+        plane = Plane.from_three_points((0, 0, 0), (1, 0, 0), (0, 1, 0))
+        a = np.array([1.0, 0.0, 0.0])
+        b = np.array([0.0, 1.0, 0.0])
+        a2 = _project_to_plane_basis(a, plane)
+        b2 = _project_to_plane_basis(b, plane)
+        dist_3d = float(np.linalg.norm(a - b))
+        dist_2d = float(np.linalg.norm(a2 - b2))
+        assert abs(dist_3d - dist_2d) < 1e-12
+
+
+# ---------------------------------------------------------------------- #
+# Convexity / area / edge normals
+# ---------------------------------------------------------------------- #
+class TestIsConvex2D:
+    def test_ccw_square_convex(self):
+        sq = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+        assert is_convex_2d(sq)
+
+    def test_cw_square_convex(self):
+        sq = np.array([[0, 0], [0, 1], [1, 1], [1, 0]], dtype=float)
+        assert is_convex_2d(sq)
+
+    def test_triangle_convex(self):
+        tri = np.array([[0, 0], [1, 0], [0, 1]], dtype=float)
+        assert is_convex_2d(tri)
+
+    def test_concave_quad_rejected(self):
+        # Arrowhead / dart concave at index 2.
+        dart = np.array([[0, 0], [2, 0], [1, 0.5], [1, 2]], dtype=float)
+        assert not is_convex_2d(dart)
+
+    def test_collinear_extra_vertex_allowed(self):
+        # Convex pentagon with a redundant midpoint vertex on one edge.
+        poly = np.array([[0, 0], [1, 0], [2, 0], [2, 2], [0, 2]], dtype=float)
+        assert is_convex_2d(poly)
+
+
+class TestPolygonSignedArea:
+    def test_unit_square_ccw_area_one(self):
+        sq = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+        assert _polygon_signed_area_2d(sq) == pytest.approx(1.0)
+
+    def test_unit_square_cw_area_neg_one(self):
+        sq = np.array([[0, 0], [0, 1], [1, 1], [1, 0]], dtype=float)
+        assert _polygon_signed_area_2d(sq) == pytest.approx(-1.0)
+
+
+class TestPolygonEdgeNormals:
+    def test_unit_square_ccw_normals_point_inward(self):
+        sq = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+        n = _polygon_edge_normals(sq)
+        # Edge 0 is the bottom; inward = +y.
+        np.testing.assert_allclose(n[0], [0, 1], atol=1e-12)
+        # Edge 1 right; inward = -x.
+        np.testing.assert_allclose(n[1], [-1, 0], atol=1e-12)
+        # Edge 2 top; inward = -y.
+        np.testing.assert_allclose(n[2], [0, -1], atol=1e-12)
+        # Edge 3 left; inward = +x.
+        np.testing.assert_allclose(n[3], [1, 0], atol=1e-12)
+
+    def test_unit_square_cw_normals_also_point_inward(self):
+        sq = np.array([[0, 0], [0, 1], [1, 1], [1, 0]], dtype=float)
+        n = _polygon_edge_normals(sq)
+        # Now edge 0 is the LEFT side; inward = +x.
+        np.testing.assert_allclose(n[0], [1, 0], atol=1e-12)
+
+
+# ---------------------------------------------------------------------- #
+# Point-in-polygon
+# ---------------------------------------------------------------------- #
+class TestClipPointInside2D:
+    @pytest.fixture
+    def square(self):
+        return np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+
+    def test_interior_inside(self, square):
+        assert _clip_point_inside_2d(np.array([0.5, 0.5]), square)
+
+    def test_exterior_outside(self, square):
+        assert not _clip_point_inside_2d(np.array([2.0, 0.5]), square)
+        assert not _clip_point_inside_2d(np.array([-1.0, 0.5]), square)
+        assert not _clip_point_inside_2d(np.array([0.5, 2.0]), square)
+
+    def test_on_edge_counts_as_inside(self, square):
+        assert _clip_point_inside_2d(np.array([0.5, 0.0]), square)
+        assert _clip_point_inside_2d(np.array([1.0, 0.5]), square)
+
+    def test_vertex_counts_as_inside(self, square):
+        assert _clip_point_inside_2d(np.array([0.0, 0.0]), square)
+        assert _clip_point_inside_2d(np.array([1.0, 1.0]), square)
+
+
+# ---------------------------------------------------------------------- #
+# Cyrus-Beck segment clipping
+# ---------------------------------------------------------------------- #
+class TestClipSegment2D:
+    @pytest.fixture
+    def square(self):
+        return np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+
+    def test_segment_through_polygon(self, square):
+        # From outside-left to outside-right at y=0.5.
+        q = _clip_segment_against_convex_polygon_2d(
+            np.array([-1.0, 0.5]), np.array([2.0, 0.5]), square,
+        )
+        assert q is not None
+        q0, q1, t0, t1 = q
+        np.testing.assert_allclose(q0, [0.0, 0.5])
+        np.testing.assert_allclose(q1, [1.0, 0.5])
+        # Parameter values: enter at t=1/3, exit at t=2/3.
+        assert t0 == pytest.approx(1.0 / 3.0)
+        assert t1 == pytest.approx(2.0 / 3.0)
+
+    def test_segment_fully_inside(self, square):
+        q = _clip_segment_against_convex_polygon_2d(
+            np.array([0.2, 0.2]), np.array([0.8, 0.8]), square,
+        )
+        q0, q1, t0, t1 = q
+        np.testing.assert_allclose(q0, [0.2, 0.2])
+        np.testing.assert_allclose(q1, [0.8, 0.8])
+        assert t0 == 0.0 and t1 == 1.0
+
+    def test_segment_fully_outside(self, square):
+        q = _clip_segment_against_convex_polygon_2d(
+            np.array([2.0, 2.0]), np.array([3.0, 3.0]), square,
+        )
+        assert q is None
+
+    def test_segment_starting_inside(self, square):
+        q = _clip_segment_against_convex_polygon_2d(
+            np.array([0.5, 0.5]), np.array([2.0, 0.5]), square,
+        )
+        q0, q1, t0, t1 = q
+        np.testing.assert_allclose(q0, [0.5, 0.5])
+        np.testing.assert_allclose(q1, [1.0, 0.5])
+        assert t0 == 0.0
+
+    def test_segment_parallel_to_edge_outside(self, square):
+        # Segment running along y=2 (above the square) — never enters.
+        q = _clip_segment_against_convex_polygon_2d(
+            np.array([-1.0, 2.0]), np.array([2.0, 2.0]), square,
+        )
+        assert q is None
+
+    def test_segment_grazing_edge(self, square):
+        # Segment along the top edge y=1; trims to that edge.
+        q = _clip_segment_against_convex_polygon_2d(
+            np.array([-1.0, 1.0]), np.array([2.0, 1.0]), square,
+        )
+        # Could be None (degenerate zero-area clip) or the edge itself.
+        # Either is acceptable per the spec; just check it doesn't
+        # produce a segment outside the polygon.
+        if q is not None:
+            q0, q1, _, _ = q
+            assert _clip_point_inside_2d(q0, square, tol=1e-6)
+            assert _clip_point_inside_2d(q1, square, tol=1e-6)
+
+
+# ---------------------------------------------------------------------- #
+# PolygonClipper end-to-end
+# ---------------------------------------------------------------------- #
+class TestPolygonClipper3D:
+    @pytest.fixture
+    def horizontal_clipper(self):
+        plane = Plane.horizontal(z=0.0)
+        square = ((-1, -1, 0), (1, -1, 0), (1, 1, 0), (-1, 1, 0))
+        return prepare_clipper(plane, square)
+
+    def test_clipper_attributes(self, horizontal_clipper):
+        # Polygon projected to (M, 2).
+        assert horizontal_clipper.polygon_2d.shape == (4, 2)
+        # Basis vectors are unit.
+        assert abs(np.linalg.norm(horizontal_clipper.e1) - 1.0) < 1e-12
+        assert abs(np.linalg.norm(horizontal_clipper.e2) - 1.0) < 1e-12
+
+    def test_clipper_point_inside_origin(self, horizontal_clipper):
+        assert horizontal_clipper.point_inside(np.array([0.0, 0.0, 0.0]))
+        assert not horizontal_clipper.point_inside(np.array([2.0, 0.0, 0.0]))
+
+    def test_clipper_segment_3d(self, horizontal_clipper):
+        p0 = np.array([-2.0, 0.0, 0.0])
+        p1 = np.array([2.0, 0.0, 0.0])
+        clipped = horizontal_clipper.clip_segment(p0, p1)
+        assert clipped is not None
+        q0, q1, t0, t1 = clipped
+        np.testing.assert_allclose(q0, [-1.0, 0.0, 0.0], atol=1e-9)
+        np.testing.assert_allclose(q1, [1.0, 0.0, 0.0], atol=1e-9)
+        # Parameter values match the 3-D interpolation:
+        # q = p0 + t (p1 - p0), so q at t=0.25 is x=-1, at t=0.75 is x=1.
+        assert t0 == pytest.approx(0.25)
+        assert t1 == pytest.approx(0.75)
+
+    def test_clipper_segment_misses(self, horizontal_clipper):
+        # Both endpoints in the polygon's exterior on the same side.
+        p0 = np.array([2.0, 0.0, 0.0])
+        p1 = np.array([3.0, 0.0, 0.0])
+        assert horizontal_clipper.clip_segment(p0, p1) is None
+
+    def test_oblique_plane(self):
+        # 45° plane through origin.
+        plane = Plane(point=(0, 0, 0), normal=(1, 0, 1))
+        # Square on that plane: vertices at distances ±1 along two
+        # orthogonal in-plane directions. Pick (0, 1, 0) and
+        # (1, 0, -1)/√2 as orthonormal in-plane axes.
+        sq3 = (
+            (1 / np.sqrt(2), 1, -1 / np.sqrt(2)),
+            (-1 / np.sqrt(2), 1, 1 / np.sqrt(2)),
+            (-1 / np.sqrt(2), -1, 1 / np.sqrt(2)),
+            (1 / np.sqrt(2), -1, -1 / np.sqrt(2)),
+        )
+        clipper = prepare_clipper(plane, sq3)
+        # Origin must be inside the square; (10, 0, -10) lies on the
+        # plane far outside.
+        assert clipper.point_inside(np.array([0.0, 0.0, 0.0]))
+        assert not clipper.point_inside(np.array([10 / np.sqrt(2), 0.0, -10 / np.sqrt(2)]))

--- a/tests/unit/cuts/test_shell_kernel.py
+++ b/tests/unit/cuts/test_shell_kernel.py
@@ -1,0 +1,417 @@
+"""Unit tests for STKO_to_python.cuts.kernels.shell.
+
+Splits into two groups:
+
+- **Pure-math tests** (no .mpco fixture needed) exercising the
+  bilinear / linear sampling weights and the inverse-shape-function
+  helpers used to map chord endpoints to natural coords.
+- **Real-fixture tests** running against ``Test_NLShell`` to verify
+  the geometry phase, the consistency check (Newton's 3rd law), and
+  the side-flip convention.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.cuts import Plane, SectionCut, SectionCutSpec
+from STKO_to_python.cuts.kernels.shell import (
+    SHELL_ELEMENT_CLASSES,
+    _invert_quad_bilinear,
+    _invert_tri_linear,
+    _quad_ip_weights,
+    _sample_shell_section_force,
+    _tri_ip_weights,
+    compute_shell_cut,
+    find_shell_intersections,
+)
+
+
+# ====================================================================== #
+# Pure-math tests
+# ====================================================================== #
+class TestQuadIpWeights:
+    """Bilinear interpolation weights from the 4 Gauss IPs of
+    ASDShellQ4 to an arbitrary (ξ, η). IP coords sit at ±1/√3.
+    """
+
+    def test_partition_of_unity_at_origin(self):
+        w = _quad_ip_weights(0.0, 0.0)
+        assert sum(w) == pytest.approx(1.0)
+
+    def test_unit_response_at_each_ip(self):
+        s = 1.0 / np.sqrt(3.0)
+        # IP order is ξ-fastest: (-s, -s), (+s, -s), (-s, +s), (+s, +s).
+        ips = [(-s, -s), (+s, -s), (-s, +s), (+s, +s)]
+        for k, (xi, eta) in enumerate(ips):
+            w = _quad_ip_weights(xi, eta)
+            expected = np.eye(4)[k]
+            np.testing.assert_allclose(w, expected, atol=1e-12)
+
+    def test_extrapolation_at_corner(self):
+        # ξ=η=+1 is outside the IP envelope; bilinear extrapolation
+        # still produces a valid (sum-to-1) weight set.
+        w = _quad_ip_weights(1.0, 1.0)
+        assert sum(w) == pytest.approx(1.0)
+
+    def test_linear_field_recovered(self):
+        # A field linear in (ξ, η) is exactly reproduced. Build it as
+        # f(ξ, η) = 2 + 3*ξ - 5*η; sample at each IP; interpolate to a
+        # test point; compare against the true value.
+        s = 1.0 / np.sqrt(3.0)
+        ips = np.array([[-s, -s], [+s, -s], [-s, +s], [+s, +s]])
+        true_field = lambda xi, eta: 2.0 + 3.0 * xi - 5.0 * eta
+        ip_values = np.array([true_field(p[0], p[1]) for p in ips])
+        for xi, eta in [(0.0, 0.0), (0.3, -0.2), (0.5, 0.5), (-0.7, 0.7)]:
+            w = _quad_ip_weights(xi, eta)
+            interp = float(w @ ip_values)
+            assert interp == pytest.approx(true_field(xi, eta), abs=1e-12)
+
+
+class TestTriIpWeights:
+    """Linear interpolation from 3 Gauss IPs on the unit triangle."""
+
+    def test_partition_of_unity_at_centroid(self):
+        w = _tri_ip_weights(1.0 / 3.0, 1.0 / 3.0)
+        assert sum(w) == pytest.approx(1.0)
+        # By symmetry the centroid evaluation gives each IP weight 1/3.
+        np.testing.assert_allclose(w, [1 / 3, 1 / 3, 1 / 3], atol=1e-12)
+
+    def test_unit_response_at_each_ip(self):
+        ip_coords = [(1 / 6, 1 / 6), (2 / 3, 1 / 6), (1 / 6, 2 / 3)]
+        for k, (xi, eta) in enumerate(ip_coords):
+            w = _tri_ip_weights(xi, eta)
+            expected = np.eye(3)[k]
+            np.testing.assert_allclose(w, expected, atol=1e-12)
+
+    def test_linear_field_recovered(self):
+        ip_coords = np.array([(1 / 6, 1 / 6), (2 / 3, 1 / 6), (1 / 6, 2 / 3)])
+        true_field = lambda xi, eta: 7.0 - 2.0 * xi + 4.0 * eta
+        ip_values = np.array([true_field(p[0], p[1]) for p in ip_coords])
+        for xi, eta in [(0.3, 0.4), (0.0, 0.0), (0.5, 0.25)]:
+            w = _tri_ip_weights(xi, eta)
+            interp = float(w @ ip_values)
+            assert interp == pytest.approx(true_field(xi, eta), abs=1e-12)
+
+
+class TestInvertShapeFunctions:
+    def test_invert_quad_at_corners(self):
+        # Unit square in the xy plane with z=0.
+        verts = np.array([
+            [-1, -1, 0],   # ↔ (ξ, η) = (-1, -1)
+            [+1, -1, 0],
+            [+1, +1, 0],
+            [-1, +1, 0],
+        ], dtype=float)
+        targets = {
+            (-1, -1): 0,
+            (+1, -1): 1,
+            (+1, +1): 2,
+            (-1, +1): 3,
+        }
+        for natural, node_idx in targets.items():
+            recovered = _invert_quad_bilinear(verts[node_idx], verts)
+            np.testing.assert_allclose(recovered, natural, atol=1e-9)
+
+    def test_invert_quad_at_centroid(self):
+        verts = np.array([
+            [0, 0, 0], [4, 0, 0], [4, 3, 0], [0, 3, 0],
+        ], dtype=float)
+        centroid = verts.mean(axis=0)
+        natural = _invert_quad_bilinear(centroid, verts)
+        np.testing.assert_allclose(natural, [0.0, 0.0], atol=1e-9)
+
+    def test_invert_quad_on_oblique_plane(self):
+        # A quad rotated 45° in 3D — same logical (ξ, η) layout.
+        s = np.sqrt(2) / 2
+        verts = np.array([
+            [-s, 0, -s],
+            [+s, 0, -s],
+            [+s, 0, +s],
+            [-s, 0, +s],
+        ], dtype=float)
+        midpoint = 0.5 * (verts[0] + verts[1])  # should map to (ξ, η) = (0, -1)
+        natural = _invert_quad_bilinear(midpoint, verts)
+        np.testing.assert_allclose(natural, [0.0, -1.0], atol=1e-9)
+
+    def test_invert_tri_at_corners(self):
+        # Unit triangle in xy plane.
+        verts = np.array([
+            [0, 0, 0],   # node 1 ↔ (0, 0)
+            [1, 0, 0],   # node 2 ↔ (1, 0)
+            [0, 1, 0],   # node 3 ↔ (0, 1)
+        ], dtype=float)
+        natural_at_node = {
+            0: (0.0, 0.0),
+            1: (1.0, 0.0),
+            2: (0.0, 1.0),
+        }
+        for node_idx, natural in natural_at_node.items():
+            recovered = _invert_tri_linear(verts[node_idx], verts)
+            np.testing.assert_allclose(recovered, natural, atol=1e-12)
+
+    def test_invert_tri_at_centroid(self):
+        verts = np.array([
+            [0, 0, 0], [2, 0, 0], [0, 3, 0],
+        ], dtype=float)
+        centroid = verts.mean(axis=0)
+        natural = _invert_tri_linear(centroid, verts)
+        np.testing.assert_allclose(natural, [1 / 3, 1 / 3], atol=1e-12)
+
+
+class TestSampleShellSectionForce:
+    """Math sanity for _sample_shell_section_force across IP layouts."""
+
+    def test_quad_sample_recovers_ip_value(self):
+        s = 1.0 / np.sqrt(3.0)
+        # 1 step, 4 IPs, 8 components — distinct values per IP / per
+        # component so a wrong index pulls obvious garbage.
+        sf = np.zeros((1, 4, 8))
+        for k in range(4):
+            for c in range(8):
+                sf[0, k, c] = 10.0 * k + c
+        # Sampling at IP 2 (-s, +s) returns that IP's components.
+        result = _sample_shell_section_force(sf, -s, +s, "ASDShellQ4")
+        np.testing.assert_allclose(result[0], sf[0, 2, :], atol=1e-12)
+
+    def test_tri_sample_recovers_ip_value(self):
+        sf = np.zeros((1, 3, 8))
+        for k in range(3):
+            sf[0, k, :] = [1.0 + k, 2.0 + k, 3.0 + k, 4.0 + k,
+                           5.0 + k, 6.0 + k, 7.0 + k, 8.0 + k]
+        # IP 1 sits at (2/3, 1/6) for the standard 3-pt triangle rule.
+        result = _sample_shell_section_force(sf, 2 / 3, 1 / 6, "ASDShellT3")
+        np.testing.assert_allclose(result[0], sf[0, 1, :], atol=1e-12)
+
+
+# ====================================================================== #
+# Real-fixture tests (Test_NLShell)
+# ====================================================================== #
+@pytest.fixture
+def shell_ds(nl_shell_dir) -> MPCODataSet:
+    return MPCODataSet(str(nl_shell_dir), "Results", verbose=False)
+
+
+@pytest.fixture
+def all_shell_eids(shell_ds) -> tuple[int, ...]:
+    df = shell_ds.elements_info["dataframe"]
+    base = {c for c in SHELL_ELEMENT_CLASSES}
+    is_shell = df["element_type"].map(
+        lambda s: any(c == s.split("-", 1)[-1].split("[", 1)[0] for c in base)
+    )
+    return tuple(int(x) for x in df.loc[is_shell, "element_id"].tolist())
+
+
+class TestShellFixtureRegistry:
+    """The Test_NLShell fixture is supposed to be the canonical
+    multi-class-shell case. Make sure the kernel sees the classes the
+    fixture actually contains.
+    """
+
+    def test_fixture_has_q4_and_t3(self, shell_ds):
+        types = list(shell_ds.unique_element_types)
+        assert any("ASDShellQ4" in t for t in types)
+        assert any("ASDShellT3" in t for t in types)
+
+
+class TestFindShellIntersections:
+    def test_horizontal_cut_crosses_some_shells(self, shell_ds, all_shell_eids):
+        # The wall spans z ∈ [180, 4530]; a cut at z=2500 must hit some.
+        plane = Plane.horizontal(z=2500.0)
+        spec = SectionCutSpec(plane=plane, element_ids=all_shell_eids)
+        ixs = find_shell_intersections(shell_ds, spec)
+        assert len(ixs) > 0
+        # Every intersection chord has nonzero length.
+        for ix in ixs:
+            assert ix.chord_length > 1e-6
+        # Natural coords stay in their parent domain (modest tolerance
+        # for numerical slop at the boundaries).
+        for ix in ixs:
+            (xi_a, eta_a), (xi_b, eta_b) = ix.chord_param_natural
+            for v in (xi_a, eta_a, xi_b, eta_b):
+                assert v == v  # not NaN
+
+    def test_above_top_returns_empty(self, shell_ds, all_shell_eids):
+        # Cut far above the wall — no shell crosses.
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=10_000.0),
+            element_ids=all_shell_eids,
+        )
+        assert find_shell_intersections(shell_ds, spec) == []
+
+    def test_below_base_returns_empty(self, shell_ds, all_shell_eids):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=-1_000.0),
+            element_ids=all_shell_eids,
+        )
+        assert find_shell_intersections(shell_ds, spec) == []
+
+
+class TestShellCutEndToEnd:
+    def test_horizontal_cut_returns_nonzero_force(self, shell_ds, all_shell_eids):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        assert not cut.is_empty
+        # Gravity loading produces a downward total weight above the
+        # cut; F_z on the kept (upper) side from the discarded (lower)
+        # side is positive.
+        assert cut.F[0, 2] > 0
+        # F has the expected shape and finite values.
+        assert cut.F.shape == (cut.n_steps, 3)
+        assert np.all(np.isfinite(cut.F))
+        assert np.all(np.isfinite(cut.M))
+
+    def test_consistency_check_passes_on_real_fixture(self, shell_ds, all_shell_eids):
+        """Newton's 3rd law: positive + negative side cuts sum to zero.
+
+        Independent of the (very complex) Test_NLShell load pattern —
+        any honest kernel must satisfy this by construction.
+        """
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        ok, residual = cut.consistency_check(shell_ds, atol=1e-3)
+        assert ok, f"Residual {np.max(np.abs(residual))} exceeds tol."
+
+    def test_negative_side_flips_resultant(self, shell_ds, all_shell_eids):
+        plane = Plane.horizontal(z=2500.0)
+        pos = SectionCut.compute(
+            SectionCutSpec(plane=plane, element_ids=all_shell_eids, side="positive"),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        neg = SectionCut.compute(
+            SectionCutSpec(plane=plane, element_ids=all_shell_eids, side="negative"),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        np.testing.assert_allclose(neg.F, -pos.F, atol=1e-3)
+        # Moments at the (identical) centroid must also flip.
+        np.testing.assert_allclose(neg.M, -pos.M, atol=1e-3)
+
+    def test_section_force_nonzero_for_some_shell(self, shell_ds, all_shell_eids):
+        """Sanity: the shell section.force reader actually pulls real
+        data — if a column-name typo silently zeroed it, the
+        consistency check above would still pass for the wrong reason.
+        """
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        # At least one shell carries a nonzero per-element force.
+        max_F = max(
+            float(np.max(np.abs(Fi))) for Fi in cut.per_shell_F.values()
+        )
+        assert max_F > 1.0
+
+    def test_repr_includes_shell_count(self, shell_ds, all_shell_eids):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        text = repr(cut)
+        # n_intersections in the repr is beams + shells.
+        n_shells = len(cut.shell_intersections)
+        assert f"n_intersections={n_shells}" in text
+
+
+class TestShellSharedEdgeBehavior:
+    """A cut plane that lands exactly on a mesh row (shared edge
+    between two adjacent shells) used to double-count the cut force —
+    both shells would report the shared edge as their chord. The
+    side-aware filter in :func:`find_shell_intersections` resolves
+    this by keeping only shells whose interior lies on the **discarded**
+    side. These tests lock in that behavior on Test_NLShell, whose
+    wall meshes meet at z=870 (T3 below, Q4 above).
+    """
+
+    def test_on_edge_cut_matches_just_below_for_positive_side(
+        self, shell_ds, all_shell_eids,
+    ):
+        # side='positive' keeps shells with interior on the lower side
+        # of z=870 — i.e., the T3 mesh below. Just-below z (z=869.999)
+        # cuts the same T3 mesh in its interior. F_z must match.
+        z_on = 870.0
+        z_below = 869.999
+        cut_on = SectionCut.compute(
+            SectionCutSpec(plane=Plane.horizontal(z=z_on),
+                           element_ids=all_shell_eids),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        cut_below = SectionCut.compute(
+            SectionCutSpec(plane=Plane.horizontal(z=z_below),
+                           element_ids=all_shell_eids),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        # Force in the wall's axial (z) direction agrees to <1% even
+        # though the chord layouts differ between meshes.
+        rel_err = abs(cut_on.F[0, 2] - cut_below.F[0, 2]) / abs(cut_below.F[0, 2])
+        assert rel_err < 1e-3, (
+            f"on-edge cut F_z={cut_on.F[0, 2]} disagrees with just-below "
+            f"F_z={cut_below.F[0, 2]}; rel_err={rel_err}"
+        )
+
+    def test_on_edge_negative_side_matches_just_above(
+        self, shell_ds, all_shell_eids,
+    ):
+        # side='negative' keeps shells with interior on the upper side
+        # of z=870 — the Q4 mesh above. Just-above z (z=870.001) cuts
+        # the same Q4 mesh in its interior.
+        z_on = 870.0
+        z_above = 870.001
+        cut_on = SectionCut.compute(
+            SectionCutSpec(plane=Plane.horizontal(z=z_on),
+                           element_ids=all_shell_eids,
+                           side="negative"),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        cut_above = SectionCut.compute(
+            SectionCutSpec(plane=Plane.horizontal(z=z_above),
+                           element_ids=all_shell_eids,
+                           side="negative"),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        rel_err = abs(cut_on.F[0, 2] - cut_above.F[0, 2]) / abs(cut_above.F[0, 2])
+        assert rel_err < 1e-3
+
+    def test_no_double_count_at_shared_edge(self, shell_ds, all_shell_eids):
+        """Verify the dedup story: at the shared edge between two
+        meshes, an honest cut force must be finite and on the order
+        of the surrounding cuts — not 2× larger from double-counting.
+        """
+        on = SectionCut.compute(
+            SectionCutSpec(plane=Plane.horizontal(z=870.0),
+                           element_ids=all_shell_eids),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        below = SectionCut.compute(
+            SectionCutSpec(plane=Plane.horizontal(z=869.999),
+                           element_ids=all_shell_eids),
+            shell_ds, model_stage="MODEL_STAGE[1]",
+        )
+        # Ratio should be ≈ 1, never ≈ 2 (the doubled-count signal).
+        ratio = abs(on.F[0, 2]) / abs(below.F[0, 2])
+        assert 0.5 < ratio < 1.5, f"ratio {ratio} suggests double-counting"
+
+
+class TestShellCutAcrossStages:
+    """Make sure the kernel works on every stage of a complex fixture
+    so we don't have a latent bug specific to one stage's analysis_steps.
+    """
+
+    @pytest.mark.parametrize("stage", ["MODEL_STAGE[1]", "MODEL_STAGE[2]", "MODEL_STAGE[3]"])
+    def test_cut_consistency_per_stage(self, shell_ds, all_shell_eids, stage):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage=stage)
+        assert not cut.is_empty
+        ok, _ = cut.consistency_check(shell_ds, atol=1e-3)
+        assert ok, f"Consistency failed for {stage}."

--- a/tests/unit/cuts/test_specs.py
+++ b/tests/unit/cuts/test_specs.py
@@ -92,6 +92,97 @@ class TestSectionCutSpecValidation:
             SectionCutSpec(plane=PLANE, element_ids=("a", "b"))  # type: ignore[arg-type]
 
 
+class TestSectionCutSpecBoundingPolygon:
+    """``bounding_polygon`` was added in v1.6.0; these tests guard the
+    validation contract documented in :class:`SectionCutSpec`."""
+
+    def test_basic_square_polygon_accepted(self):
+        # z = 3 horizontal plane; polygon on it.
+        square = ((0, 0, 3), (1, 0, 3), (1, 1, 3), (0, 1, 3))
+        spec = SectionCutSpec(plane=PLANE, element_ids=(1,), bounding_polygon=square)
+        # Coerced to tuple of float-triples for hashability.
+        assert spec.bounding_polygon == (
+            (0.0, 0.0, 3.0), (1.0, 0.0, 3.0),
+            (1.0, 1.0, 3.0), (0.0, 1.0, 3.0),
+        )
+
+    def test_polygon_accepts_ndarray(self):
+        poly = np.array([[0, 0, 3], [1, 0, 3], [0.5, 1, 3]], dtype=float)
+        spec = SectionCutSpec(plane=PLANE, element_ids=(1,), bounding_polygon=poly)
+        assert spec.bounding_polygon == (
+            (0.0, 0.0, 3.0), (1.0, 0.0, 3.0), (0.5, 1.0, 3.0),
+        )
+
+    def test_too_few_vertices_raises(self):
+        with pytest.raises(ValueError, match="at least 3 vertices"):
+            SectionCutSpec(
+                plane=PLANE, element_ids=(1,),
+                bounding_polygon=((0, 0, 3), (1, 0, 3)),
+            )
+
+    def test_off_plane_vertex_raises(self):
+        with pytest.raises(ValueError, match="on the cut plane"):
+            SectionCutSpec(
+                plane=PLANE, element_ids=(1,),
+                bounding_polygon=((0, 0, 3), (1, 0, 3.5), (0.5, 1, 3)),
+            )
+
+    def test_collinear_polygon_raises(self):
+        # Three collinear points have zero planar area.
+        with pytest.raises(ValueError, match="degenerate"):
+            SectionCutSpec(
+                plane=PLANE, element_ids=(1,),
+                bounding_polygon=((0, 0, 3), (1, 1, 3), (2, 2, 3)),
+            )
+
+    def test_non_convex_polygon_raises(self):
+        # 4-vertex "arrowhead" / dart that's concave at the third vertex.
+        dart = ((0, 0, 3), (2, 0, 3), (1, 0.5, 3), (1, 2, 3))
+        with pytest.raises(ValueError, match="convex"):
+            SectionCutSpec(
+                plane=PLANE, element_ids=(1,),
+                bounding_polygon=dart,
+            )
+
+    def test_bad_shape_raises(self):
+        with pytest.raises(ValueError, match=r"\(M, 3\)|triples"):
+            SectionCutSpec(
+                plane=PLANE, element_ids=(1,),
+                bounding_polygon=((0, 0), (1, 0), (0, 1)),  # length-2 vertices
+            )
+
+    def test_cw_polygon_accepted(self):
+        # Reverse a CCW polygon — convexity check is sign-agnostic.
+        cw_square = ((0, 0, 3), (0, 1, 3), (1, 1, 3), (1, 0, 3))
+        spec = SectionCutSpec(plane=PLANE, element_ids=(1,), bounding_polygon=cw_square)
+        assert len(spec.bounding_polygon) == 4
+
+    def test_polygon_persists_through_hash(self):
+        a = SectionCutSpec(plane=PLANE, element_ids=(1,),
+                           bounding_polygon=((0, 0, 3), (1, 0, 3), (0, 1, 3)))
+        b = SectionCutSpec(plane=PLANE, element_ids=(1,),
+                           bounding_polygon=((0, 0, 3), (1, 0, 3), (0, 1, 3)))
+        assert hash(a) == hash(b)
+        assert a == b
+
+    def test_polygon_inequality_when_vertices_differ(self):
+        a = SectionCutSpec(plane=PLANE, element_ids=(1,),
+                           bounding_polygon=((0, 0, 3), (1, 0, 3), (0, 1, 3)))
+        b = SectionCutSpec(plane=PLANE, element_ids=(1,),
+                           bounding_polygon=((0, 0, 3), (2, 0, 3), (0, 2, 3)))
+        assert a != b
+
+    def test_polygon_pickle_roundtrip(self, tmp_path):
+        spec = SectionCutSpec(
+            plane=PLANE, element_ids=(1,),
+            bounding_polygon=((0, 0, 3), (1, 0, 3), (1, 1, 3), (0, 1, 3)),
+        )
+        path = spec.save_pickle(tmp_path / "spec.pkl")
+        restored = SectionCutSpec.load_pickle(path)
+        assert restored == spec
+        assert restored.bounding_polygon == spec.bounding_polygon
+
+
 class TestSectionCutSpecSignedNormal:
     def test_positive_side_returns_plane_normal(self):
         spec = SectionCutSpec(plane=PLANE, element_ids=(1,), side="positive")


### PR DESCRIPTION
## Summary

- Adds the **shell section-cut kernel** (`ASDShellQ4` / `ASDShellT3`, layered variants transparent) — integrates `section.force` (8 components per IP) along the chord at which the cut plane crosses each shell midsurface via 2-pt Gauss-Legendre line quadrature with bilinear/linear sampling between IPs.
- Adds an optional **convex `bounding_polygon`** on the cut plane (`SectionCutSpec.bounding_polygon=...` and `ds.section_cut(..., bounding_polygon=...)`) that restricts the cut to elements whose intersection falls inside it — useful when the recorded selection sets don't pre-filter to the structural sub-region of interest. Validation rejects off-plane / degenerate / non-convex inputs at construction.
- Composes the beam and shell kernels in `SectionCut.compute`, sharing a `PolygonClipper`, aggregating `(F, M)` about a mixed centroid. New `shell_intersections` / `per_shell_F` / `per_shell_M_at_midpoint` fields on the result.
- Resolves the **shared-edge case** (two adjacent shells reporting the same edge as their chord on a mesh-row cut) with a side-aware geometric filter: only the shell whose interior lies on the *discarded* side contributes. Verified on Test_NLShell's z=870 T3/Q4 interface.
- Bumps version to **1.6.0**; CHANGELOG entry folds in the previously-Unreleased docs + bench arcs.

## Out of scope (v2.0 candidates)
- Solid (continuum) section-cut kernel.
- Non-convex `bounding_polygon` (would need Sutherland-Hodgman instead of convex-only Cyrus-Beck).
- Bounding half-spaces.
- Per-layer / per-fiber breakdown of shell cuts via `material.fiber.stress`.

## Test plan
- [x] **Spec validation** — 11 new tests in `tests/unit/cuts/test_specs.py` for `bounding_polygon` (≥3 vertices, on-plane within tol, non-degenerate, convex, ndarray coercion, CW acceptance, hash/equality, pickle round-trip).
- [x] **Geometry helpers** — 30 tests in `tests/unit/cuts/test_geometry.py` for plane basis, signed area / convexity / inward normals (CCW + CW), point-in-polygon, Cyrus-Beck clipping cases, `PolygonClipper` on horizontal + oblique planes.
- [x] **Shell kernel** — 29 tests in `tests/unit/cuts/test_shell_kernel.py` split into pure-math (interpolation weight identities, inverse shape-function helpers) and real-fixture (Test_NLShell) coverage. Real-fixture: geometry phase, end-to-end consistency (`Newton's 3rd law` residual = 0 at z=2500 across all three model stages), side-flip equivalence, shared-edge side-aware filter at z=870.
- [x] **Bounding polygon integration** — 10 tests in `tests/unit/cuts/test_bounding_polygon.py`: half-plate beam cut returns half the gravity force (5000 → 2500 against `elasticFrame_mesh_displacementBased`), shell chord clipping at the polygon boundary on Test_NLShell, empty-polygon edge cases, dataset API inline form.
- [x] **Regression** — full unit suite green: 996 passed, 4 skipped (all pre-existing fixture skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)