### PR TITLE
Document the v1.6.0 section-cut surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,21 @@ narrowed via a convex polygon on the cut plane.
 
 ### Documentation
 
+- New cookbook recipe
+  [10 — Section cuts through frames with shells](docs/cookbook/10-section-cut-shells.md)
+  walks through the v1.6.0 surface end-to-end: single-elevation cut,
+  `consistency_check` + `compare_to` validators, a `SectionSweep` for
+  story-shear-vs-elevation profiles, a `bounding_polygon` clip
+  restricting the cut to the left half of the wall, spec-driven
+  reuse + pickle, and the shared-edge behavior with a note on
+  consistency at load-discontinuity elevations.
+- New API reference page
+  [Section cuts API](docs/api/section-cuts.md) covers the public
+  surface (`Plane`, `SectionCutSpec`, `SectionCut`, `SectionSweep`,
+  `MultiCutResult`, `DriftSpec`), the dataset entry points, the
+  v1.6.0 additions (shell kernel, shared-edge resolution, bounding
+  polygon), and pulls full mkdocstrings autodoc per class. Wired
+  into the nav under "API reference → Section cuts".
 - `docs/MPCODataSet.md` gains a "Resource management" section showing
   the `with MPCODataSet(...) as ds:` pattern, when it's worth reaching
   for, and how `ds.clear_result_caches()` fits as a finer-grained

--- a/docs/api/section-cuts.md
+++ b/docs/api/section-cuts.md
@@ -1,0 +1,175 @@
+# Section cuts
+
+Compute the resultant `(F, M)` force/moment carried across a plane sliced
+through the discretized model. Beams contribute through the line-element
+internal force at the intersection; shells contribute via a chord
+integral of `section.force` along the intersection chord. The two are
+composed in one pass and aggregated about a shared centroid.
+
+A v1.5.0 surface that v1.6.0 extends with:
+
+- the **shell kernel** (`ASDShellQ4`, `ASDShellT3`; layered variants
+  transparent),
+- an optional **convex bounding polygon** on the cut plane that
+  restricts the cut to a structural sub-region.
+
+For the engineering walkthrough — story shears with shells + a
+bounding-polygon-bounded "left half of the wall" cut — see the
+cookbook recipe [Section cuts through frames with
+shells](../cookbook/10-section-cut-shells.md).
+
+```python
+from STKO_to_python import MPCODataSet
+from STKO_to_python.cuts import Plane
+
+ds = MPCODataSet(r"C:\path\to\Results", "Results", verbose=False)
+cut = ds.section_cut(
+    plane=Plane.horizontal(z=2500.0),
+    element_ids=tuple(ds.elements_info["dataframe"]["element_id"].tolist()),
+    model_stage="MODEL_STAGE[1]",
+)
+print(cut)                       # SectionCut(stage=..., n_intersections=...)
+print(cut.F[0])                  # force at step 0
+print(cut.envelope())            # peak per component
+ok, residual = cut.consistency_check(ds)
+```
+
+---
+
+## Public surface
+
+| Symbol | Module | Purpose |
+|---|---|---|
+| `Plane` | `STKO_to_python.cuts.plane` | Geometric primitive (point + outward unit normal). Constructors: `horizontal`, `vertical`, `from_three_points`, `horizontal_grid`. |
+| `SectionCutSpec` | `STKO_to_python.cuts.specs` | Picklable definition of a cut (plane + filter + side + optional `bounding_polygon`). Hashable by value. |
+| `SectionCut` | `STKO_to_python.cuts.section_cut` | Dataset-bound result with `F`, `M`, `time`, validators, and a `.plot` namespace. |
+| `SectionSweep` | `STKO_to_python.cuts.sweep` | Many planes against one dataset — story-shear-vs-elevation profiles. |
+| `MultiCutResult` | `STKO_to_python.cuts.multi_cut` | One spec, many cases (ground-motion ensembles). |
+| `DriftSpec` | `STKO_to_python.cuts.specs` | Node-pair drift spec — paired here because it's the second "saved cut definition" type. |
+
+The two **dataset entry points** are:
+
+| Call | Returns |
+|---|---|
+| `ds.section_cut(plane=..., ..., model_stage=...)` | `SectionCut` |
+| `ds.section_cut(spec=spec, model_stage=...)` | `SectionCut` |
+| `ds.section_sweep(planes=[...], ..., model_stage=...)` | `SectionSweep` |
+
+The inline form accepts `bounding_polygon=` directly. The spec form
+carries the polygon on the spec. `section_sweep` does **not** accept
+`bounding_polygon` because a single polygon can only lie on a single
+plane — for per-plane polygons, build a list of specs and pass them
+to `SectionSweep.from_specs(...)`.
+
+---
+
+## What ships in v1.6.0
+
+### Shell kernel
+
+For each shell whose midsurface crosses the cut plane, the kernel:
+
+1. computes the chord at which the cut plane crosses the midsurface
+   polygon (3- or 4-node shells in v1.6),
+2. maps each chord endpoint to element natural coords `(ξ, η)`
+   (bilinear inversion for quads, linear for triangles),
+3. integrates `section.force` (8 components per IP — `Fxx, Fyy,
+   Fxy, Mxx, Myy, Mxy, Vxz, Vyz`) along the chord with 2-point
+   Gauss-Legendre quadrature, sampling between IPs via bilinear
+   (Q4) or linear (T3) interpolation,
+4. assembles a per-unit-length traction `(F_local, M_local)` from
+   the section tensors and the in-plane cut normal, rotates to
+   global via `cdata.rotation_matrix(eid)`, and sums.
+
+Supported shell classes (`SHELL_ELEMENT_CLASSES`):
+
+- `ASDShellQ4`, `ASDShellT3` (4-IP and 3-IP standard quadrature)
+- `ShellMITC4`, `ShellNLDKGQ`, `ShellNLDKGT`, `ShellDKGQ`,
+  `ShellDKGT` (decorated names match after stripping the
+  `<classTag>-` prefix)
+
+Layered-shell variants use the same code path — `section.force` is
+already through-thickness-integrated regardless of layer count.
+
+### Shared-edge resolution
+
+When a cut plane lands exactly on a shared edge between two adjacent
+shells (e.g. `z=870` in a stacked wall mesh where T3 elements sit
+below and Q4 sit above), both shells would report that shared edge
+as their chord. The naive sum would double-count.
+
+`find_shell_intersections` resolves this with a side-aware geometric
+filter: **only shells whose interior lies on the discarded side**
+contribute. With `side="positive"` (kept = positive normal side),
+the shell on the negative side reports the chord; with
+`side="negative"`, the shell on the positive side does. The
+``consistency_check`` (positive + negative ≈ 0) holds on either
+side of the load-discontinuity; at the exact discontinuity
+elevation, the two cuts pick up the section.force just above vs
+just below the loads and the check intentionally reflects the load
+jump.
+
+### Bounding polygon
+
+`SectionCutSpec.bounding_polygon` is an optional tuple of `(x, y, z)`
+triples defining a convex polygon **on the cut plane**. The kernel
+clips beam intersection points and shell chords against this polygon
+before computing the resultant. Validation at construction:
+
+- at least 3 vertices,
+- all vertices within `1e-6` of the plane,
+- non-degenerate planar area,
+- convex (Cyrus-Beck clipping assumes convexity).
+
+Useful when the recorded selection sets don't pre-filter to a
+structural sub-region — e.g. cut just the left half of a wall by
+passing a rectangular polygon over that half.
+
+---
+
+## Validators
+
+| Validator | What it checks |
+|---|---|
+| `cut.consistency_check(ds)` | Newton 3rd law — `F_positive + F_negative ≈ 0`. Independent of boundary conditions; works for DRM / PML / explicit dynamics. |
+| `cut.compare_to(other_cut)` | Two parallel cuts at planes between which there is no external load must give the same resultant (moments transferred to a common reference). |
+| `cut.moment_about(point)` | Transfer the moment to a different reference point — what `compare_to` uses internally. |
+
+Both validators return `(ok, residual)` so the caller can inspect the
+per-step residual when a check fails.
+
+---
+
+## SectionCutSpec
+
+::: STKO_to_python.cuts.specs.SectionCutSpec
+
+---
+
+## SectionCut
+
+::: STKO_to_python.cuts.section_cut.SectionCut
+
+---
+
+## Plane
+
+::: STKO_to_python.cuts.plane.Plane
+
+---
+
+## SectionSweep
+
+::: STKO_to_python.cuts.sweep.SectionSweep
+
+---
+
+## MultiCutResult
+
+::: STKO_to_python.cuts.multi_cut.MultiCutResult
+
+---
+
+## DriftSpec
+
+::: STKO_to_python.cuts.specs.DriftSpec

--- a/docs/cookbook/10-section-cut-shells.md
+++ b/docs/cookbook/10-section-cut-shells.md
@@ -1,0 +1,293 @@
+# Section cuts through frames with shells
+
+> Compute the cut force `(F, M)` across a horizontal plane that slices
+> through a structural wall meshed with shells — and use a bounding
+> polygon to restrict the cut to just the left half.
+
+The engineering question is: *I have a model whose lateral system
+involves shell-meshed walls; for each step, what force does each story
+diaphragm transmit?* In OpenSees the answer lives in
+`section.force` on each shell, which records the through-thickness-
+integrated membrane / bending / shear tensors at every integration
+point. v1.6.0 wires this into the same `section_cut` surface used for
+beams.
+
+The fixture used here is `stko_results_examples/Test_NLShell` — a
+multi-partition (4 ranks) wall meshed with `ASDShellT3` below
+`z=870` and `ASDShellQ4` above, with three model stages of analysis.
+
+```python
+from pathlib import Path
+import matplotlib.pyplot as plt
+import numpy as np
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.cuts import Plane, SectionCutSpec, SectionSweep
+
+REPO_ROOT = Path("path/to/STKO_to_python")
+DATASET = REPO_ROOT / "stko_results_examples" / "Test_NLShell"
+STAGE = "MODEL_STAGE[1]"
+
+ds = MPCODataSet(str(DATASET), "Results", verbose=False)
+shell_eids = tuple(ds.elements_info["dataframe"]["element_id"].tolist())
+```
+
+---
+
+## 1. Cut at a single elevation
+
+The simplest form: one `Plane`, one inline call.
+
+```python
+cut = ds.section_cut(
+    plane=Plane.horizontal(z=2500.0),
+    element_ids=shell_eids,
+    model_stage=STAGE,
+)
+print(cut)
+# SectionCut(stage='MODEL_STAGE[1]', n_steps=10, n_intersections=6,
+#            side='positive')
+
+print(cut.F[0])              # [F_x, F_y, F_z] at step 0
+print(cut.envelope())        # peak per component
+```
+
+Returned `SectionCut` fields:
+
+| Field | Shape | Meaning |
+|---|---|---|
+| `cut.F` | `(n_steps, 3)` | Force in **global** axes the discarded side exerts on the kept side. |
+| `cut.M` | `(n_steps, 3)` | Moment about `cut.centroid` in global axes. |
+| `cut.time` | `(n_steps,)` | Time axis. |
+| `cut.centroid` | `(3,)` | Reference point — mean of beam intersection points + shell chord midpoints. |
+| `cut.intersections` | `tuple[BeamIntersection, ...]` | Beam contributions. |
+| `cut.shell_intersections` | `tuple[ShellIntersection, ...]` | Shell contributions. |
+
+For a wall-only model `cut.intersections` is empty and
+`cut.shell_intersections` carries the 6 shells the plane crosses.
+
+---
+
+## 2. Validate the cut
+
+The first thing to do with any new cut is to **check that it's
+internally consistent**. Newton's third law: the cut force on the
+positive side plus the cut force on the negative side must sum to
+zero (with the moments transferred to a common reference). This holds
+for any analysis — gravity-static, dynamic, DRM, even non-classical
+boundary conditions — so it's a clean sanity check.
+
+```python
+ok, residual = cut.consistency_check(ds, atol=1e-3)
+assert ok, f"Cut failed consistency, max residual {residual.max()}"
+```
+
+`residual` is shape `(n_steps, 6)` for the `F + F_neg` and
+`M + M_neg_at_self_centroid` deltas. Use it to debug a failing check.
+
+A second, complementary validator compares two parallel cuts at
+planes between which there's no external load — they must give the
+same resultant (transferred to a common point):
+
+```python
+cut_a = ds.section_cut(plane=Plane.horizontal(z=2500.0), element_ids=shell_eids, model_stage=STAGE)
+cut_b = ds.section_cut(plane=Plane.horizontal(z=2700.0), element_ids=shell_eids, model_stage=STAGE)
+ok, _ = cut_a.compare_to(cut_b, atol=1e-3)
+```
+
+This catches sign / rotation bugs that the per-side check might miss
+when the shells happen to share the same orientation.
+
+---
+
+## 3. Story-shear profile via `SectionSweep`
+
+For "shear vs elevation" the natural object is `SectionSweep` — a
+list of cuts at parallel planes sharing one filter and one model
+stage.
+
+```python
+elevations = np.linspace(500.0, 4000.0, 8)
+planes = [Plane.horizontal(z=z) for z in elevations]
+
+sweep = ds.section_sweep(
+    planes=planes,
+    element_ids=shell_eids,
+    model_stage=STAGE,
+)
+print(sweep)   # SectionSweep(n_planes=8, model_stage='MODEL_STAGE[1]')
+```
+
+A `SectionSweep` is iterable (`for cut in sweep`) and indexable
+(`sweep[3]`). Aggregations:
+
+| Call | Shape |
+|---|---|
+| `sweep.envelope()` | `(n_planes, 18)` — peak `max/min/peak_abs` per component, per plane. |
+| `sweep.to_dataframe("Fx")` | `(n_steps, n_planes)` — wide DataFrame for one component, rows=time. |
+| `sweep.plane_locators("z")` | `(n_planes,)` — z-coords for an elevation axis. |
+
+Plot the peak F_x vs elevation:
+
+```python
+env = sweep.envelope()
+elevs = sweep.plane_locators("z")
+
+fig, ax = plt.subplots()
+ax.plot(env["Fx_peak_abs"], elevs, "o-", lw=1.5)
+ax.set_xlabel("|F_x|  (story shear envelope)")
+ax.set_ylabel("Elevation z")
+plt.show()
+```
+
+---
+
+## 4. Cut only the left half of the wall via `bounding_polygon`
+
+The Test_NLShell wall spans roughly `x ∈ [-485, 735]`. To compute the
+shear carried by only the **left half** without rebuilding selection
+sets in STKO, drop a convex polygon on the cut plane covering the
+left region.
+
+```python
+z_cut = 2500.0
+left_polygon = (
+    (-1000.0, -1000.0, z_cut),
+    (   125.0, -1000.0, z_cut),
+    (   125.0,  1000.0, z_cut),
+    (-1000.0,  1000.0, z_cut),
+)
+
+full = ds.section_cut(
+    plane=Plane.horizontal(z=z_cut),
+    element_ids=shell_eids,
+    model_stage=STAGE,
+)
+left = ds.section_cut(
+    plane=Plane.horizontal(z=z_cut),
+    element_ids=shell_eids,
+    bounding_polygon=left_polygon,
+    model_stage=STAGE,
+)
+
+print(f"Full  n_shells = {len(full.shell_intersections):>2}, F_z[0] = {full.F[0, 2]:.1f}")
+print(f"Left  n_shells = {len(left.shell_intersections):>2}, F_z[0] = {left.F[0, 2]:.1f}")
+```
+
+A few things to note:
+
+- Every vertex of `bounding_polygon` must lie on the cut plane within
+  `1e-6` (validated at `SectionCutSpec` construction).
+- The polygon must be **convex** — Cyrus-Beck clipping assumes
+  convexity. Non-convex regions can be split into convex sub-polygons
+  and the cuts added.
+- Polygons are stored as `tuple[tuple[float, float, float], ...]` so
+  the spec stays hashable and pickle-stable.
+- For shells the bounding polygon clips the chord; for beams it drops
+  any intersection point outside the polygon.
+
+---
+
+## 5. Spec-driven cuts (re-use the same definition across cases)
+
+For multi-case studies — same cut against different ground motions,
+different stages, different parameter values — define the cut once
+as a `SectionCutSpec` and apply it everywhere.
+
+```python
+spec = SectionCutSpec(
+    plane=Plane.horizontal(z=2500.0),
+    element_ids=shell_eids,
+    bounding_polygon=left_polygon,
+    label="Story 6 — left half",
+)
+
+# Reuse across stages:
+cuts_per_stage = {
+    stage: ds.section_cut(spec=spec, model_stage=stage)
+    for stage in ds.model_stages
+}
+
+# Or persist for a separate batch job:
+spec_path = spec.save_pickle("/tmp/story6_left_cut.pkl")
+restored = SectionCutSpec.load_pickle(spec_path)
+assert restored == spec
+```
+
+For multi-case workflows the companion `MultiCutResult` aggregates one
+spec across many datasets / cases:
+
+```python
+from STKO_to_python.cuts import MultiCutResult
+
+datasets = {"GM1": ds1, "GM2": ds2, ...}
+multi = MultiCutResult.from_datasets(datasets, spec, model_stage=STAGE)
+print(multi.peak_over_cases("Fx"))      # Series indexed by case name
+print(multi.envelope_per_case())        # DataFrame: one row per case
+```
+
+---
+
+## 6. Cuts at exact mesh-row elevations
+
+A subtle case worth knowing about: when the cut plane lands **exactly
+on a shared edge** between two adjacent shells (e.g. `z=870` in
+Test_NLShell where the T3 mesh meets the Q4 mesh), both shells would
+report that edge as their chord — the naive sum double-counts.
+
+The kernel resolves this with a **side-aware geometric filter**:
+only shells whose interior lies on the *discarded* side contribute.
+With `side="positive"` (the default; kept = upper) you get the
+section.force from the lower mesh; with `side="negative"` you get
+the section.force from the upper mesh. Both correctly represent the
+cut force from one side or the other.
+
+```python
+on_edge = ds.section_cut(
+    plane=Plane.horizontal(z=870.0),
+    element_ids=shell_eids,
+    model_stage=STAGE,
+)
+just_below = ds.section_cut(
+    plane=Plane.horizontal(z=869.999),
+    element_ids=shell_eids,
+    model_stage=STAGE,
+)
+
+print(on_edge.F[0, 2], just_below.F[0, 2])
+# Match within numerical noise — the on-edge cut picks up the same
+# section.force as just-below for side='positive'.
+```
+
+When the geometry has a **concentrated load at the on-edge elevation**
+(common in real models — node loads applied to the diaphragm row),
+the `consistency_check` *may* fail at that exact elevation. The cut
+just below and just above honestly differ by the magnitude of that
+load. This is correct physical behavior, not a kernel bug — but if
+you need strict per-side cancellation, cut at an elevation `±ε`
+away from the discontinuity.
+
+---
+
+## Variations
+
+- **Multi-stage `(F, M)` series**: drop the `model_stage` kwarg in
+  a loop over `ds.model_stages` and concatenate. Time axes are
+  per-stage; align them by step index, not by absolute time.
+- **Custom moment reference**: `cut.moment_about(point)` transfers
+  the moment to any reference point. Useful when comparing cuts
+  against support-reaction sums from `REACTION`.
+- **Plotting**: `cut.plot.history("Fx")` returns a matplotlib axes
+  with the F_x history; the sweep has `sweep.plot.profile(...)` and
+  `sweep.plot.heatmap(...)`.
+- **Beam + shell mixed**: with no code changes, a model carrying both
+  beams and shells in the same filter produces a single combined
+  `SectionCut`. Beam intersection points and shell chord midpoints
+  go into the same centroid.
+- **Save cuts for downstream tools**: `cut.save_pickle("cut.pkl")`
+  serializes the whole result (no dataset reference, no HDF5 handle)
+  — handy when batch-computing cuts on a cluster and post-processing
+  on a workstation.
+
+For the full API reference of the cuts subpackage see
+[Section cuts API](../api/section-cuts.md).

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -20,6 +20,7 @@ workflows the library is built around. Each tutorial:
 | 7 | [Select by STKO geometry and property name](07-select-by-geometry-and-property.md) | `elasticFrame/QuadFrame_results` | `203-ASDShellQ4` + `5-ElasticBeam3d` |
 | 8 | [Rotate beam-local forces to global](08-rotate-beam-forces-to-global.md) | `elasticFrame/elasticFrame_mesh_results` | `5-ElasticBeam3d` |
 | 9 | [Render beams as 3D extruded solids](09-render-beam-solids.md) | `elasticFrame/QuadFrame_results` | `5-ElasticBeam3d` (+ shell backdrop) |
+| 10 | [Section cuts through frames with shells](10-section-cut-shells.md) | `Test_NLShell` (gitignored — skip-if-absent) | `203-ASDShellQ4` + `204-ASDShellT3` |
 
 For broader tours of the API on a single fixture see the
 [Examples](../examples/usage_tour.md) section. For the reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Query engines: api/query-engines.md
       - Plotting: api/plotting.md
       - MPCOResults: api/mpco-results.md
+      - Section cuts: api/section-cuts.md
       - Canonical names: api/canonical-names.md
   - Usage guides:
       - MPCODataSet: MPCODataSet.md
@@ -108,6 +109,7 @@ nav:
       - Select by STKO geometry and property name: cookbook/07-select-by-geometry-and-property.md
       - Rotate beam-local forces to global: cookbook/08-rotate-beam-forces-to-global.md
       - Render beams as 3D extruded solids: cookbook/09-render-beam-solids.md
+      - Section cuts through frames with shells: cookbook/10-section-cut-shells.md
   - Examples:
       - Usage tour: examples/usage_tour.md
       - Elastic frame: examples/elastic_frame.md


### PR DESCRIPTION
Follow-up to #76. The v1.6.0 implementation merged cleanly but the
cookbook recipe + API reference page were on a follow-up commit that
landed after the merge. This PR brings them in.

## Summary

- New cookbook recipe [10 — Section cuts through frames with shells](https://github.com/nmorabowen/STKO_to_python/blob/guppi/vigilant-lovelace-6877de/docs/cookbook/10-section-cut-shells.md) — end-to-end walkthrough against Test_NLShell: single-elevation cut, `consistency_check` + `compare_to` validators, `SectionSweep` for story-shear-vs-elevation profiles, a `bounding_polygon` "left half of the wall" clip, spec-driven reuse + pickle, and the shared-edge story with a note on consistency at load-discontinuity elevations.
- New API reference page [Section cuts API](https://github.com/nmorabowen/STKO_to_python/blob/guppi/vigilant-lovelace-6877de/docs/api/section-cuts.md) — covers the public surface (`Plane`, `SectionCutSpec`, `SectionCut`, `SectionSweep`, `MultiCutResult`, `DriftSpec`), the dataset entry points, the v1.6.0 additions (shell kernel, shared-edge filter, bounding polygon), and pulls mkdocstrings autodoc per class.
- `docs/cookbook/index.md` lists recipe #10.
- `mkdocs.yml` nav wired under "API reference → Section cuts" and "Cookbook → Section cuts through frames with shells".
- `CHANGELOG.md` documentation subsection extended.

No code changes — docs only.

## Test plan
- [x] `mkdocs build --strict` succeeds (no broken refs, no warnings).
- [x] New pages render (`site/api/section-cuts/`, `site/cookbook/10-section-cut-shells/`).
- [x] `mkdocstrings` autodoc resolves every `:::` directive in the API page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)