### PR TITLE
Add solid section-cut kernel and per-layer/fiber shell views — v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,225 @@ spelled out in [`CLAUDE.md`](CLAUDE.md#versioning-policy):
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-05-12
+
+Extends v1.7 with **higher-order solid section cuts** (20- and 27-node
+hexahedra) and the **per-fiber breakdown for fibered layers** in
+layered shells. Both are additive — the v1.7 surface (beam + shell +
+solid composition, per-layer shell view) is unchanged; v1.8 adds new
+element classes the solid kernel accepts and a new
+`SectionCut.per_fiber_force` accessor.
+
+### Added
+
+- **Higher-order solid section cuts** — `Brick20`, `Brick27`, and the
+  OpenSees aliases `TwentyNodeBrick` / `TwentySevenNodeBrick` join the
+  solid kernel's registry. The geometry phase uses the first 8 nodes
+  (corners) for the plane-vs-polyhedron polygon math — sound because
+  the corners define the element's convex hull and the cut polygon
+  math is on convex polyhedra. Stress sampling dispatches on IP count:
+  8-pt 2×2×2 stays trilinear; 27-pt 3×3×3 uses **triquadratic
+  Lagrange** interpolation over the tensor-product grid. Curvature
+  induced by midpoint / face / centre nodes is ignored at the geometry
+  layer — adequate for any well-conditioned higher-order hex.
+- **27-IP triquadratic sampler** — `_brick_27ip_weights(ξ, η, ζ)`
+  returns the 27 tensor-product Lagrange weights at the 3×3×3
+  Gauss-Legendre IPs (1-D nodes at `±√(3/5)` and 0). Partition of
+  unity, unit response at each IP, and exact reproduction of any
+  separable triquadratic polynomial are pinned by tests.
+- **Per-fiber breakdown for fibered layers** —
+  `SectionCut.per_fiber_force(layer_idx, fiber_idx, dataset)` returns
+  a derivative cut from one fiber inside one through-thickness layer
+  of the layered shells in the cut. Required when a layer is itself a
+  Fiber section; the MPCO recorder then writes columns named
+  `<comp>_f<F>_l<L>_ip<K>`. The fiber's tributary thickness defaults
+  to `t_layer / n_fibers_in_layer` (uniform distribution within the
+  layer); the fiber's z-offset is the centroid of that sub-band.
+  Summing all fibers in a layer recovers the per-layer cut for that
+  layer.
+- **`ds.section_cut(..., per_layer=k, per_fiber=f)`** — both shortcuts
+  resolved together: with only `per_layer` the dataset returns the
+  per-layer view; with both, it returns the per-fiber-in-layer view.
+  `per_fiber` without `per_layer` raises — fibers are indexed within a
+  single layer.
+
+### Added (internal)
+
+- `STKO_to_python.cuts.kernels.solid._brick_27ip_1d_lagrange` and
+  `_brick_27ip_weights` — pure-math triquadratic Lagrange basis at the
+  3-pt Gauss-Legendre nodes and the resulting 27-IP tensor-product
+  weights. Both are independently tested.
+- `_CORNER_NODES_PER_CLASS` — fixed mapping from element class to the
+  number of corner nodes the geometry phase consumes (8 for any hex
+  variant; 4 for the tet). Higher-order classes carry richer
+  connectivity but the geometry sub-frame is always 8 corners.
+- `STKO_to_python.cuts.kernels.shell._fiber_in_layer_column_candidates`,
+  `_read_fiber_in_layer_stress_array`, and
+  `_discover_fiber_count_in_layer` — read `<comp>_f<F>_l<L>_ip<K>`
+  columns under both naming conventions (`sigma11_f<F>_l<L>_ip<K>` and
+  the `nDMaterial`-fallback `UnknownStress(n)_f<F>_l<L>_ip<K>`). The
+  fiber count is discovered from the available columns rather than
+  hard-coded — the same kernel works for sections with arbitrary
+  fiber counts per layer.
+- `STKO_to_python.cuts.kernels.shell.compute_shell_cut_per_fiber` —
+  parallel to `compute_shell_cut_per_layer`. Uses the uniform fiber
+  distribution to compute the fiber's tributary `LayerInfo` (subset
+  of the layer's thickness centred at the fiber's z-band centroid)
+  and delegates to `_shell_cut_per_element_for_layer`.
+
+### Test coverage
+
+- `tests/unit/cuts/test_solid_kernel.py` gains 8 new tests covering
+  the higher-order machinery: registry contents (Brick20 / Brick27 /
+  OpenSees aliases), node-count mapping (20 vs 27 connectivity, 8
+  corners for the geometry phase), 1-D Lagrange basis (unit response,
+  partition of unity), 27-IP weights (partition of unity at origin,
+  unit response at each of the 27 IPs, exact reproduction of a
+  separable triquadratic), dispatch into the 27-IP sampler from
+  `_sample_solid_stress`, and a corner-only plane-vs-polyhedron test
+  on a synthetic 20-node hex.
+- `tests/unit/cuts/test_per_layer_shell.py` gains 8 new tests covering
+  the fiber-in-layer reader (`sigma11_f<F>_l<L>_ip<K>` and
+  `UnknownStress(n)_f<F>_l<L>_ip<K>` variants, missing-layer fallback
+  to zero, fiber count discovery, the `per_fiber` inline-form
+  argument contract, and the "non-fibered layer + `per_fiber_force`"
+  error path).
+
+### Out of scope (v1.9 candidates)
+
+- Curved-edge geometry on higher-order hexes — `Brick20` / `Brick27`
+  midpoints define an actual curved face on the element interior,
+  which the current corner-only polygon math ignores. For
+  well-conditioned models this is an O(midpoint-deviation²) error
+  that doesn't affect resultants meaningfully; for badly-shaped
+  higher-order elements it can.
+- Explicit fiber positions for fibered layers — the v1.8 kernel
+  assumes uniform distribution within a layer. Real fiber positions
+  may be specified in the OpenSees model and would arrive via the
+  `.cdata` or `sections.tcl`.
+- 10-node tetrahedra (`TenNodeTetrahedron` and friends), wedge, and
+  pyramid solids — not in the static catalog.
+
+## [1.7.0] — 2026-05-12
+
+Adds the **solid (continuum) section-cut kernel** and the **per-layer
+breakdown for layered shells**. Both are additive — no breaking changes
+to the public surface. Section cuts now compose contributions from
+beams, shells, and solids in a single `SectionCut.compute` call; the
+per-layer view exposes the through-thickness slice of a layered-shell
+cut.
+
+### Added
+
+- **Solid section-cut kernel** — `compute_solid_cut` integrates
+  `material.stress` (six Voigt components per IP — `σ11, σ22, σ33,
+  σ12, σ23, σ13` in global frame) over the planar polygon clipped from
+  each crossing continuum element. Plane-vs-polyhedron geometry walks
+  the element's edges (12 for an 8-node hex, 6 for a 4-node tet),
+  collects crossings + on-plane vertices, dedupes, and sorts CCW around
+  the plane normal. The polygon is fan-triangulated; each triangle
+  gets a 3-point Gauss rule. Trilinear inversion at each quadrature
+  point pulls (ξ, η, ζ) for stress sampling; the traction
+  `t = σ · n_cut` integrates to the resultant force in global frame.
+  Supports `Brick`, `BbarBrick`, `SSPbrick` (all 8-node hexes) and
+  `FourNodeTetrahedron`.
+- **Side-aware shared-face resolution for solids** — when a cut plane
+  lands on the shared face between two adjacent solids, the same
+  side-aware filter used in the shell kernel skips elements whose
+  interior is entirely on the kept side; avoids double-counts at mesh
+  boundaries.
+- **`SectionCut.compute` composition over three kernels** — beam +
+  shell + solid in one pass, sharing a `PolygonClipper` so the plane
+  basis isn't recomputed. New `solid_intersections`, `per_solid_F`,
+  `per_solid_M_at_centroid` fields on `SectionCut`;
+  `contributing_element_ids` walks all three kernels.
+- **Per-layer breakdown for layered shells** —
+  `SectionCut.per_layer_force(layer_idx, dataset)` returns a
+  derivative cut from only one through-thickness layer of the
+  contributing layered shells. The math replaces the through-thickness
+  integrated `section.force` with the per-layer contribution
+  `(σ_11^(k) · t_k, σ_22^(k) · t_k, σ_12^(k) · t_k, σ_11^(k) · t_k ·
+  z_k, ...)` and reuses the same chord integration + rotation. Summing
+  every layer's contribution recovers the standard cut to numerical
+  tolerance (verified on Test_NLShell, 7-layer wall sections 15/16).
+  `dataset.section_cut(..., per_layer=k)` short-circuits to the
+  per-layer view.
+- **`MPCODataSet.layered_sections`** — lazy property that locates and
+  parses `sections.tcl` beside the recorder output. Returns
+  `{section_id: tuple[LayerInfo, ...]}` where each `LayerInfo` carries
+  `material_id`, `thickness`, and `z_offset` (signed distance from the
+  section midplane). Empty dict when no script is found — the
+  per-layer surface raises a clear error in that case rather than
+  silently zeroing.
+- **`STKO_to_python.model.layered_section_reader`** — new module with
+  `LayerInfo` dataclass, `parse_sections_tcl(path)` parser, and
+  `find_sections_tcl(directory)` locator. Handles Tcl line
+  continuations, multiple section blocks, comments, and the
+  per-section sanity check that the body has 2·n tokens for n declared
+  layers.
+
+### Added (internal)
+
+- `STKO_to_python.cuts.kernels.solid` — `SOLID_ELEMENT_CLASSES`
+  registry, `SolidIntersection` record carrying both the planar
+  polygon in global coords and its natural-coord image,
+  `find_solid_intersections`, `compute_solid_cut`, `SolidCutResult`.
+  Helpers cover plane-vs-polyhedron polygon math, hex trilinear /
+  tet linear inverse maps, Voigt-to-tensor stress expansion, and a
+  Sutherland-Hodgman polygon-vs-polygon clip used when a
+  `bounding_polygon` is set.
+- `STKO_to_python.cuts.kernels.shell.compute_shell_cut_per_layer` —
+  parallel to `compute_shell_cut`. The standard `section.force`
+  8-vector is built from a single layer's stress and geometric weights
+  rather than read from the recorder. Recognises three column-naming
+  conventions for `section.fiber.stress`: explicit
+  `sigma11_l<L>_ip<K>`, explicit `sigma11_f<L>_ip<K>`, and the
+  `nDMaterial`-fallback `UnknownStress(n)_f<L>_ip<K>` mapped to
+  `(σ11, σ22, σ12, σ13, σ23)` per the PlateFiber convention.
+
+### Test coverage
+
+- `tests/unit/cuts/test_solid_kernel.py` — 33 tests split into
+  pure-math and real-fixture groups. Pure-math (23 tests) covers
+  the trilinear IP weights (partition of unity, unit response at each
+  IP, linear-field reproduction), the Voigt-to-tensor mapping
+  (symmetry, traction against unit normal), the brick / tet inverse
+  shape-function maps, and the plane-vs-polyhedron polygon math
+  (horizontal cut → square, diagonal cut → hexagon, face-aligned cut
+  → 4 on-plane vertices, plane missing the polyhedron → None, tet
+  cut → triangle). Real-fixture tests (10 tests, gated on
+  `solid_partition_example`) verify the geometry phase, Newton's-3rd-
+  law consistency, side-flip equivalence, the mixed beam + solid
+  composition through `SectionCut.compute`, and that `per_solid_F`
+  actually pulls real stress data.
+- `tests/unit/cuts/test_per_layer_shell.py` — 21 tests covering
+  the layered Voigt stress reader (single layer, multi-layer
+  disambiguation, multi-IP), the `_sample_layer_stress` IP-weight
+  dispatch on Q4/T3, and the `sections.tcl` parser (parses
+  Test_NLShell's two `LayeredShell` blocks, layer thicknesses,
+  symmetric z_offsets, missing-file error, truncated-body error,
+  comment skipping). Real-fixture tests against `Test_NLShell`
+  validate the dataset's `layered_sections` accessor, the per-layer
+  cut's shape and contents, the **sum-of-layers = full-cut**
+  identity (Σ_k F^(k) ≈ cut.F to ~1% of the cut magnitude across the
+  step axis), error paths for out-of-range layer indices and
+  shell-less cuts, and the `dataset.section_cut(..., per_layer=k)`
+  inline form.
+
+### Out of scope (v1.8 candidates)
+
+- Higher-order solids (Brick20, Brick27 connectivity beyond 8-node
+  hex). The 27-IP catalog entry already exists for 2×2×2 sampling on
+  a Brick8; full Brick27 connectivity is v1.8.
+- Per-fiber stress on layered shells (one level deeper than per-
+  layer). The MPCO format already supports it (the column-name parser
+  handles `_f<F>_l<L>_ip<K>` suffixes); the surface to expose it is
+  v1.8.
+- Non-convex intersection polygons. The current solid kernel assumes
+  convexity, which all standard FE element shapes satisfy.
+- Wedge / pyramid solids — not in the static catalog. Treat as
+  follow-up.
+
 ## [1.6.0] — 2026-05-12
 
 Extends the v1.5.0 section-cut subpackage with the **shell kernel**
@@ -452,7 +671,11 @@ transparently.
 
 See `git log --merges v1.0.0` for the full pre-1.0 history.
 
-[Unreleased]: https://github.com/nmorabowen/STKO_to_python/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/nmorabowen/STKO_to_python/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/nmorabowen/STKO_to_python/compare/v1.1.0...v1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "STKO_to_python"
-version = "1.6.0"
+version = "1.8.0"
 description = "STKO tools for Python"
 readme = "README.md"
 authors = [

--- a/src/STKO_to_python/__init__.py
+++ b/src/STKO_to_python/__init__.py
@@ -11,6 +11,7 @@ from .elements.selector import ElementSelector
 from .elements.result_mask import ResultMask
 from .model.model_info_reader import ModelInfoReader
 from .model.cdata_reader import BeamProfile, CDataReader, ElementInfo
+from .model.layered_section_reader import LayerInfo
 from .model.transforms import quaternion_to_rotation_matrix
 
 from .plotting.plot import Plot
@@ -45,6 +46,7 @@ __all__ = [
     "CData",
     "ElementInfo",
     "BeamProfile",
+    "LayerInfo",
     "quaternion_to_rotation_matrix",
     "Nodes",
     "Elements",

--- a/src/STKO_to_python/core/dataset.py
+++ b/src/STKO_to_python/core/dataset.py
@@ -20,6 +20,28 @@ from ..plotting.plot_settings import PlotSettings
 logger = logging.getLogger(__name__)
 
 
+def _apply_per_layer_per_fiber(cut, dataset, per_layer, per_fiber):
+    """Apply optional ``per_layer`` / ``per_fiber`` short-circuit to a cut.
+
+    Resolution rules:
+
+    - Neither flag set → return the standard cut unchanged.
+    - Only ``per_layer`` → return the per-layer view.
+    - Both flags set → return the per-fiber-in-layer view.
+    - Only ``per_fiber`` (without ``per_layer``) → error.
+    """
+    if per_layer is None and per_fiber is None:
+        return cut
+    if per_fiber is not None and per_layer is None:
+        raise ValueError(
+            "per_fiber requires per_layer to also be specified — fibers are "
+            "indexed within a single layer."
+        )
+    if per_fiber is not None:
+        return cut.per_fiber_force(int(per_layer), int(per_fiber), dataset)
+    return cut.per_layer_force(int(per_layer), dataset)
+
+
 class MPCODataSet:
     
     """
@@ -292,6 +314,29 @@ class MPCODataSet:
         """
         return SelectionSetResolver(self.selection_set)
 
+    @cached_property
+    def layered_sections(self) -> Dict[int, tuple]:
+        """``{section_id -> tuple[LayerInfo, ...]}`` parsed from sections.tcl.
+
+        Lazy. Searches the dataset directory (and its parent) for a
+        ``sections.tcl`` file and parses every ``section LayeredShell``
+        statement. Returns an empty dict if no script is found — the
+        per-layer cut surface
+        (:meth:`SectionCut.per_layer_force`) raises a clear error in
+        that case rather than silently zeroing.
+
+        See :mod:`STKO_to_python.model.layered_section_reader` for the
+        format and :class:`LayerInfo` for the per-layer record.
+        """
+        from ..model.layered_section_reader import (
+            find_sections_tcl,
+            parse_sections_tcl,
+        )
+        path = find_sections_tcl(self.hdf5_directory)
+        if path is None:
+            return {}
+        return parse_sections_tcl(path)
+
     def section_cut(
         self,
         *,
@@ -305,6 +350,8 @@ class MPCODataSet:
         label=None,
         name=None,
         bounding_polygon=None,
+        per_layer: Optional[int] = None,
+        per_fiber: Optional[int] = None,
     ):
         """Compute a section cut against this dataset.
 
@@ -321,6 +368,17 @@ class MPCODataSet:
         inside it — handy when the recorded selection sets don't
         pre-filter to a structural sub-region. See
         :class:`SectionCutSpec` for the validation rules.
+
+        ``per_layer`` (optional, v1.7+) short-circuits to the per-layer
+        view: the returned cut contains only the contribution of the
+        specified through-thickness layer of the layered shells in the
+        filter. Beams and solids are dropped from the per-layer view.
+
+        ``per_fiber`` (optional, v1.8+) further restricts the cut to
+        one fiber within the per-layer view; requires ``per_layer`` to
+        also be set. The fiber's tributary thickness is the layer
+        thickness divided by the layer's fiber count
+        (uniformly distributed).
 
         Returns a :class:`~STKO_to_python.cuts.SectionCut` carrying the
         ``(F, M)`` resultant time series, intersection records, and the
@@ -355,7 +413,8 @@ class MPCODataSet:
                 raise TypeError(
                     f"spec must be a SectionCutSpec, got {type(spec).__name__}."
                 )
-            return SectionCut.compute(spec, self, model_stage=model_stage)
+            cut = SectionCut.compute(spec, self, model_stage=model_stage)
+            return _apply_per_layer_per_fiber(cut, self, per_layer, per_fiber)
 
         if plane is None:
             raise ValueError(
@@ -371,7 +430,8 @@ class MPCODataSet:
             name=name,
             bounding_polygon=bounding_polygon,
         )
-        return SectionCut.compute(new_spec, self, model_stage=model_stage)
+        cut = SectionCut.compute(new_spec, self, model_stage=model_stage)
+        return _apply_per_layer_per_fiber(cut, self, per_layer, per_fiber)
 
     def section_sweep(
         self,

--- a/src/STKO_to_python/cuts/kernels/__init__.py
+++ b/src/STKO_to_python/cuts/kernels/__init__.py
@@ -16,7 +16,16 @@ from .shell import (
     ShellCutResult,
     ShellIntersection,
     compute_shell_cut,
+    compute_shell_cut_per_fiber,
+    compute_shell_cut_per_layer,
     find_shell_intersections,
+)
+from .solid import (
+    SOLID_ELEMENT_CLASSES,
+    SolidCutResult,
+    SolidIntersection,
+    compute_solid_cut,
+    find_solid_intersections,
 )
 
 __all__ = [
@@ -30,4 +39,11 @@ __all__ = [
     "find_shell_intersections",
     "ShellCutResult",
     "compute_shell_cut",
+    "compute_shell_cut_per_layer",
+    "compute_shell_cut_per_fiber",
+    "SOLID_ELEMENT_CLASSES",
+    "SolidIntersection",
+    "find_solid_intersections",
+    "SolidCutResult",
+    "compute_solid_cut",
 ]

--- a/src/STKO_to_python/cuts/kernels/shell.py
+++ b/src/STKO_to_python/cuts/kernels/shell.py
@@ -39,6 +39,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ...model.layered_section_reader import LayerInfo
+
 if TYPE_CHECKING:
     from ..specs import SectionCutSpec
     from ..geometry import PolygonClipper
@@ -722,6 +724,633 @@ def _shell_cut_per_element(
         M_local[:, 0] += weight * m_per_unit_x
         M_local[:, 1] += weight * m_per_unit_y
         # m_per_unit_z is identically zero — skip.
+
+    F_global = F_local @ R.T
+    M_global = M_local @ R.T
+    return F_global, M_global
+
+
+# ---------------------------------------------------------------------- #
+# Per-layer breakdown (v1.7)
+# ---------------------------------------------------------------------- #
+#
+# A layered shell's ``section.fiber.stress`` recorder writes one block
+# per ``(gauss_point × thickness_layer)`` pair. The library's column-name
+# parser flattens those blocks into columns named
+# ``sigma11_l<L>_ip<K>`` (or ``sigma11_f<F>_l<L>_ip<K>`` when there are
+# fibers within a layer). The layer 0 is conventionally the bottom; the
+# top layer is index ``n_layers - 1``.
+#
+# Per-layer math
+# --------------
+# The shell's standard ``section.force`` 8-vector is the through-
+# thickness integral of the layer-wise stress against simple geometry
+# weights:
+#
+#     Fxx = ∫ σ_11 dz  ≈  Σ_k σ_11^(k) · t_k
+#     Mxx = ∫ σ_11 · z dz  ≈  Σ_k σ_11^(k) · t_k · z_offset_k
+#
+# Replacing the standard 8-vector with the kth-layer-only version gives
+# the per-layer contribution to the cut. The rest of the math (chord
+# integration, rotation to global) is identical to
+# :func:`_shell_cut_per_element`.
+
+# Voigt column order used internally by the layered-shell kernel.
+#     0: sigma11   1: sigma22   2: sigma33
+#     3: sigma12   4: sigma23   5: sigma13
+_LAYER_STRESS_SHORTNAMES = ("sigma11", "sigma22", "sigma33", "sigma12", "sigma23", "sigma13")
+
+
+# Layered-shell nDMaterial response — most OpenSees nDMaterials don't
+# tag their stress components with standard codes, so MPCO falls back
+# to ``UnknownStress(n)`` placeholders. The five-component PlateFiber
+# layout is consistent across PlaneStress-wrapped and full PlateFiber
+# materials in the OpenSees source:
+#
+#     UnknownStress     -> sigma11 (in-plane normal x)
+#     UnknownStress(1)  -> sigma22 (in-plane normal y)
+#     UnknownStress(2)  -> sigma12 (in-plane shear)
+#     UnknownStress(3)  -> sigma13 (transverse shear x-z) — often ~0
+#     UnknownStress(4)  -> sigma23 (transverse shear y-z) — often ~0
+#
+# Each tuple entry is ``(column_basename, voigt_position)``.
+_UNKNOWN_STRESS_TO_VOIGT: tuple[tuple[str, int], ...] = (
+    ("UnknownStress", 0),     # sigma11
+    ("UnknownStress(1)", 1),  # sigma22
+    ("UnknownStress(2)", 3),  # sigma12
+    ("UnknownStress(3)", 5),  # sigma13
+    ("UnknownStress(4)", 4),  # sigma23
+)
+
+
+def _layer_column_candidates(
+    layer_idx: int, ip: int, available: set[str],
+) -> list[tuple[str, int]]:
+    """Return ``[(column_name, voigt_position), ...]`` for one
+    (layer, IP) pair.
+
+    Probes the column index in priority order:
+
+    1. Explicit ``sigma11_l<L>_ip<K>`` (per the docs / format
+       conventions §17).
+    2. Explicit ``sigma11_f<L>_ip<K>`` (alternate when MPCO writes the
+       layer axis as a fiber index).
+    3. ``UnknownStress(n)_f<L>_ip<K>`` (fallback for layered shells
+       whose nDMaterial doesn't register response codes — the standard
+       Test_NLShell case).
+
+    Returns only columns that exist in ``available``.
+    """
+    candidates: list[tuple[str, int]] = []
+    # Path 1: explicit sigma<ij>_l<L>_ip<K>.
+    for pos, name in enumerate(_LAYER_STRESS_SHORTNAMES):
+        col = f"{name}_l{layer_idx}_ip{ip}"
+        if col in available:
+            candidates.append((col, pos))
+    if candidates:
+        return candidates
+    # Path 2: explicit sigma<ij>_f<L>_ip<K>.
+    for pos, name in enumerate(_LAYER_STRESS_SHORTNAMES):
+        col = f"{name}_f{layer_idx}_ip{ip}"
+        if col in available:
+            candidates.append((col, pos))
+    if candidates:
+        return candidates
+    # Path 3: UnknownStress(n)_f<L>_ip<K> (the nDMaterial fallback —
+    # most common for Test_NLShell-style layered plate sections).
+    for base, pos in _UNKNOWN_STRESS_TO_VOIGT:
+        col = f"{base}_f{layer_idx}_ip{ip}"
+        if col in available:
+            candidates.append((col, pos))
+    return candidates
+
+
+def _fiber_in_layer_column_candidates(
+    fiber_idx: int, layer_idx: int, ip: int, available: set[str],
+) -> list[tuple[str, int]]:
+    """Return ``[(column_name, voigt_position), ...]`` for one
+    (fiber, layer, IP) triple.
+
+    Probes the column index in priority order:
+
+    1. Explicit ``sigma11_f<F>_l<L>_ip<K>``.
+    2. ``UnknownStress(n)_f<F>_l<L>_ip<K>`` (nDMaterial fallback).
+    """
+    candidates: list[tuple[str, int]] = []
+    # Path 1: explicit sigma<ij>_f<F>_l<L>_ip<K>.
+    for pos, name in enumerate(_LAYER_STRESS_SHORTNAMES):
+        col = f"{name}_f{fiber_idx}_l{layer_idx}_ip{ip}"
+        if col in available:
+            candidates.append((col, pos))
+    if candidates:
+        return candidates
+    # Path 2: UnknownStress(n)_f<F>_l<L>_ip<K>.
+    for base, pos in _UNKNOWN_STRESS_TO_VOIGT:
+        col = f"{base}_f{fiber_idx}_l{layer_idx}_ip{ip}"
+        if col in available:
+            candidates.append((col, pos))
+    return candidates
+
+
+def _read_fiber_in_layer_stress_array(
+    rows, n_ip: int, layer_idx: int, fiber_idx: int,
+) -> np.ndarray:
+    """Extract a ``(n_steps, n_ip, 6)`` Voigt stress array for one
+    fiber within one layer.
+
+    Recognises ``sigma11_f<F>_l<L>_ip<K>`` and
+    ``UnknownStress(n)_f<F>_l<L>_ip<K>``. Missing components default
+    to zero.
+    """
+    n_steps = rows.shape[0]
+    out = np.zeros((n_steps, n_ip, 6), dtype=float)
+    available = set(rows.columns)
+    for k in range(n_ip):
+        for col, pos in _fiber_in_layer_column_candidates(
+            fiber_idx, layer_idx, k, available,
+        ):
+            out[:, k, pos] = rows[col].to_numpy(dtype=float)
+    return out
+
+
+_FIBER_IN_LAYER_RE = re.compile(
+    r"_f(\d+)_l(\d+)_ip(\d+)$"
+)
+
+
+def _discover_fiber_count_in_layer(columns, layer_idx: int) -> int:
+    """Return the number of distinct fibers in ``layer_idx`` by scanning
+    the available column names for ``_f<F>_l<layer_idx>_ip<K>``
+    patterns.
+
+    Returns 0 when no fiber-in-layer columns exist for the requested
+    layer — the caller treats that as "this layer has no fibers" and
+    raises a clear error.
+    """
+    seen: set[int] = set()
+    for c in columns:
+        m = _FIBER_IN_LAYER_RE.search(str(c))
+        if m is None:
+            continue
+        f_idx = int(m.group(1))
+        l_idx = int(m.group(2))
+        if l_idx == int(layer_idx):
+            seen.add(f_idx)
+    return len(seen)
+
+
+def _read_layer_stress_array(
+    rows, n_ip: int, layer_idx: int,
+) -> np.ndarray:
+    """Extract a ``(n_steps, n_ip, 6)`` Voigt stress array for one layer.
+
+    Recognises three column conventions (see
+    :func:`_layer_column_candidates`):
+
+    - ``sigma11_l<L>_ip<K>`` — explicit ``_l<L>_`` layer index with
+      named stress shortnames (per the format-conventions doc).
+    - ``sigma11_f<L>_ip<K>`` — explicit ``_f<L>_`` index when MPCO
+      treats the layer axis as a fiber axis.
+    - ``UnknownStress(n)_f<L>_ip<K>`` — the ``nDMaterial`` fallback
+      with indexed component names. The mapping to Voigt positions
+      follows the PlateFiber convention (σ11, σ22, σ12, σ13, σ23).
+
+    Missing components default to zero — many materials (e.g. rebar
+    uniaxial wrapped into a layer) only carry σ11.
+    """
+    n_steps = rows.shape[0]
+    out = np.zeros((n_steps, n_ip, 6), dtype=float)
+    available = set(rows.columns)
+    for k in range(n_ip):
+        for col, pos in _layer_column_candidates(layer_idx, k, available):
+            out[:, k, pos] = rows[col].to_numpy(dtype=float)
+    return out
+
+
+def _sample_layer_stress(
+    stress: np.ndarray, xi: float, eta: float, base_type: str,
+) -> np.ndarray:
+    """Sample layer Voigt stress at arbitrary ``(ξ, η)`` on the shell.
+
+    Reuses the standard quad/tri interpolation weights. ``stress``
+    shape ``(n_steps, n_ip, 6)`` → returns ``(n_steps, 6)``.
+    """
+    n_ip = stress.shape[1]
+    if n_ip == 4 and "Q4" in base_type:
+        w = _quad_ip_weights(xi, eta)
+    elif n_ip == 3 and "T3" in base_type:
+        w = _tri_ip_weights(xi, eta)
+    elif n_ip == 1:
+        return stress[:, 0, :].copy()
+    elif n_ip == 4:
+        w = _quad_ip_weights(xi, eta)
+    elif n_ip == 3:
+        w = _tri_ip_weights(xi, eta)
+    else:
+        raise NotImplementedError(
+            f"Shell {base_type!r} has {n_ip} layered IPs; only 1/3/4 IPs "
+            "are supported in v1.7."
+        )
+    return np.einsum("sij,i->sj", stress, w)
+
+
+def _resolve_layer_table(
+    dataset: "MPCODataSet", element_id: int,
+):
+    """Look up the layer table for one element.
+
+    Chain: ``cdata.element_info[eid].physical_property_id ->
+    dataset.layered_sections[section_id]``.
+
+    The two side tables are populated from different files
+    (``.cdata`` for the element-info index, ``sections.tcl`` for the
+    layer geometry); a mismatch surfaces here as ``KeyError`` rather
+    than silently producing zero per-layer forces.
+    """
+    info = dataset.cdata.element_info.get(int(element_id))
+    if info is None:
+        raise KeyError(
+            f"Element {element_id} has no *ELEMENT_INFO record in the "
+            f".cdata sidecar. Per-layer cuts require it to resolve the "
+            f"element's physical_property_id."
+        )
+    section_id = int(info.physical_property_id)
+    layers = dataset.layered_sections.get(section_id)
+    if layers is None:
+        raise KeyError(
+            f"Element {element_id}: physical_property_id={section_id} "
+            "does not match any LayeredShell section parsed from "
+            "sections.tcl. Verify that sections.tcl lives beside the "
+            ".mpco recorder output and that the section id matches the "
+            "STKO physical_property_id."
+        )
+    return layers
+
+
+def compute_shell_cut_per_layer(
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    *,
+    model_stage: str,
+    layer_idx: int,
+    clipper: "PolygonClipper | None" = None,
+) -> "ShellCutResult":
+    """Compute a per-layer slice of the shell section cut.
+
+    The geometry phase is identical to :func:`compute_shell_cut` — same
+    shells, same chords. The resultant phase replaces
+    ``section.force`` with the layer's own contribution to the section
+    force 8-vector::
+
+        Fxx^(k) = σ_11^(k) · t_k
+        Fyy^(k) = σ_22^(k) · t_k
+        Fxy^(k) = σ_12^(k) · t_k
+        Mxx^(k) = σ_11^(k) · t_k · z_offset_k
+        Myy^(k) = σ_22^(k) · t_k · z_offset_k
+        Mxy^(k) = σ_12^(k) · t_k · z_offset_k
+        Vxz^(k) = σ_13^(k) · t_k
+        Vyz^(k) = σ_23^(k) · t_k
+
+    Summing all per-layer cuts must recover the standard cut to
+    numerical tolerance (verified by
+    :meth:`SectionCut.per_layer_force` and its test).
+
+    Parameters
+    ----------
+    layer_idx : int
+        Layer index from 0 (bottom) to ``n_layers - 1`` (top), matching
+        the ordering in ``sections.tcl``.
+
+    Raises
+    ------
+    KeyError
+        If a contributing shell's section can't be resolved (missing
+        ``*ELEMENT_INFO`` or no ``LayeredShell`` definition for its
+        ``physical_property_id``).
+    """
+    if not isinstance(layer_idx, (int, np.integer)) or int(layer_idx) < 0:
+        raise ValueError(f"layer_idx must be a non-negative int, got {layer_idx!r}.")
+    layer_idx = int(layer_idx)
+
+    intersections = find_shell_intersections(dataset, spec, clipper=clipper)
+
+    by_type: dict[str, list[ShellIntersection]] = {}
+    for ix in intersections:
+        by_type.setdefault(ix.element_type, []).append(ix)
+
+    per_shell_F: dict[int, np.ndarray] = {}
+    per_shell_M_at_mid: dict[int, np.ndarray] = {}
+    time: np.ndarray | None = None
+
+    for elem_type, sub in by_type.items():
+        eids = [ix.element_id for ix in sub]
+        er = dataset.elements.get_element_results(
+            results_name="section.fiber.stress",
+            element_type=elem_type,
+            model_stage=model_stage,
+            element_ids=eids,
+        )
+        n_ip = int(er.n_ip) if er.n_ip > 0 else 0
+        if n_ip == 0:
+            raise ValueError(
+                f"Shell {elem_type!r} has no integration points in the "
+                "section.fiber.stress result. The per-layer cut needs "
+                "stress recorded at each in-plane Gauss point; verify "
+                "the recorder writes section.fiber.stress on this class."
+            )
+        base_type = _strip_class_tag(elem_type)
+        for ix in sub:
+            layers = _resolve_layer_table(dataset, ix.element_id)
+            if layer_idx >= len(layers):
+                raise IndexError(
+                    f"layer_idx={layer_idx} out of range for element "
+                    f"{ix.element_id}: section has {len(layers)} layers."
+                )
+            layer = layers[layer_idx]
+            rows = er.df.xs(ix.element_id, level="element_id")
+            layer_stress = _read_layer_stress_array(rows, n_ip, layer_idx)
+            F, M = _shell_cut_per_element_for_layer(
+                layer_stress, layer, ix, dataset, spec, base_type,
+            )
+            per_shell_F[ix.element_id] = F
+            per_shell_M_at_mid[ix.element_id] = M
+        if time is None:
+            time = np.asarray(er.time, dtype=float)
+
+    if not intersections or time is None:
+        return ShellCutResult(
+            F=np.zeros((0, 3)),
+            M=np.zeros((0, 3)),
+            time=np.zeros((0,)),
+            centroid=np.zeros(3),
+            intersections=(),
+        )
+
+    centroid = np.mean(
+        np.stack([ix.chord_midpoint for ix in intersections], axis=0), axis=0
+    )
+    F_total = np.zeros((time.shape[0], 3), dtype=float)
+    M_total = np.zeros_like(F_total)
+    for ix in intersections:
+        Fi = per_shell_F[ix.element_id]
+        Mi = per_shell_M_at_mid[ix.element_id]
+        arm = ix.chord_midpoint - centroid
+        F_total += Fi
+        M_total += Mi + np.cross(arm, Fi)
+
+    return ShellCutResult(
+        F=F_total,
+        M=M_total,
+        time=time,
+        centroid=centroid,
+        intersections=tuple(intersections),
+        per_shell_F=per_shell_F,
+        per_shell_M_at_midpoint=per_shell_M_at_mid,
+    )
+
+
+def compute_shell_cut_per_fiber(
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    *,
+    model_stage: str,
+    layer_idx: int,
+    fiber_idx: int,
+    clipper: "PolygonClipper | None" = None,
+) -> "ShellCutResult":
+    """Compute a per-fiber slice of the shell section cut.
+
+    A layered shell whose layer L is itself a Fiber section produces
+    ``section.fiber.stress`` columns named
+    ``<comp>_f<F>_l<L>_ip<K>``. This kernel reads the F-th fiber's
+    stress within the L-th layer and integrates its contribution to
+    the cut, using the fiber's tributary thickness (defaulted to
+    ``t_layer / n_fibers_in_layer`` for uniform distribution) and its
+    z_offset within the layer.
+
+    Sum-of-fibers identity: summing every fiber's per-fiber cut within
+    a layer recovers that layer's standard per-layer cut, when the
+    fiber distribution is uniform. Layers without fiber decomposition
+    raise — use :func:`compute_shell_cut_per_layer` for those.
+
+    Parameters
+    ----------
+    layer_idx : int
+        Layer index from 0 (bottom) to ``n_layers - 1`` (top).
+    fiber_idx : int
+        Fiber index within the layer, 0 to ``n_fibers_in_layer - 1``.
+
+    Raises
+    ------
+    KeyError
+        If a contributing shell's section can't be resolved.
+    ValueError
+        If the requested layer carries no fiber columns (use
+        :func:`compute_shell_cut_per_layer` instead).
+    IndexError
+        If ``layer_idx`` or ``fiber_idx`` is out of range.
+    """
+    if not isinstance(layer_idx, (int, np.integer)) or int(layer_idx) < 0:
+        raise ValueError(f"layer_idx must be a non-negative int, got {layer_idx!r}.")
+    if not isinstance(fiber_idx, (int, np.integer)) or int(fiber_idx) < 0:
+        raise ValueError(f"fiber_idx must be a non-negative int, got {fiber_idx!r}.")
+    layer_idx = int(layer_idx)
+    fiber_idx = int(fiber_idx)
+
+    intersections = find_shell_intersections(dataset, spec, clipper=clipper)
+
+    by_type: dict[str, list[ShellIntersection]] = {}
+    for ix in intersections:
+        by_type.setdefault(ix.element_type, []).append(ix)
+
+    per_shell_F: dict[int, np.ndarray] = {}
+    per_shell_M_at_mid: dict[int, np.ndarray] = {}
+    time: np.ndarray | None = None
+
+    for elem_type, sub in by_type.items():
+        eids = [ix.element_id for ix in sub]
+        er = dataset.elements.get_element_results(
+            results_name="section.fiber.stress",
+            element_type=elem_type,
+            model_stage=model_stage,
+            element_ids=eids,
+        )
+        n_ip = int(er.n_ip) if er.n_ip > 0 else 0
+        if n_ip == 0:
+            raise ValueError(
+                f"Shell {elem_type!r} has no integration points in the "
+                "section.fiber.stress result."
+            )
+        base_type = _strip_class_tag(elem_type)
+        for ix in sub:
+            layers = _resolve_layer_table(dataset, ix.element_id)
+            if layer_idx >= len(layers):
+                raise IndexError(
+                    f"layer_idx={layer_idx} out of range for element "
+                    f"{ix.element_id}: section has {len(layers)} layers."
+                )
+            layer = layers[layer_idx]
+            rows = er.df.xs(ix.element_id, level="element_id")
+            n_fibers = _discover_fiber_count_in_layer(rows.columns, layer_idx)
+            if n_fibers == 0:
+                raise ValueError(
+                    f"Element {ix.element_id}, layer {layer_idx}: no "
+                    "fiber-in-layer columns (`_f<F>_l<L>_ip<K>`) "
+                    "available. Use compute_shell_cut_per_layer for "
+                    "non-fibered layers."
+                )
+            if fiber_idx >= n_fibers:
+                raise IndexError(
+                    f"fiber_idx={fiber_idx} out of range for element "
+                    f"{ix.element_id} layer {layer_idx}: layer has "
+                    f"{n_fibers} fibers."
+                )
+            fiber_stress = _read_fiber_in_layer_stress_array(
+                rows, n_ip, layer_idx, fiber_idx,
+            )
+            # Uniform fiber distribution within the layer's thickness.
+            # Fiber k of N gets thickness t_layer / N, centred at
+            # z_layer + (k - (N-1)/2) * (t_layer / N).
+            t_fiber = float(layer.thickness) / float(n_fibers)
+            z_layer = float(layer.z_offset)
+            z_fiber = z_layer + (fiber_idx - 0.5 * (n_fibers - 1)) * t_fiber
+            fiber_layer_info = LayerInfo(
+                material_id=int(layer.material_id),
+                thickness=t_fiber,
+                z_offset=z_fiber,
+            )
+            F, M = _shell_cut_per_element_for_layer(
+                fiber_stress, fiber_layer_info, ix, dataset, spec, base_type,
+            )
+            per_shell_F[ix.element_id] = F
+            per_shell_M_at_mid[ix.element_id] = M
+        if time is None:
+            time = np.asarray(er.time, dtype=float)
+
+    if not intersections or time is None:
+        return ShellCutResult(
+            F=np.zeros((0, 3)),
+            M=np.zeros((0, 3)),
+            time=np.zeros((0,)),
+            centroid=np.zeros(3),
+            intersections=(),
+        )
+
+    centroid = np.mean(
+        np.stack([ix.chord_midpoint for ix in intersections], axis=0), axis=0
+    )
+    F_total = np.zeros((time.shape[0], 3), dtype=float)
+    M_total = np.zeros_like(F_total)
+    for ix in intersections:
+        Fi = per_shell_F[ix.element_id]
+        Mi = per_shell_M_at_mid[ix.element_id]
+        arm = ix.chord_midpoint - centroid
+        F_total += Fi
+        M_total += Mi + np.cross(arm, Fi)
+
+    return ShellCutResult(
+        F=F_total,
+        M=M_total,
+        time=time,
+        centroid=centroid,
+        intersections=tuple(intersections),
+        per_shell_F=per_shell_F,
+        per_shell_M_at_midpoint=per_shell_M_at_mid,
+    )
+
+
+def _shell_cut_per_element_for_layer(
+    layer_stress: np.ndarray,
+    layer,
+    intersection: ShellIntersection,
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    base_type: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Integrate one layer's traction along the chord of one shell.
+
+    Parallel to :func:`_shell_cut_per_element` — same chord, same
+    Gauss rule, same cut-normal orientation — but the 8-vector input
+    is built from the layer's Voigt stress, its thickness, and its
+    through-thickness offset rather than the recorded
+    ``section.force``.
+    """
+    chord = intersection.chord_endpoints_arr
+    L = intersection.chord_length
+    p_mid = intersection.chord_midpoint
+
+    n_shell = _midsurface_normal(intersection.midsurface_polygon_global)
+    chord_dir = chord[1] - chord[0]
+    chord_dir /= np.linalg.norm(chord_dir)
+    n_cut_global = np.cross(chord_dir, n_shell)
+    n_cut_norm = float(np.linalg.norm(n_cut_global))
+    if n_cut_norm < 1e-12:
+        return (
+            np.zeros((layer_stress.shape[0], 3)),
+            np.zeros((layer_stress.shape[0], 3)),
+        )
+    n_cut_global /= n_cut_norm
+    n_cut_global = _orient_cut_normal(
+        n_cut_global, intersection.midsurface_polygon_global, p_mid, spec,
+    )
+
+    R = dataset.cdata.rotation_matrix(intersection.element_id)
+    n_cut_local = R.T @ n_cut_global
+    n_x = float(n_cut_local[0])
+    n_y = float(n_cut_local[1])
+
+    gs, gw = _GAUSS_LEGENDRE_2
+    xi_a, eta_a = intersection.chord_param_natural[0]
+    xi_b, eta_b = intersection.chord_param_natural[1]
+    half_L = 0.5 * L
+
+    n_steps = layer_stress.shape[0]
+    F_local = np.zeros((n_steps, 3), dtype=float)
+    M_local = np.zeros((n_steps, 3), dtype=float)
+
+    t_k = float(layer.thickness)
+    z_k = float(layer.z_offset)
+
+    for s, w in zip(gs, gw):
+        alpha = 0.5 * (s + 1.0)
+        xi_g = (1 - alpha) * xi_a + alpha * xi_b
+        eta_g = (1 - alpha) * eta_a + alpha * eta_b
+        sigma = _sample_layer_stress(layer_stress, xi_g, eta_g, base_type)
+        # Voigt order matches _LAYER_STRESS_SHORTNAMES:
+        # (sigma11, sigma22, sigma33, sigma12, sigma23, sigma13)
+        s11 = sigma[:, 0]
+        s22 = sigma[:, 1]
+        # s33 is the through-thickness normal stress — not used in the
+        # shell section-force 8-vector (vanishes in classical plate
+        # theory and isn't part of (Fxx, Fyy, Fxy, ...)).
+        s12 = sigma[:, 3]
+        s23 = sigma[:, 4]
+        s13 = sigma[:, 5]
+        # Build the layer's contribution to the standard 8-vector and
+        # apply the same traction formulas as the full-section kernel:
+        #     Fxx^(k) = s11 * t_k
+        #     Mxx^(k) = s11 * t_k * z_k
+        # ... and so on. Substitute into the per-unit-length traction
+        # formulas.
+        Fxx = s11 * t_k
+        Fyy = s22 * t_k
+        Fxy = s12 * t_k
+        Mxx = s11 * t_k * z_k
+        Myy = s22 * t_k * z_k
+        Mxy = s12 * t_k * z_k
+        Vxz = s13 * t_k
+        Vyz = s23 * t_k
+        f_per_unit_x = Fxx * n_x + Fxy * n_y
+        f_per_unit_y = Fxy * n_x + Fyy * n_y
+        f_per_unit_z = Vxz * n_x + Vyz * n_y
+        m_per_unit_x = Mxx * n_x + Mxy * n_y
+        m_per_unit_y = Mxy * n_x + Myy * n_y
+        weight = w * half_L
+        F_local[:, 0] += weight * f_per_unit_x
+        F_local[:, 1] += weight * f_per_unit_y
+        F_local[:, 2] += weight * f_per_unit_z
+        M_local[:, 0] += weight * m_per_unit_x
+        M_local[:, 1] += weight * m_per_unit_y
 
     F_global = F_local @ R.T
     M_global = M_local @ R.T

--- a/src/STKO_to_python/cuts/kernels/solid.py
+++ b/src/STKO_to_python/cuts/kernels/solid.py
@@ -1,0 +1,1121 @@
+"""Solid (continuum) section-cut kernel — geometry + resultant.
+
+The solid kernel mirrors the beam and shell kernels in shape:
+
+- a registry of solid classes the kernel knows how to handle,
+- a :class:`SolidIntersection` record per solid whose volume a plane
+  cuts (the planar intersection polygon plus enough metadata to sample
+  the stress field at quadrature points on the polygon),
+- a :func:`find_solid_intersections` step that computes those records,
+- a :func:`compute_solid_cut` step that reads ``material.stress``,
+  integrates the traction ``t = σ · n_cut`` over each polygon, and
+  aggregates ``(F, M)``.
+
+Why a polygon integration
+-------------------------
+OpenSees continuum recorders write ``material.stress`` per integration
+point — six components per IP in the recorder's frame:
+``σ₁₁, σ₂₂, σ₃₃, σ₁₂, σ₂₃, σ₁₃``. The cut through a continuum element
+produces a planar polygon (a triangle, quadrilateral, pentagon, or
+hexagon for a hex element; a triangle or quadrilateral for a tet);
+the cut force is the surface integral of the traction over that
+polygon. We triangulate the polygon (fan from the first vertex,
+valid because the polygon is convex), place a 3-point Gauss rule on
+each triangle, invert the element's shape function at each quadrature
+point to find natural coords, and sample the stress field by
+trilinear (hex) or linear (tet) interpolation between IPs.
+
+Sign convention
+---------------
+Same as the beam and shell kernels: the cut force is what the
+**discarded** side exerts on the **kept** side. For solids we choose
+the cut normal ``n_cut`` to point from kept → discarded; the traction
+``t = σ · n_cut`` then integrates to the resultant force on the kept
+body. ``spec.side`` and the side-aware filter pick the kept side
+consistently with the beam and shell kernels.
+
+Continuum stress frame
+----------------------
+For OpenSees continuum elements the ``material.stress`` recorder
+writes Cauchy stress in the **global** frame; no rotation is required
+to combine the contribution with beam and shell kernels that emit
+their resultants in global. We do not multiply by an element rotation
+matrix here. If a future element class writes stress in a local frame,
+register it with an explicit rotation hook rather than silently
+guessing.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ...format.shape_functions import _brick_N, _brick_dN
+
+if TYPE_CHECKING:
+    from ..geometry import PolygonClipper
+    from ..specs import SectionCutSpec
+    from ...core.dataset import MPCODataSet
+
+
+# Solid element classes this kernel handles. As in the shell / beam
+# kernels, the MPCO element index carries decorated names like
+# ``"56-Brick"``; we strip the ``<tag>-`` prefix before matching, so
+# both decorated and base names resolve.
+#
+# Supported topologies:
+#   - 8-node trilinear hexahedra (Brick, BbarBrick, SSPbrick)
+#   - 20-node serendipity / 27-node Lagrange hexahedra (Brick20,
+#     TwentyNodeBrick, Brick27, TwentySevenNodeBrick) — geometry phase
+#     uses the 8 corner nodes (OpenSees node order puts the corners
+#     first, midpoint nodes after); stress sampling dispatches on the
+#     IP count (8-pt 2×2×2 → trilinear weights, 27-pt 3×3×3 →
+#     triquadratic Lagrange weights).
+#   - 4-node linear tetrahedra (FourNodeTetrahedron)
+#
+# Wedge / pyramid solids and 10-node tetrahedra are still out of scope
+# (no static catalog entry yet, not enough surveyed in user fixtures).
+SOLID_ELEMENT_CLASSES: tuple[str, ...] = (
+    "Brick",
+    "BbarBrick",
+    "SSPbrick",
+    "Brick20",
+    "Brick27",
+    "TwentyNodeBrick",
+    "TwentySevenNodeBrick",
+    "FourNodeTetrahedron",
+)
+
+
+_TAG_PREFIX_RE = re.compile(r"^\d+-")
+
+
+def _strip_class_tag(decorated: str) -> str:
+    """``'56-Brick' -> 'Brick'``; idempotent on plain names."""
+    return _TAG_PREFIX_RE.sub("", str(decorated))
+
+
+# Number of nodes per element class. Used to distinguish hex variants
+# from tet without parsing the element_type a second time.
+_NODES_PER_CLASS: dict[str, int] = {
+    "Brick": 8,
+    "BbarBrick": 8,
+    "SSPbrick": 8,
+    "Brick20": 20,
+    "TwentyNodeBrick": 20,
+    "Brick27": 27,
+    "TwentySevenNodeBrick": 27,
+    "FourNodeTetrahedron": 4,
+}
+
+
+# Number of nodes treated as the element's "corners" for the geometry
+# phase. Higher-order hexes carry midpoint / face / center nodes after
+# the 8 corners; we slice down to the first 8 for the plane-vs-volume
+# intersection and the trilinear inversion. Curvature induced by the
+# extra nodes is ignored at the cut-polygon level — sound for any
+# well-conditioned higher-order hex where the midpoint nodes don't
+# stray far from the straight-edge midpoint.
+_CORNER_NODES_PER_CLASS: dict[str, int] = {
+    "Brick": 8, "BbarBrick": 8, "SSPbrick": 8,
+    "Brick20": 8, "TwentyNodeBrick": 8,
+    "Brick27": 8, "TwentySevenNodeBrick": 8,
+    "FourNodeTetrahedron": 4,
+}
+
+
+# 8-node hex edges (pairs of node indices, OpenSees Brick connectivity).
+# Bottom face (z = -1): 0-1-2-3; top face (z = +1): 4-5-6-7.
+# Vertical edges connect bottom corner k to top corner k+4.
+_HEX_EDGES: tuple[tuple[int, int], ...] = (
+    # bottom face
+    (0, 1), (1, 2), (2, 3), (3, 0),
+    # top face
+    (4, 5), (5, 6), (6, 7), (7, 4),
+    # vertical connectors
+    (0, 4), (1, 5), (2, 6), (3, 7),
+)
+
+
+# 4-node tet edges (OpenSees FourNodeTetrahedron uses the standard
+# isoparametric layout: node 0 at the origin, nodes 1/2/3 at the unit
+# axes). Six edges total.
+_TET_EDGES: tuple[tuple[int, int], ...] = (
+    (0, 1), (0, 2), (0, 3),
+    (1, 2), (2, 3), (3, 1),
+)
+
+
+# ---------------------------------------------------------------------- #
+# Geometry record
+# ---------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class SolidIntersection:
+    """A single solid element cut by the plane.
+
+    Attributes
+    ----------
+    element_id : int
+    element_type : str
+        Decorated type string (e.g. ``"56-Brick"``).
+    polygon_global : ``(K, 3)`` ndarray
+        Vertices of the planar intersection polygon in global coords,
+        ordered CCW around the plane normal. ``K ∈ {3, 4, 5, 6}`` for a
+        hex; ``K ∈ {3, 4}`` for a tet.
+    polygon_natural : ``(K, 3)`` ndarray
+        Same vertices in element natural coords ``(ξ, η, ζ)``. The
+        per-vertex inversion is well-posed because the vertices lie on
+        the cut plane and inside the parent cube / tet.
+    element_node_coords : ``(n_nodes, 3)`` ndarray
+        Element nodes in global coords, ordered as the connectivity.
+    node_ids : tuple[int, ...]
+    """
+
+    element_id: int
+    element_type: str
+    polygon_global: np.ndarray = field(repr=False)
+    polygon_natural: np.ndarray = field(repr=False)
+    element_node_coords: np.ndarray = field(repr=False)
+    node_ids: tuple[int, ...]
+
+    @property
+    def n_vertices(self) -> int:
+        return int(self.polygon_global.shape[0])
+
+    @property
+    def polygon_centroid(self) -> np.ndarray:
+        """Centroid of the polygon vertices in global coords.
+
+        Used as the reference point for the per-element moment — the
+        analogue of ``point_arr`` on :class:`BeamIntersection` and
+        ``chord_midpoint`` on :class:`ShellIntersection`.
+        """
+        return np.mean(self.polygon_global, axis=0)
+
+    @property
+    def polygon_area(self) -> float:
+        """Area of the planar polygon (positive scalar, in global units).
+
+        Computed from the fan triangulation rooted at the first vertex
+        — valid for any convex polygon.
+        """
+        v = self.polygon_global
+        a = 0.0
+        for i in range(1, v.shape[0] - 1):
+            e1 = v[i] - v[0]
+            e2 = v[i + 1] - v[0]
+            a += 0.5 * float(np.linalg.norm(np.cross(e1, e2)))
+        return a
+
+
+# ---------------------------------------------------------------------- #
+# Plane vs convex polyhedron — extract the planar intersection polygon
+# ---------------------------------------------------------------------- #
+def _classify_signed_distance(
+    d: np.ndarray, tol: float
+) -> np.ndarray:
+    """Classify signed distances as -1 / 0 / +1 with a tolerance band."""
+    sgn = np.zeros_like(d, dtype=np.int8)
+    sgn[d > tol] = 1
+    sgn[d < -tol] = -1
+    return sgn
+
+
+def _plane_polyhedron_polygon(
+    node_coords: np.ndarray,
+    edges: tuple[tuple[int, int], ...],
+    plane_point: np.ndarray,
+    plane_normal: np.ndarray,
+    plane_e1: np.ndarray,
+    plane_e2: np.ndarray,
+    *,
+    tol: float = 1e-9,
+) -> np.ndarray | None:
+    """Compute the planar intersection polygon of a plane vs a convex polyhedron.
+
+    Walks the polyhedron's edges, collects crossing points (and any
+    on-plane vertices), dedupes near-coincident points, and sorts them
+    counter-clockwise around the plane normal using the supplied 2-D
+    plane basis ``(e1, e2)``.
+
+    Returns the polygon as an ``(K, 3)`` ndarray ordered CCW around the
+    plane normal, or ``None`` if the plane misses the polyhedron, only
+    grazes a vertex, or produces a degenerate (fewer than 3 unique
+    point) intersection.
+
+    Parameters
+    ----------
+    node_coords : ``(n_nodes, 3)`` ndarray
+        Polyhedron vertices in global coords.
+    edges : tuple of ``(int, int)``
+        Edge connectivity as index pairs into ``node_coords``.
+    plane_point, plane_normal : ``(3,)`` ndarrays
+        Anchor and unit normal of the cut plane.
+    plane_e1, plane_e2 : ``(3,)`` ndarrays
+        Orthonormal in-plane axes used to sort vertices CCW.
+    tol : float
+        On-plane and dedup tolerance (length units of ``node_coords``).
+    """
+    d = (node_coords - plane_point) @ plane_normal
+    sgn = _classify_signed_distance(d, tol)
+
+    # Polyhedron entirely on one side — no crossing.
+    if np.all(sgn > 0) or np.all(sgn < 0):
+        return None
+
+    pts: list[np.ndarray] = []
+    for i, j in edges:
+        si, sj = int(sgn[i]), int(sgn[j])
+        if si == 0:
+            pts.append(node_coords[i])
+        if sj == 0:
+            pts.append(node_coords[j])
+        if si * sj < 0:
+            di, dj = float(d[i]), float(d[j])
+            t = di / (di - dj)
+            pts.append(node_coords[i] + t * (node_coords[j] - node_coords[i]))
+
+    if not pts:
+        return None
+
+    # Dedupe near-coincident points (on-plane vertices appear at every
+    # adjacent edge they belong to).
+    unique: list[np.ndarray] = []
+    for p in pts:
+        if not any(np.linalg.norm(p - u) <= tol for u in unique):
+            unique.append(p)
+    if len(unique) < 3:
+        return None
+
+    arr = np.stack(unique, axis=0)  # (K, 3)
+    # Project to 2-D using the supplied plane basis and sort CCW around
+    # the polygon centroid. CCW vs CW doesn't matter for the integration
+    # (we'll re-derive orientation independently); we just need a
+    # consistent ordering so the fan triangulation is valid.
+    centroid = arr.mean(axis=0)
+    rel = arr - centroid
+    u = rel @ plane_e1
+    v = rel @ plane_e2
+    angles = np.arctan2(v, u)
+    order = np.argsort(angles)
+    return arr[order]
+
+
+# ---------------------------------------------------------------------- #
+# Inverse shape-function maps
+# ---------------------------------------------------------------------- #
+def _invert_brick_trilinear(
+    p: np.ndarray, node_coords: np.ndarray, *, max_iter: int = 25, tol: float = 1e-10,
+) -> np.ndarray:
+    """Invert the trilinear hex map ``x(ξ, η, ζ) → physical`` for one point.
+
+    Newton iteration starting at ``(0, 0, 0)``. ``node_coords`` is
+    ``(8, 3)`` in OpenSees Brick node order (bottom face CCW at ζ=-1,
+    top face CCW at ζ=+1 — see :data:`STKO_to_python.format.shape_functions._BRICK_NODE_SIGNS`).
+
+    Raises if Newton fails to converge — silent fallback would mask
+    real bugs. The starting point (0, 0, 0) is well inside the parent
+    cube and the trilinear map is well-conditioned for any
+    physically-meaningful hex.
+    """
+    xi = np.zeros(3, dtype=float)
+    for _ in range(max_iter):
+        N = _brick_N(xi[None, :])[0]              # (8,)
+        x_curr = N @ node_coords                  # (3,)
+        residual = x_curr - p
+        if np.linalg.norm(residual) < tol:
+            return xi
+        dN = _brick_dN(xi[None, :])[0]            # (8, 3)
+        J = node_coords.T @ dN                     # (3, 3) — ∂x/∂(ξ, η, ζ)
+        try:
+            step = np.linalg.solve(J, residual)
+        except np.linalg.LinAlgError as exc:
+            raise RuntimeError(
+                f"Singular Jacobian inverting brick trilinear at xi={xi.tolist()}."
+            ) from exc
+        xi -= step
+    raise RuntimeError(
+        f"Brick inversion did not converge after {max_iter} iterations "
+        f"(final residual {np.linalg.norm(residual)}, p={p.tolist()})."
+    )
+
+
+def _invert_tet_linear(
+    p: np.ndarray, node_coords: np.ndarray,
+) -> np.ndarray:
+    """Invert the linear tet map for one point — closed-form 3×3 solve.
+
+    The reference tet has nodes at ``(0,0,0), (1,0,0), (0,1,0), (0,0,1)``
+    and the linear map is
+    ``x(ξ, η, ζ) = v0 + (v1-v0)ξ + (v2-v0)η + (v3-v0)ζ``. So
+    ``[v1-v0 | v2-v0 | v3-v0] · [ξ, η, ζ]ᵀ = p - v0``.
+    """
+    v0, v1, v2, v3 = node_coords
+    A = np.column_stack([v1 - v0, v2 - v0, v3 - v0])  # (3, 3)
+    rhs = p - v0
+    try:
+        return np.linalg.solve(A, rhs)
+    except np.linalg.LinAlgError as exc:
+        raise RuntimeError(
+            f"Singular Jacobian inverting tet linear; node_coords may be "
+            f"degenerate: {node_coords.tolist()}."
+        ) from exc
+
+
+def _natural_coords_of_polygon(
+    polygon_global: np.ndarray, node_coords: np.ndarray, base_type: str,
+) -> np.ndarray:
+    """Compute element natural coords for every polygon vertex.
+
+    Hex: trilinear inversion via Newton. Tet: closed-form 3×3 solve.
+    Returns ``(K, 3)`` in the element's parent domain.
+    """
+    n_nodes = node_coords.shape[0]
+    out = np.empty((polygon_global.shape[0], 3), dtype=float)
+    if n_nodes == 8:
+        for k in range(polygon_global.shape[0]):
+            out[k] = _invert_brick_trilinear(polygon_global[k], node_coords)
+    elif n_nodes == 4:
+        for k in range(polygon_global.shape[0]):
+            out[k] = _invert_tet_linear(polygon_global[k], node_coords)
+    else:
+        raise NotImplementedError(
+            f"Solid class {base_type!r} has {n_nodes} nodes; only 4-node "
+            "tetrahedra and 8-node hexahedra are supported in v1.7."
+        )
+    return out
+
+
+# ---------------------------------------------------------------------- #
+# Geometry phase
+# ---------------------------------------------------------------------- #
+def find_solid_intersections(
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    *,
+    clipper: "PolygonClipper | None" = None,
+) -> list[SolidIntersection]:
+    """Find intersections between ``spec.plane`` and every solid in the filter.
+
+    A solid is skipped without warning when:
+
+    - the plane misses its volume (every vertex on the same side),
+    - the plane only grazes a vertex or edge (fewer than 3 unique
+      crossing points → degenerate polygon),
+    - the spec carries a ``bounding_polygon`` and the intersection
+      polygon is fully outside the polygon — in that case the polygon
+      is intersected against the bounding polygon and only the
+      common region is recorded.
+    - the element's interior is entirely on the kept side (the
+      side-aware filter — mirrors the shell rule, prevents double-
+      counts when two adjacent solids share a face that the plane
+      crosses).
+
+    Parameters
+    ----------
+    clipper : :class:`PolygonClipper`, optional
+        Pre-built clipper for ``spec.bounding_polygon``. The caller
+        builds this once per cut and threads it through to all kernel
+        phases so the plane basis isn't recomputed.
+    """
+    candidate_ids = dataset._selection_resolver.resolve_elements(
+        names=spec.selection_set_name,
+        ids=spec.selection_set_id,
+        explicit_ids=spec.element_ids,
+    )
+    candidate_set = {int(x) for x in candidate_ids}
+
+    df_elems = dataset.elements_info["dataframe"]
+    df_nodes = dataset.nodes_info["dataframe"]
+    node_coord: dict[int, tuple[float, float, float]] = {
+        int(r.node_id): (float(r.x), float(r.y), float(r.z))
+        for r in df_nodes.itertuples(index=False)
+    }
+
+    solid_set = set(SOLID_ELEMENT_CLASSES)
+    is_solid = df_elems["element_type"].map(
+        lambda s: _strip_class_tag(s) in solid_set
+    )
+    in_filter = df_elems["element_id"].isin(candidate_set)
+    solid_rows = df_elems[is_solid & in_filter]
+
+    plane = spec.plane
+    plane_point = np.asarray(plane.point, dtype=float)
+    plane_normal = np.asarray(plane.normal, dtype=float)
+    # Build a 2-D plane basis once for the CCW sort of polygon vertices.
+    # Prefer the clipper's cached basis when one is supplied; otherwise
+    # derive a fresh one. (The two paths give the same orientation when
+    # the same axis-selection rule is used.)
+    if clipper is not None:
+        plane_e1 = np.asarray(clipper.e1, dtype=float)
+        plane_e2 = np.asarray(clipper.e2, dtype=float)
+    else:
+        from ..geometry import _plane_basis
+        plane_e1, plane_e2 = _plane_basis(plane)
+
+    out: list[SolidIntersection] = []
+    for row in solid_rows.itertuples(index=False):
+        node_list = row.node_list
+        base_type = _strip_class_tag(row.element_type)
+        expected_nodes = _NODES_PER_CLASS.get(base_type)
+        if expected_nodes is None or len(node_list) != expected_nodes:
+            # Class is in the registry but the connectivity doesn't
+            # match the expected node count — likely a higher-order
+            # variant we don't support yet. Skip silently.
+            continue
+        try:
+            coords = np.array(
+                [node_coord[int(nid)] for nid in node_list], dtype=float,
+            )
+        except KeyError:
+            # Node missing from the node table — skip rather than
+            # exploding (defensive; real models always include their
+            # connectivity nodes).
+            continue
+
+        # Higher-order hexes carry midpoint / face / center nodes
+        # after the 8 corners. The geometry phase ignores them and
+        # works on the corner sub-frame — sound because the corners
+        # define the element's convex hull, and the cut polygon math
+        # is on convex polyhedra.
+        n_corners = _CORNER_NODES_PER_CLASS[base_type]
+        corner_coords = coords[:n_corners]
+
+        # Side-aware filter mirrors the shell rule. When two adjacent
+        # solids share a face that lies on the cut plane, both would
+        # report that face as their polygon. The cut traction comes
+        # from the DISCARDED side per the standard convention, so we
+        # skip an element whose interior is entirely on the kept side.
+        d_signed = (corner_coords - plane_point) @ spec.signed_normal
+        tol_d = 1e-9
+        if not bool(np.any(d_signed < -tol_d)):
+            continue
+
+        edges = _HEX_EDGES if n_corners == 8 else _TET_EDGES
+        polygon = _plane_polyhedron_polygon(
+            corner_coords, edges, plane_point, plane_normal, plane_e1, plane_e2,
+        )
+        if polygon is None:
+            continue
+
+        # Optional bounding-polygon clipping against the 2-D polygon
+        # carried by the clipper. Reuse the 2-D Cyrus-Beck primitives
+        # by walking the polygon edges and clipping each segment. The
+        # planar intersection-of-two-convex-polygons could be done in
+        # one Sutherland-Hodgman pass, but the polygon we have here is
+        # small (≤ 6 vertices) and the Cyrus-Beck per-edge approach
+        # reuses the existing tested primitive — simpler and adequate.
+        if clipper is not None:
+            polygon = _clip_polygon_against_clipper(polygon, clipper)
+            if polygon is None or polygon.shape[0] < 3:
+                continue
+
+        polygon_natural = _natural_coords_of_polygon(
+            polygon, corner_coords, base_type,
+        )
+        out.append(
+            SolidIntersection(
+                element_id=int(row.element_id),
+                element_type=str(row.element_type),
+                polygon_global=polygon,
+                polygon_natural=polygon_natural,
+                element_node_coords=coords,
+                node_ids=tuple(int(nid) for nid in node_list),
+            )
+        )
+    out.sort(key=lambda s: s.element_id)
+    return out
+
+
+def _clip_polygon_against_clipper(
+    polygon_global: np.ndarray, clipper: "PolygonClipper",
+) -> np.ndarray | None:
+    """Clip the planar intersection polygon against the clipper's
+    bounding polygon, using Sutherland-Hodgman against each
+    half-plane of the convex bounding polygon.
+
+    Both polygons are coplanar (live on ``clipper.plane``), so the
+    clipping is done in 2-D plane coords for numerical robustness, then
+    re-embedded into 3-D from the clipper's origin + basis.
+
+    Returns a CCW-sorted 3-D polygon, or ``None`` when the clipped
+    polygon collapses to fewer than 3 points.
+    """
+    from ..geometry import (
+        _polygon_edge_normals,
+        _project_to_plane_basis,
+        _plane_basis,  # noqa: F401  — type stability across reload
+    )
+
+    pts_2d = _project_to_plane_basis(
+        polygon_global, clipper.plane, basis=(clipper.e1, clipper.e2),
+    )
+    if pts_2d.ndim == 1:
+        pts_2d = pts_2d[None, :]
+
+    polygon_2d = clipper.polygon_2d
+    normals = _polygon_edge_normals(polygon_2d)  # inward-pointing
+
+    # Sutherland-Hodgman against each half-plane of the bounding polygon.
+    output = pts_2d.copy()
+    tol = 1e-12
+    for k in range(polygon_2d.shape[0]):
+        if output.shape[0] == 0:
+            break
+        n_e = normals[k]
+        v_e = polygon_2d[k]
+        new_output: list[np.ndarray] = []
+        m = output.shape[0]
+        for i in range(m):
+            a = output[i]
+            b = output[(i + 1) % m]
+            f_a = float(np.dot(a - v_e, n_e))
+            f_b = float(np.dot(b - v_e, n_e))
+            a_in = f_a >= -tol
+            b_in = f_b >= -tol
+            if a_in:
+                new_output.append(a)
+            if a_in != b_in and abs(f_a - f_b) > tol:
+                t = f_a / (f_a - f_b)
+                cross = a + t * (b - a)
+                new_output.append(cross)
+        output = (
+            np.stack(new_output, axis=0)
+            if new_output
+            else np.zeros((0, 2), dtype=float)
+        )
+
+    if output.shape[0] < 3:
+        return None
+
+    # Dedupe near-coincident points (Sutherland-Hodgman can emit a
+    # duplicate when the clipped polygon touches a corner of the bound).
+    keep: list[np.ndarray] = [output[0]]
+    for p in output[1:]:
+        if np.linalg.norm(p - keep[-1]) > tol * 1e3:
+            keep.append(p)
+    # Wraparound check.
+    if len(keep) >= 2 and np.linalg.norm(keep[0] - keep[-1]) <= tol * 1e3:
+        keep.pop()
+    if len(keep) < 3:
+        return None
+
+    out_2d = np.stack(keep, axis=0)
+    # Re-embed into 3-D.
+    origin = np.asarray(clipper.plane.point, dtype=float)
+    out_3d = origin[None, :] + out_2d[:, 0:1] * clipper.e1[None, :] + out_2d[:, 1:2] * clipper.e2[None, :]
+    # Sutherland-Hodgman preserves orientation, but our caller relies on
+    # CCW-around-the-normal ordering — sort again for safety.
+    centroid = out_3d.mean(axis=0)
+    rel = out_3d - centroid
+    angles = np.arctan2(rel @ clipper.e2, rel @ clipper.e1)
+    order = np.argsort(angles)
+    return out_3d[order]
+
+
+# ---------------------------------------------------------------------- #
+# Stress reading + sampling
+# ---------------------------------------------------------------------- #
+# Index of each continuum ``material.stress`` shortname in the 6-vector
+# we carry through the math. Layout follows OpenSees Voigt-style
+# convention (sym tensor, off-diagonal entries are paired so σᵢⱼ for
+# i != j appears once).
+_SOLID_STRESS_POSITIONS: dict[str, int] = {
+    "sigma11": 0,  # σ_xx in element / global frame
+    "sigma22": 1,  # σ_yy
+    "sigma33": 2,  # σ_zz
+    "sigma12": 3,  # σ_xy
+    "sigma23": 4,  # σ_yz
+    "sigma13": 5,  # σ_xz
+}
+
+
+def _read_solid_stress_array(rows, n_ip: int) -> np.ndarray:
+    """Extract a ``(n_steps, n_ip, 6)`` array from a material.stress DataFrame.
+
+    Columns are ``<shortname>_ip<k>``. Missing components default to
+    zero; they shouldn't ever be missing for a continuum recorder but
+    treating absence as zero matches the shell kernel's defensive
+    posture.
+    """
+    n_steps = rows.shape[0]
+    out = np.zeros((n_steps, n_ip, 6), dtype=float)
+    available = set(rows.columns)
+    for k in range(n_ip):
+        for shortname, pos in _SOLID_STRESS_POSITIONS.items():
+            col = f"{shortname}_ip{k}"
+            if col in available:
+                out[:, k, pos] = rows[col].to_numpy(dtype=float)
+    return out
+
+
+def _stress_voigt_to_tensor(s: np.ndarray) -> np.ndarray:
+    """Expand ``(..., 6)`` Voigt stress to a symmetric ``(..., 3, 3)`` tensor.
+
+    Mapping matches :data:`_SOLID_STRESS_POSITIONS`:
+
+        σ = [[s00, s03, s05],
+             [s03, s01, s04],
+             [s05, s04, s02]]
+    """
+    out = np.empty(s.shape[:-1] + (3, 3), dtype=float)
+    out[..., 0, 0] = s[..., 0]
+    out[..., 1, 1] = s[..., 1]
+    out[..., 2, 2] = s[..., 2]
+    out[..., 0, 1] = s[..., 3]
+    out[..., 1, 0] = s[..., 3]
+    out[..., 1, 2] = s[..., 4]
+    out[..., 2, 1] = s[..., 4]
+    out[..., 0, 2] = s[..., 5]
+    out[..., 2, 0] = s[..., 5]
+    return out
+
+
+# 8-IP 2×2×2 Gauss-Legendre — IPs at (±s, ±s, ±s), s = 1/√3.
+# OpenSees enumerates ξ-fastest, then η, then ζ (matches
+# :func:`STKO_to_python.format.gauss_points.tensor_product_3d`).
+_BRICK_8IP_S = 1.0 / np.sqrt(3.0)
+_BRICK_8IP_SIGNS = np.array(
+    [
+        [-1, -1, -1],
+        [+1, -1, -1],
+        [-1, +1, -1],
+        [+1, +1, -1],
+        [-1, -1, +1],
+        [+1, -1, +1],
+        [-1, +1, +1],
+        [+1, +1, +1],
+    ],
+    dtype=float,
+)
+
+
+def _brick_8ip_weights(xi: float, eta: float, zeta: float) -> np.ndarray:
+    """Trilinear interpolation weights from the 8 Gauss IPs of a Brick
+    to an arbitrary ``(ξ, η, ζ)`` in the parent cube.
+
+    Mapping ``(ξ, η, ζ) → (ξ/s, η/s, ζ/s)`` puts the IPs at the
+    corners of an auxiliary unit cube; trilinear interpolation on that
+    cube yields the weights returned here. Extrapolates linearly for
+    points beyond the IP envelope (between the cube corners ±s and the
+    parent cube boundary ±1).
+    """
+    xi_l = xi / _BRICK_8IP_S
+    eta_l = eta / _BRICK_8IP_S
+    zeta_l = zeta / _BRICK_8IP_S
+    pt = np.array([xi_l, eta_l, zeta_l])
+    return 0.125 * np.prod(1.0 + _BRICK_8IP_SIGNS * pt[None, :], axis=1)
+
+
+# 27-IP 3×3×3 Gauss-Legendre — 1-D nodes at {-√(3/5), 0, +√(3/5)};
+# IPs at all tensor-product combinations, ξ varying fastest. Used by
+# higher-order hexes (Brick20 / Brick27) for stress sampling.
+_BRICK_27IP_A = float(np.sqrt(3.0 / 5.0))
+
+
+def _brick_27ip_1d_lagrange(x: float) -> tuple[float, float, float]:
+    """1-D quadratic Lagrange basis at the three Gauss-Legendre 3-pt
+    nodes ``(-a, 0, +a)`` with ``a = √(3/5)``.
+
+    Returns ``(L_-(x), L_0(x), L_+(x))``. ``L_-(-a) = L_0(0) =
+    L_+(+a) = 1``; each basis function is zero at the other two
+    nodes by construction. Sum is identically 1 (partition of unity).
+    """
+    a = _BRICK_27IP_A
+    inv2a2 = 5.0 / 6.0      # 1 / (2 a²) with a² = 3/5
+    inv_a2 = 5.0 / 3.0      # 1 / a²
+    l_minus = inv2a2 * x * (x - a)
+    l_zero = 1.0 - inv_a2 * x * x
+    l_plus = inv2a2 * x * (x + a)
+    return l_minus, l_zero, l_plus
+
+
+def _brick_27ip_weights(xi: float, eta: float, zeta: float) -> np.ndarray:
+    """Triquadratic Lagrange interpolation weights at the 27 IPs of a
+    Brick (3×3×3 Gauss-Legendre rule).
+
+    IP enumeration is ξ-fastest then η then ζ — matching
+    :func:`STKO_to_python.format.gauss_points.tensor_product_3d`. The
+    weight at IP ``(n_ξ, n_η, n_ζ)`` is ``L_{n_ξ}(ξ) · L_{n_η}(η) ·
+    L_{n_ζ}(ζ)``.
+    """
+    lx = _brick_27ip_1d_lagrange(xi)
+    le = _brick_27ip_1d_lagrange(eta)
+    lz = _brick_27ip_1d_lagrange(zeta)
+    w = np.empty(27, dtype=float)
+    for nzeta in range(3):
+        for neta in range(3):
+            for nxi in range(3):
+                idx = (nzeta * 3 + neta) * 3 + nxi
+                w[idx] = lx[nxi] * le[neta] * lz[nzeta]
+    return w
+
+
+def _sample_solid_stress(
+    stress: np.ndarray, xi: float, eta: float, zeta: float, base_type: str, n_ip: int,
+) -> np.ndarray:
+    """Sample ``material.stress`` at arbitrary natural coords on a solid.
+
+    Returns ``(n_steps, 6)``. Dispatches on ``(base_type, n_ip)``:
+
+    - 8-pt 2×2×2 Brick (any Brick* class): trilinear weights between
+      the eight corner IPs.
+    - 27-pt 3×3×3 Brick (Brick20 / Brick27 + the 27-IP catalog entry):
+      triquadratic Lagrange weights between the 27 tensor-product IPs.
+    - 1-pt: single value broadcast.
+    - 4-pt tet: barycentric weights on the reference tetrahedron
+      (coarse — only used when a fixture surfaces it).
+
+    Unknown ``(base_type, n_ip)`` pairs fall back to the closest IP.
+    """
+    if "Brick" in base_type:
+        if n_ip == 8:
+            w = _brick_8ip_weights(xi, eta, zeta)
+            return np.einsum("sij,i->sj", stress, w)
+        if n_ip == 27:
+            w = _brick_27ip_weights(xi, eta, zeta)
+            return np.einsum("sij,i->sj", stress, w)
+    if n_ip == 1:
+        return stress[:, 0, :].copy()
+    if n_ip == 4 and "Tetrahedron" in base_type:
+        # 4-pt tet rule: assume the IPs lie near the centroid; we
+        # interpolate using barycentric weights in (ξ, η, ζ) on the
+        # reference tet. This is a coarse approximation — but for the
+        # typical FourNodeTetrahedron with 1-IP (which IS the common
+        # case) we never enter this branch; the 4-IP path is here for
+        # completeness so we don't crash on a hypothetical fixture.
+        bary = np.array([1.0 - xi - eta - zeta, xi, eta, zeta])
+        # Normalise defensively; numerical noise can push outside the
+        # simplex by a few ulps.
+        bary = np.clip(bary, 0.0, 1.0)
+        bary /= bary.sum()
+        return np.einsum("sij,i->sj", stress, bary)
+    # Generic fallback: pick the IP closest to (ξ, η, ζ) in the natural
+    # domain. Loud TODO for a future reviewer.
+    return stress[:, 0, :].copy()
+
+
+# ---------------------------------------------------------------------- #
+# Result container
+# ---------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class SolidCutResult:
+    """Output of :func:`compute_solid_cut`.
+
+    Attributes
+    ----------
+    F : np.ndarray
+        ``(n_steps, 3)`` — total cut force from solids, global frame.
+    M : np.ndarray
+        ``(n_steps, 3)`` — total cut moment about ``centroid``, global.
+    time : np.ndarray
+        ``(n_steps,)``.
+    centroid : np.ndarray
+        ``(3,)`` — reference point for moments (unweighted mean of the
+        per-element polygon centroids).
+    intersections : tuple[SolidIntersection, ...]
+    per_solid_F, per_solid_M_at_centroid : dict[int, np.ndarray]
+        Per-element contributions. ``per_solid_M_at_centroid[eid]`` is
+        the moment summed about ``intersections[k].polygon_centroid``
+        for the matching ``eid`` — the composite cut transfers them to
+        the shared centroid via the standard arm × force step.
+    """
+
+    F: np.ndarray
+    M: np.ndarray
+    time: np.ndarray
+    centroid: np.ndarray
+    intersections: tuple[SolidIntersection, ...]
+    per_solid_F: dict[int, np.ndarray] = field(default_factory=dict)
+    per_solid_M_at_centroid: dict[int, np.ndarray] = field(default_factory=dict)
+
+    @property
+    def n_steps(self) -> int:
+        return int(self.time.shape[0])
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self.intersections) == 0
+
+
+# ---------------------------------------------------------------------- #
+# Per-triangle Gauss rule on a triangle in 3-D
+# ---------------------------------------------------------------------- #
+# Standard 3-point rule on the unit triangle (vertices at (0,0), (1,0),
+# (0,1) in barycentric ξ/η). Same rule used in
+# :func:`STKO_to_python.format.gauss_points.gauss_triangle` — kept
+# inline here to avoid a runtime import cycle and to make the kernel
+# self-contained.
+_TRI3_BARYCENTRIC = np.array(
+    [
+        [1.0 / 6.0, 1.0 / 6.0],
+        [2.0 / 3.0, 1.0 / 6.0],
+        [1.0 / 6.0, 2.0 / 3.0],
+    ]
+)
+_TRI3_WEIGHTS = np.array([1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0])
+
+
+def _triangle_quadrature_points(
+    a: np.ndarray, b: np.ndarray, c: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """3-pt Gauss quadrature on a 3-D triangle with vertices ``a, b, c``.
+
+    Returns ``(quad_points_global, weights_scaled, area)`` where
+    ``weights_scaled[k] = unit_weight[k] * (2 * area)`` so that
+    ``sum(weights_scaled * f(quad_points))`` integrates ``f`` over the
+    triangle (the factor of 2 accounts for the parent triangle's area
+    of 1/2 — the quadrature weights sum to 1/2 on the unit triangle,
+    and we want them to sum to the triangle's physical area).
+    """
+    # Triangle area via cross product.
+    e1 = b - a
+    e2 = c - a
+    area = 0.5 * float(np.linalg.norm(np.cross(e1, e2)))
+    # Quadrature points in physical coords.
+    xi = _TRI3_BARYCENTRIC[:, 0]
+    eta = _TRI3_BARYCENTRIC[:, 1]
+    lam0 = 1.0 - xi - eta
+    pts = lam0[:, None] * a[None, :] + xi[:, None] * b[None, :] + eta[:, None] * c[None, :]
+    weights_scaled = _TRI3_WEIGHTS * (2.0 * area)
+    return pts, weights_scaled, area
+
+
+# ---------------------------------------------------------------------- #
+# Resultant phase
+# ---------------------------------------------------------------------- #
+def compute_solid_cut(
+    dataset: "MPCODataSet",
+    spec: "SectionCutSpec",
+    *,
+    model_stage: str,
+    clipper: "PolygonClipper | None" = None,
+) -> SolidCutResult:
+    """Compute the ``(F, M)`` resultant of a section cut through solids.
+
+    Returns an empty result when no solid in the filter crosses the
+    plane (``F.shape == (0, 3)``).
+    """
+    intersections = find_solid_intersections(dataset, spec, clipper=clipper)
+
+    # Group by decorated element type for batched material.stress reads.
+    by_type: dict[str, list[SolidIntersection]] = {}
+    for ix in intersections:
+        by_type.setdefault(ix.element_type, []).append(ix)
+
+    per_solid_F: dict[int, np.ndarray] = {}
+    per_solid_M_at_centroid: dict[int, np.ndarray] = {}
+    time: np.ndarray | None = None
+
+    for elem_type, sub in by_type.items():
+        eids = [ix.element_id for ix in sub]
+        er = dataset.elements.get_element_results(
+            results_name="material.stress",
+            element_type=elem_type,
+            model_stage=model_stage,
+            element_ids=eids,
+        )
+        # ``n_ip`` lives directly on ElementResults; fall back to the
+        # column count when the catalog hasn't surfaced it for an
+        # element class (defensive — the standard Brick/Tet entries
+        # are present in ``gauss_points.ELEMENT_IP_CATALOG``).
+        n_ip = _resolve_n_ip(er)
+        if n_ip == 0:
+            raise ValueError(
+                f"Solid {elem_type!r} has no integration points in the "
+                "material.stress result. Register the class in "
+                "STKO_to_python.format.gauss_points before running a "
+                "section cut on it."
+            )
+        base_type = _strip_class_tag(elem_type)
+        for ix in sub:
+            rows = er.df.xs(ix.element_id, level="element_id")
+            stress = _read_solid_stress_array(rows, n_ip)
+            F, M = _solid_cut_per_element(
+                stress, ix, spec, base_type, n_ip,
+            )
+            per_solid_F[ix.element_id] = F
+            per_solid_M_at_centroid[ix.element_id] = M
+        if time is None:
+            time = np.asarray(er.time, dtype=float)
+
+    if not intersections or time is None:
+        return SolidCutResult(
+            F=np.zeros((0, 3)),
+            M=np.zeros((0, 3)),
+            time=np.zeros((0,)),
+            centroid=np.zeros(3),
+            intersections=(),
+        )
+
+    centroid = np.mean(
+        np.stack([ix.polygon_centroid for ix in intersections], axis=0), axis=0
+    )
+    F_total = np.zeros((time.shape[0], 3), dtype=float)
+    M_total = np.zeros_like(F_total)
+    for ix in intersections:
+        Fi = per_solid_F[ix.element_id]
+        Mi = per_solid_M_at_centroid[ix.element_id]
+        arm = ix.polygon_centroid - centroid
+        F_total += Fi
+        M_total += Mi + np.cross(arm, Fi)
+
+    return SolidCutResult(
+        F=F_total,
+        M=M_total,
+        time=time,
+        centroid=centroid,
+        intersections=tuple(intersections),
+        per_solid_F=per_solid_F,
+        per_solid_M_at_centroid=per_solid_M_at_centroid,
+    )
+
+
+def _resolve_n_ip(er) -> int:
+    """Return the integration-point count for an ElementResults bucket.
+
+    Prefers the ``n_ip`` attribute (set by the read path from the
+    catalog); falls back to deducing it from the number of distinct
+    ``_ip<k>`` suffixes in the column index. The fallback exists so a
+    user who registers a new solid class but forgets to update the
+    catalog still gets a useful error path (the kernel raises a clear
+    "register your class" message rather than silently zeroing).
+    """
+    if hasattr(er, "n_ip"):
+        n = int(er.n_ip)
+        if n > 0:
+            return n
+    cols = list(er.df.columns)
+    ips = set()
+    for c in cols:
+        if "_ip" in c:
+            tail = c.rsplit("_ip", 1)[1]
+            try:
+                ips.add(int(tail))
+            except ValueError:
+                pass
+    return len(ips)
+
+
+def _orient_cut_normal_for_solid(
+    node_coords: np.ndarray,
+    polygon_centroid: np.ndarray,
+    spec: "SectionCutSpec",
+) -> np.ndarray:
+    """Choose the cut normal sign so it points from KEPT → DISCARDED.
+
+    For solids the cut plane normal itself is the geometric in-plane
+    normal — there is no element-local direction to construct from
+    cross products as in the shell kernel. We simply align with
+    ``spec.signed_normal`` and then verify the sign against the
+    "most-clearly-kept" vertex (highest signed distance):
+
+    - In the normal case (some vertex strictly on the kept side),
+      ``n_cut`` should point AWAY from that vertex.
+    - In the edge-coincident case (every kept-side vertex is exactly
+      on the plane; the side-aware filter guarantees at least one
+      vertex strictly on the discarded side), ``n_cut`` should point
+      TOWARD the most-clearly-discarded vertex.
+
+    Both yield the convention ``n_cut · (kept_vertex - polygon_centroid)
+    < 0`` consistent with the shell kernel.
+    """
+    signed_n = spec.signed_normal
+    plane_point = np.asarray(spec.plane.point, dtype=float)
+    rel = node_coords - plane_point
+    d = rel @ signed_n  # (n_nodes,)
+    n_cut = np.asarray(signed_n, dtype=float)
+    if float(d.max()) > 0.0:
+        idx = int(np.argmax(d))
+        offset = node_coords[idx] - polygon_centroid
+        if offset @ n_cut > 0:
+            return -n_cut
+        return n_cut
+    # Edge-coincident — use the most-discarded vertex; n_cut must point
+    # toward it.
+    idx = int(np.argmin(d))
+    offset = node_coords[idx] - polygon_centroid
+    if offset @ n_cut < 0:
+        return -n_cut
+    return n_cut
+
+
+def _solid_cut_per_element(
+    stress: np.ndarray,
+    intersection: SolidIntersection,
+    spec: "SectionCutSpec",
+    base_type: str,
+    n_ip: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Integrate a single solid's traction over its cut polygon.
+
+    Returns ``(F, M)`` shape ``(n_steps, 3)`` each — cut force/moment in
+    **global** frame, with the moment summed about the polygon
+    centroid. The composite cut aggregator transfers moments to a
+    common centroid afterwards.
+
+    Math sketch
+    -----------
+    For a convex planar polygon ``Π`` we fan-triangulate from its first
+    vertex ``v0``::
+
+        Π = ∪_{k=1..K-2} Δ(v0, v_k, v_{k+1})
+
+    Each triangle gets a 3-point Gauss rule. For each quadrature point
+    we invert the element's shape function to get ``(ξ, η, ζ)``, sample
+    the stress tensor, compute the traction ``t = σ · n_cut``, weight
+    by the Gauss weight (scaled to the triangle's physical area) and
+    accumulate. The moment uses the lever arm ``r = q - centroid``
+    where ``q`` is the quadrature point and ``centroid`` is the
+    polygon centroid.
+    """
+    polygon = intersection.polygon_global
+    polygon_natural = intersection.polygon_natural
+    K = polygon.shape[0]
+    polygon_centroid = intersection.polygon_centroid
+    n_cut_global = _orient_cut_normal_for_solid(
+        intersection.element_node_coords, polygon_centroid, spec,
+    )
+
+    n_steps = stress.shape[0]
+    F = np.zeros((n_steps, 3), dtype=float)
+    M = np.zeros((n_steps, 3), dtype=float)
+
+    # Walk the fan triangles. Use the global polygon for the area /
+    # quadrature-point positions in physical space; use the natural-
+    # coord polygon to interpolate (ξ, η, ζ) at each quadrature point
+    # via the same barycentric weights.
+    v0 = polygon[0]
+    v0_nat = polygon_natural[0]
+    for k in range(1, K - 1):
+        a, b, c = v0, polygon[k], polygon[k + 1]
+        a_nat = v0_nat
+        b_nat = polygon_natural[k]
+        c_nat = polygon_natural[k + 1]
+        # Physical-space quadrature.
+        pts_phys, w_scaled, _area = _triangle_quadrature_points(a, b, c)
+        # Natural-coord quadrature: linear interpolation by the same
+        # barycentric weights. Valid because the cut polygon is planar
+        # and the element shape function is well-defined on it.
+        for q_idx in range(pts_phys.shape[0]):
+            xi_bc = _TRI3_BARYCENTRIC[q_idx, 0]
+            eta_bc = _TRI3_BARYCENTRIC[q_idx, 1]
+            lam0 = 1.0 - xi_bc - eta_bc
+            nat_q = lam0 * a_nat + xi_bc * b_nat + eta_bc * c_nat
+            sigma_voigt = _sample_solid_stress(
+                stress, float(nat_q[0]), float(nat_q[1]), float(nat_q[2]),
+                base_type, n_ip,
+            )  # (n_steps, 6)
+            sigma_tensor = _stress_voigt_to_tensor(sigma_voigt)  # (n_steps, 3, 3)
+            # Traction t = sigma · n_cut, shape (n_steps, 3).
+            t = sigma_tensor @ n_cut_global
+            weight = w_scaled[q_idx]
+            F += weight * t
+            arm = pts_phys[q_idx] - polygon_centroid
+            # arm is (3,), t is (n_steps, 3); np.cross broadcasts arm
+            # across the time axis.
+            M += weight * np.cross(arm, t)
+
+    return F, M

--- a/src/STKO_to_python/cuts/section_cut.py
+++ b/src/STKO_to_python/cuts/section_cut.py
@@ -38,7 +38,13 @@ import pandas as pd
 
 from .kernels.beam import BeamIntersection
 from .kernels.beam_resultant import compute_beam_cut
-from .kernels.shell import ShellIntersection, compute_shell_cut
+from .kernels.shell import (
+    ShellIntersection,
+    compute_shell_cut,
+    compute_shell_cut_per_fiber,
+    compute_shell_cut_per_layer,
+)
+from .kernels.solid import SolidIntersection, compute_solid_cut
 from .specs import SectionCutSpec
 
 if TYPE_CHECKING:
@@ -88,6 +94,9 @@ class SectionCut:
     shell_intersections: tuple[ShellIntersection, ...] = ()
     per_shell_F: dict[int, np.ndarray] = field(default_factory=dict)
     per_shell_M_at_midpoint: dict[int, np.ndarray] = field(default_factory=dict)
+    solid_intersections: tuple[SolidIntersection, ...] = ()
+    per_solid_F: dict[int, np.ndarray] = field(default_factory=dict)
+    per_solid_M_at_centroid: dict[int, np.ndarray] = field(default_factory=dict)
 
     # ------------------------------------------------------------------ #
     # Construction
@@ -102,13 +111,13 @@ class SectionCut:
     ) -> "SectionCut":
         """Compute the cut against ``dataset`` at ``model_stage``.
 
-        Composes the beam and shell kernels and aggregates ``(F, M)``
-        about a shared centroid (the mean of all reference points —
-        beam intersection points and shell chord midpoints). The solid
-        kernel will plug into the same composition in v2.0.
+        Composes the beam, shell, and solid kernels and aggregates
+        ``(F, M)`` about a shared centroid — the mean of all reference
+        points (beam intersection points, shell chord midpoints, and
+        solid polygon centroids).
         """
-        # Share one PolygonClipper between the two kernels so the plane
-        # basis isn't recomputed twice when bounding_polygon is set.
+        # Share one PolygonClipper across every kernel so the plane
+        # basis isn't recomputed when bounding_polygon is set.
         clipper = None
         if spec.bounding_polygon is not None:
             from .geometry import prepare_clipper
@@ -120,15 +129,20 @@ class SectionCut:
         shell = compute_shell_cut(
             dataset, spec, model_stage=model_stage, clipper=clipper,
         )
+        solid = compute_solid_cut(
+            dataset, spec, model_stage=model_stage, clipper=clipper,
+        )
 
-        # Pick a time axis from whichever kernel found something. Beam
-        # and shell readers route through the same broker, so when both
-        # have intersections their time arrays are identical by
+        # Pick a time axis from whichever kernel found something. All
+        # kernels route through the same broker, so when more than one
+        # has intersections their time arrays are identical by
         # construction.
         if not beam.is_empty:
             time = beam.time
         elif not shell.is_empty:
             time = shell.time
+        elif not solid.is_empty:
+            time = solid.time
         else:
             return cls(
                 spec=spec,
@@ -143,15 +157,20 @@ class SectionCut:
                 shell_intersections=(),
                 per_shell_F={},
                 per_shell_M_at_midpoint={},
+                solid_intersections=(),
+                per_solid_F={},
+                per_solid_M_at_centroid={},
             )
 
         # Aggregate F + M about the shared centroid of every reference
-        # point in both kernels.
+        # point across the three kernels.
         ref_points = []
         for b in beam.intersections:
             ref_points.append(b.point_arr)
         for s in shell.intersections:
             ref_points.append(s.chord_midpoint)
+        for ss in solid.intersections:
+            ref_points.append(ss.polygon_centroid)
         centroid = np.mean(np.stack(ref_points, axis=0), axis=0)
 
         F_total = np.zeros((time.shape[0], 3), dtype=float)
@@ -168,6 +187,12 @@ class SectionCut:
             arm = ix.chord_midpoint - centroid
             F_total += Fi
             M_total += Mi + np.cross(arm, Fi)
+        for ix in solid.intersections:
+            Fi = solid.per_solid_F[ix.element_id]
+            Mi = solid.per_solid_M_at_centroid[ix.element_id]
+            arm = ix.polygon_centroid - centroid
+            F_total += Fi
+            M_total += Mi + np.cross(arm, Fi)
 
         return cls(
             spec=spec,
@@ -182,6 +207,9 @@ class SectionCut:
             shell_intersections=shell.intersections,
             per_shell_F=dict(shell.per_shell_F),
             per_shell_M_at_midpoint=dict(shell.per_shell_M_at_midpoint),
+            solid_intersections=solid.intersections,
+            per_solid_F=dict(solid.per_solid_F),
+            per_solid_M_at_centroid=dict(solid.per_solid_M_at_centroid),
         )
 
     # ------------------------------------------------------------------ #
@@ -209,19 +237,26 @@ class SectionCut:
         return (
             len(self.intersections) == 0
             and len(self.shell_intersections) == 0
+            and len(self.solid_intersections) == 0
         )
 
     @property
     def contributing_element_ids(self) -> tuple[int, ...]:
         """All element ids whose contribution the cut sums up — beams
-        first, then shells, each block sorted by element_id."""
+        first, then shells, then solids; each block sorted by
+        element_id."""
         beam_ids = [ix.element_id for ix in self.intersections]
         shell_ids = [ix.element_id for ix in self.shell_intersections]
-        return tuple(beam_ids + shell_ids)
+        solid_ids = [ix.element_id for ix in self.solid_intersections]
+        return tuple(beam_ids + shell_ids + solid_ids)
 
     def __repr__(self) -> str:
         label = f", label={self.spec.label!r}" if self.spec.label else ""
-        n_total = len(self.intersections) + len(self.shell_intersections)
+        n_total = (
+            len(self.intersections)
+            + len(self.shell_intersections)
+            + len(self.solid_intersections)
+        )
         return (
             f"SectionCut(stage={self.model_stage!r}, n_steps={self.n_steps}, "
             f"n_intersections={n_total}, "
@@ -302,6 +337,161 @@ class SectionCut:
             data,
             columns=list(_COMPONENTS),
             index=pd.Index(self.time, name="time"),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Per-layer view (v1.7) — layered-shell decomposition
+    # ------------------------------------------------------------------ #
+    def per_layer_force(
+        self,
+        layer_idx: int,
+        dataset: "MPCODataSet",
+    ) -> "SectionCut":
+        """Return a derivative cut from only one through-thickness layer
+        of the layered shells in this cut.
+
+        The math: instead of reading the through-thickness-integrated
+        ``section.force``, read ``section.fiber.stress`` and integrate
+        the layer's stress weighted by its thickness (for the force) and
+        its thickness × z_offset (for the moment). Beams and solids in
+        the original cut are dropped — per-layer breakdown is a
+        shell-only concept.
+
+        Summing all layers must recover the standard shell cut::
+
+            cut = ds.section_cut(...)
+            per_layers = [cut.per_layer_force(k, ds) for k in range(n_layers)]
+            np.testing.assert_allclose(
+                cut.F - sum(c.F for c in per_layers),
+                some_beam_solid_contributions,
+                atol=1e-3,
+            )
+
+        (The exact equality holds layer-by-layer when the cut contains
+        only shells; with mixed beam + solid + shell contributions, the
+        per-layer sums recover only the shell portion of the standard
+        cut.)
+
+        Parameters
+        ----------
+        layer_idx : int
+            Layer index, 0 (bottom) to ``n_layers - 1`` (top), matching
+            the ``LayeredShell`` definition in ``sections.tcl``.
+        dataset : MPCODataSet
+            Source data; needed to re-read ``section.fiber.stress`` and
+            to resolve the layer table for each contributing shell.
+
+        Raises
+        ------
+        ValueError
+            If this cut contains no shell intersections.
+        IndexError
+            If ``layer_idx`` is out of range for any contributing shell.
+        """
+        if not self.shell_intersections:
+            raise ValueError(
+                "per_layer_force requires at least one shell intersection; "
+                "this cut has none."
+            )
+        clipper = None
+        if self.spec.bounding_polygon is not None:
+            from .geometry import prepare_clipper
+            clipper = prepare_clipper(self.spec.plane, self.spec.bounding_polygon)
+        shell_layer = compute_shell_cut_per_layer(
+            dataset, self.spec,
+            model_stage=self.model_stage,
+            layer_idx=int(layer_idx),
+            clipper=clipper,
+        )
+        return SectionCut(
+            spec=self.spec,
+            model_stage=self.model_stage,
+            F=shell_layer.F,
+            M=shell_layer.M,
+            time=shell_layer.time,
+            centroid=shell_layer.centroid,
+            intersections=(),
+            per_beam_F={},
+            per_beam_M_at_intersection={},
+            shell_intersections=shell_layer.intersections,
+            per_shell_F=dict(shell_layer.per_shell_F),
+            per_shell_M_at_midpoint=dict(shell_layer.per_shell_M_at_midpoint),
+            solid_intersections=(),
+            per_solid_F={},
+            per_solid_M_at_centroid={},
+        )
+
+    def per_fiber_force(
+        self,
+        layer_idx: int,
+        fiber_idx: int,
+        dataset: "MPCODataSet",
+    ) -> "SectionCut":
+        """Return a derivative cut from one fiber within one
+        through-thickness layer of the layered shells in this cut.
+
+        Available only for layered shells whose layers carry fiber-
+        decomposed columns (``<comp>_f<F>_l<L>_ip<K>``). Layers backed
+        by a single ``nDMaterial`` raise — use :meth:`per_layer_force`
+        for those.
+
+        The fiber's tributary thickness defaults to ``t_layer /
+        n_fibers_in_layer`` (uniform distribution along the layer's
+        thickness); the fiber's z-offset is the centroid of that
+        sub-band relative to the section midplane. Summing all fibers
+        within a layer recovers that layer's standard per-layer cut.
+
+        Parameters
+        ----------
+        layer_idx : int
+            Layer index, 0 (bottom) to ``n_layers - 1`` (top).
+        fiber_idx : int
+            Fiber index within the layer, 0 to
+            ``n_fibers_in_layer - 1``.
+        dataset : MPCODataSet
+            Source data; needed to re-read ``section.fiber.stress`` and
+            to resolve the layer table for each contributing shell.
+
+        Raises
+        ------
+        ValueError
+            If this cut contains no shell intersections, or if the
+            layer carries no fiber decomposition.
+        IndexError
+            If ``layer_idx`` or ``fiber_idx`` is out of range.
+        """
+        if not self.shell_intersections:
+            raise ValueError(
+                "per_fiber_force requires at least one shell intersection; "
+                "this cut has none."
+            )
+        clipper = None
+        if self.spec.bounding_polygon is not None:
+            from .geometry import prepare_clipper
+            clipper = prepare_clipper(self.spec.plane, self.spec.bounding_polygon)
+        shell_fiber = compute_shell_cut_per_fiber(
+            dataset, self.spec,
+            model_stage=self.model_stage,
+            layer_idx=int(layer_idx),
+            fiber_idx=int(fiber_idx),
+            clipper=clipper,
+        )
+        return SectionCut(
+            spec=self.spec,
+            model_stage=self.model_stage,
+            F=shell_fiber.F,
+            M=shell_fiber.M,
+            time=shell_fiber.time,
+            centroid=shell_fiber.centroid,
+            intersections=(),
+            per_beam_F={},
+            per_beam_M_at_intersection={},
+            shell_intersections=shell_fiber.intersections,
+            per_shell_F=dict(shell_fiber.per_shell_F),
+            per_shell_M_at_midpoint=dict(shell_fiber.per_shell_M_at_midpoint),
+            solid_intersections=(),
+            per_solid_F={},
+            per_solid_M_at_centroid={},
         )
 
     # ------------------------------------------------------------------ #

--- a/src/STKO_to_python/model/layered_section_reader.py
+++ b/src/STKO_to_python/model/layered_section_reader.py
@@ -1,0 +1,171 @@
+"""Reader for ``LayeredShell`` section definitions in OpenSees Tcl scripts.
+
+The MPCO HDF5 file carries layered-shell **results** (one column per
+``(gauss_point × thickness_layer)`` block under
+``material.fiber.stress`` / ``section.fiber.stress``), but it does not
+carry the geometric layer definition — the layer thicknesses and
+materials live in the source ``sections.tcl`` script that builds the
+OpenSees model. The per-layer section-cut breakdown
+(:func:`STKO_to_python.cuts.kernels.shell.compute_shell_cut_per_layer`)
+needs that geometry to weight each layer's stress by its thickness and
+through-thickness offset.
+
+This module parses the lines
+
+::
+
+    section LayeredShell <section_id> <n_layers> \\
+         <mat_id_1> <t_1>  <mat_id_2> <t_2>  ...
+
+and exposes them as a ``{section_id: tuple[LayerInfo, ...]}`` table.
+``LayerInfo.z_offset`` is the layer midplane's signed distance from the
+section midplane, computed as ``bottom_z + 0.5 * thickness`` with
+``bottom_z = -T/2 + Σ t_j`` for layers ``j < k``.
+
+The parser is intentionally lenient: lines that don't start with
+``section LayeredShell`` are skipped, Tcl continuation backslashes are
+collapsed, and unknown trailing tokens (e.g. ``-fName`` style options)
+are dropped. The MPCO results carry the ground truth — this module is
+only a convenience for callers who keep their model source alongside
+their recorder output.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LayerInfo:
+    """One through-thickness layer in a LayeredShell section.
+
+    Attributes
+    ----------
+    material_id : int
+        OpenSees material tag assigned to this layer.
+    thickness : float
+        Layer thickness (length units of the model).
+    z_offset : float
+        Signed distance of the layer midplane from the **section
+        midplane**. Bottom layer has the most-negative offset; top
+        layer has the most-positive. Used to compute through-thickness
+        moments via ``M = ∫ σ · z dz ≈ Σ σ_k · t_k · z_offset_k``.
+    """
+
+    material_id: int
+    thickness: float
+    z_offset: float
+
+
+# Tcl section command — captures the section id and the parameter
+# tail. The tail is parsed token-by-token below; matching a flexible
+# regex on the whole layer list would have to handle continuation
+# backslashes and arbitrary whitespace, which is simpler done linearly.
+_SECTION_HEADER_RE = re.compile(
+    r"\bsection\s+LayeredShell\s+(\d+)\s+(\d+)\s+(.*)$",
+    re.IGNORECASE,
+)
+
+
+def parse_sections_tcl(path: str | Path) -> dict[int, tuple[LayerInfo, ...]]:
+    """Parse a Tcl script's ``LayeredShell`` definitions.
+
+    Returns ``{section_id: (LayerInfo, ...)}``. Sections without a
+    ``LayeredShell`` declaration (``ElasticMembranePlateSection``, etc.)
+    are silently skipped.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    ValueError
+        If a ``LayeredShell`` header declares N layers but the
+        following body doesn't carry N ``(material_id, thickness)``
+        pairs after the continuation backslashes are collapsed.
+    """
+    p = Path(path)
+    text = p.read_text(encoding="utf-8", errors="replace")
+
+    # Collapse Tcl line continuations: ``\\\n`` becomes a single space
+    # so each ``section ...`` statement lives on one logical line.
+    logical = re.sub(r"\\\s*\n", " ", text)
+
+    out: dict[int, tuple[LayerInfo, ...]] = {}
+    for raw_line in logical.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _SECTION_HEADER_RE.search(line)
+        if m is None:
+            continue
+        section_id = int(m.group(1))
+        n_layers = int(m.group(2))
+        tail = m.group(3).strip()
+
+        # Parse the tail as alternating <material_id> <thickness> pairs.
+        # Tcl tolerates extra whitespace; ``.split()`` handles any
+        # combination of spaces / tabs.
+        tokens = tail.split()
+        if len(tokens) < 2 * n_layers:
+            raise ValueError(
+                f"LayeredShell section {section_id}: declared "
+                f"{n_layers} layers but the body has only {len(tokens)} "
+                f"tokens (need at least {2 * n_layers})."
+            )
+        layers_raw: list[tuple[int, float]] = []
+        for k in range(n_layers):
+            mat_str = tokens[2 * k]
+            thick_str = tokens[2 * k + 1]
+            try:
+                mat_id = int(mat_str)
+                thick = float(thick_str)
+            except ValueError as exc:
+                raise ValueError(
+                    f"LayeredShell section {section_id} layer {k}: "
+                    f"cannot parse ({mat_str!r}, {thick_str!r}) as "
+                    "(int, float)."
+                ) from exc
+            layers_raw.append((mat_id, thick))
+
+        # Compute z_offset for each layer: midplane of layer k =
+        # -T/2 + sum_{j<k} t_j + t_k / 2.
+        total_t = float(sum(t for _, t in layers_raw))
+        out[section_id] = _build_layer_infos(layers_raw, total_t)
+
+    return out
+
+
+def _build_layer_infos(
+    layers_raw: list[tuple[int, float]], total_t: float,
+) -> tuple[LayerInfo, ...]:
+    """Compute centroid z-offsets given (material_id, thickness) pairs."""
+    half_t = 0.5 * total_t
+    out: list[LayerInfo] = []
+    running_bottom = -half_t
+    for mat_id, thick in layers_raw:
+        midplane = running_bottom + 0.5 * thick
+        out.append(LayerInfo(
+            material_id=int(mat_id),
+            thickness=float(thick),
+            z_offset=float(midplane),
+        ))
+        running_bottom += thick
+    return tuple(out)
+
+
+def find_sections_tcl(dataset_directory: str | Path) -> Path | None:
+    """Locate ``sections.tcl`` beside an MPCO recorder.
+
+    Searches ``dataset_directory`` and its immediate parent for a file
+    named ``sections.tcl`` (case-insensitive on case-preserving file
+    systems). Returns the path of the first match, or ``None`` if no
+    candidate is found. Callers should treat ``None`` as "no layer
+    table available" and surface a useful error message.
+    """
+    base = Path(dataset_directory)
+    candidates = [base / "sections.tcl", base.parent / "sections.tcl"]
+    for cand in candidates:
+        if cand.exists():
+            return cand
+    return None

--- a/tests/unit/cuts/test_per_layer_shell.py
+++ b/tests/unit/cuts/test_per_layer_shell.py
@@ -1,0 +1,452 @@
+"""Unit tests for the per-layer breakdown of layered-shell cuts (v1.7).
+
+Two layers of coverage:
+
+- **Pure-math tests** — exercise the layered-shell stress reader and
+  the layer-table parser on synthetic inputs that don't need the
+  Test_NLShell fixture.
+- **Real-fixture tests** — against ``Test_NLShell`` (gated on the
+  ``nl_shell_dir`` conftest fixture) verify the
+  ``sum(per_layer_force(k)) == cut.F`` invariant and the dataset
+  ``per_layer=k`` short-circuit.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.cuts import Plane, SectionCut, SectionCutSpec
+from STKO_to_python.cuts.kernels.shell import (
+    SHELL_ELEMENT_CLASSES,
+    _discover_fiber_count_in_layer,
+    _read_fiber_in_layer_stress_array,
+    _read_layer_stress_array,
+    _sample_layer_stress,
+)
+from STKO_to_python.model.layered_section_reader import (
+    LayerInfo,
+    parse_sections_tcl,
+)
+
+
+# ====================================================================== #
+# Pure-math tests
+# ====================================================================== #
+class TestReadLayerStressArray:
+    """``_read_layer_stress_array`` extracts the layered Voigt stress
+    from a flat DataFrame with ``<comp>_l<layer>_ip<ip>`` columns.
+    """
+
+    def test_recognises_membrane_columns(self):
+        import pandas as pd
+        # 2 steps, 1 IP, 1 layer. Membrane stresses only.
+        df = pd.DataFrame({
+            "sigma11_l0_ip0": [1.0, 2.0],
+            "sigma22_l0_ip0": [3.0, 4.0],
+            "sigma12_l0_ip0": [5.0, 6.0],
+        })
+        stress = _read_layer_stress_array(df, n_ip=1, layer_idx=0)
+        assert stress.shape == (2, 1, 6)
+        # Voigt order: (sigma11, sigma22, sigma33, sigma12, sigma23, sigma13)
+        np.testing.assert_allclose(stress[:, 0, 0], [1.0, 2.0])
+        np.testing.assert_allclose(stress[:, 0, 1], [3.0, 4.0])
+        np.testing.assert_allclose(stress[:, 0, 3], [5.0, 6.0])
+        # Missing components stay zero.
+        np.testing.assert_allclose(stress[:, 0, 2], 0.0)
+
+    def test_picks_only_the_requested_layer(self):
+        import pandas as pd
+        # Two layers — the function should ignore the other one.
+        df = pd.DataFrame({
+            "sigma11_l0_ip0": [10.0],
+            "sigma11_l1_ip0": [99.0],
+            "sigma22_l0_ip0": [20.0],
+            "sigma22_l1_ip0": [88.0],
+        })
+        stress = _read_layer_stress_array(df, n_ip=1, layer_idx=0)
+        np.testing.assert_allclose(stress[0, 0, 0], 10.0)
+        np.testing.assert_allclose(stress[0, 0, 1], 20.0)
+        stress = _read_layer_stress_array(df, n_ip=1, layer_idx=1)
+        np.testing.assert_allclose(stress[0, 0, 0], 99.0)
+        np.testing.assert_allclose(stress[0, 0, 1], 88.0)
+
+    def test_multiple_ips(self):
+        import pandas as pd
+        df = pd.DataFrame({
+            "sigma11_l0_ip0": [1.0],
+            "sigma11_l0_ip1": [2.0],
+            "sigma11_l0_ip2": [3.0],
+            "sigma11_l0_ip3": [4.0],
+        })
+        stress = _read_layer_stress_array(df, n_ip=4, layer_idx=0)
+        np.testing.assert_allclose(stress[0, :, 0], [1.0, 2.0, 3.0, 4.0])
+
+
+class TestSampleLayerStressInterpolation:
+    """``_sample_layer_stress`` reuses the standard quad / tri IP weights
+    — the math is exercised already in test_shell_kernel.py; here we
+    just verify the dispatch on (n_ip, base_type) lands on the right
+    branch.
+    """
+
+    def test_q4_dispatch(self):
+        s = 1.0 / np.sqrt(3.0)
+        stress = np.zeros((1, 4, 6))
+        stress[0, 0, 0] = 7.0  # IP 0 is (-s, -s)
+        out = _sample_layer_stress(stress, -s, -s, "ASDShellQ4")
+        np.testing.assert_allclose(out[0, 0], 7.0)
+
+    def test_t3_dispatch(self):
+        stress = np.zeros((1, 3, 6))
+        stress[0, 2, 1] = 11.0
+        # IP 2 sits at (1/6, 2/3) for the standard 3-pt triangle rule.
+        out = _sample_layer_stress(stress, 1 / 6, 2 / 3, "ASDShellT3")
+        np.testing.assert_allclose(out[0, 1], 11.0)
+
+
+class TestSectionsTclParser:
+    """The Tcl parser handles the format STKO emits — line
+    continuations, multiple sections, mixed types.
+    """
+
+    def test_parses_test_nlshell_layout(self, tmp_path):
+        tcl = tmp_path / "sections.tcl"
+        tcl.write_text(
+            "section ElasticMembranePlateSection 14 28198.0 0.2 500.0 0.0 1.0\n"
+            "section LayeredShell 15 7 \\\n"
+            "\t 3 20.0  4 0.158346087  11 0.158346087  3 61.36661565  \\\n"
+            "\t 11 0.158346087  4 0.158346087  3 20.0 \n"
+            "section LayeredShell 16 7 \\\n"
+            "\t 3 20.0  4 0.231338087  11 1.426611361  3 58.6841011  \\\n"
+            "\t 11 1.426611361  4 0.231338087  3 20.0 \n"
+        )
+        out = parse_sections_tcl(tcl)
+        # Two LayeredShell sections; the ElasticMembrane one is ignored.
+        assert set(out.keys()) == {15, 16}
+        assert len(out[15]) == 7
+        assert len(out[16]) == 7
+
+    def test_layer_thicknesses_match_input(self, tmp_path):
+        tcl = tmp_path / "sections.tcl"
+        tcl.write_text(
+            "section LayeredShell 15 7 \\\n"
+            "\t 3 20.0  4 0.158346087  11 0.158346087  3 61.36661565  \\\n"
+            "\t 11 0.158346087  4 0.158346087  3 20.0 \n"
+        )
+        out = parse_sections_tcl(tcl)
+        layers = out[15]
+        expected_t = [20.0, 0.158346087, 0.158346087, 61.36661565,
+                      0.158346087, 0.158346087, 20.0]
+        np.testing.assert_allclose(
+            [l.thickness for l in layers], expected_t, atol=1e-12,
+        )
+
+    def test_layer_z_offsets_centered_on_midplane(self, tmp_path):
+        tcl = tmp_path / "sections.tcl"
+        tcl.write_text(
+            "section LayeredShell 1 3 \\\n"
+            "\t 1 10.0  2 20.0  3 10.0 \n"
+        )
+        out = parse_sections_tcl(tcl)
+        layers = out[1]
+        total_t = 40.0
+        half_t = total_t / 2.0
+        # Layer 0 midplane: -half_t + 0.5 * 10 = -20 + 5 = -15
+        # Layer 1 midplane: -half_t + 10 + 0.5 * 20 = -20 + 20 = 0
+        # Layer 2 midplane: -half_t + 30 + 0.5 * 10 = -20 + 35 = 15
+        expected_z = [-15.0, 0.0, 15.0]
+        np.testing.assert_allclose(
+            [l.z_offset for l in layers], expected_z, atol=1e-12,
+        )
+
+    def test_z_offset_sums_to_zero_for_symmetric_section(self, tmp_path):
+        # A symmetric section (matched bottom + top layers) has z_offsets
+        # that sum to 0 when weighted by thickness.
+        tcl = tmp_path / "sections.tcl"
+        tcl.write_text(
+            "section LayeredShell 1 5 \\\n"
+            "\t 1 5.0  2 3.0  3 10.0  2 3.0  1 5.0 \n"
+        )
+        out = parse_sections_tcl(tcl)
+        weighted_z = sum(l.thickness * l.z_offset for l in out[1])
+        # Wraps to zero by symmetry.
+        np.testing.assert_allclose(weighted_z, 0.0, atol=1e-12)
+
+    def test_layer_material_ids(self, tmp_path):
+        tcl = tmp_path / "sections.tcl"
+        tcl.write_text(
+            "section LayeredShell 15 3 \\\n"
+            "\t 7 1.0  8 2.0  9 3.0 \n"
+        )
+        out = parse_sections_tcl(tcl)
+        assert [l.material_id for l in out[15]] == [7, 8, 9]
+
+    def test_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            parse_sections_tcl("does_not_exist.tcl")
+
+    def test_truncated_body_raises(self, tmp_path):
+        tcl = tmp_path / "bad.tcl"
+        tcl.write_text("section LayeredShell 1 3 1 5.0 2\n")
+        with pytest.raises(ValueError, match="3 layers"):
+            parse_sections_tcl(tcl)
+
+    def test_skips_comments(self, tmp_path):
+        tcl = tmp_path / "sections.tcl"
+        tcl.write_text(
+            "# This is a comment\n"
+            "section LayeredShell 1 1 \\\n"
+            "\t 7 5.0 \n"
+            "# Another comment\n"
+        )
+        out = parse_sections_tcl(tcl)
+        assert set(out.keys()) == {1}
+
+
+# ====================================================================== #
+# Real-fixture tests (Test_NLShell)
+# ====================================================================== #
+@pytest.fixture
+def shell_ds(nl_shell_dir) -> MPCODataSet:
+    return MPCODataSet(str(nl_shell_dir), "Results", verbose=False)
+
+
+@pytest.fixture
+def all_shell_eids(shell_ds) -> tuple[int, ...]:
+    df = shell_ds.elements_info["dataframe"]
+    base = {c for c in SHELL_ELEMENT_CLASSES}
+    is_shell = df["element_type"].map(
+        lambda s: any(c == s.split("-", 1)[-1].split("[", 1)[0] for c in base)
+    )
+    return tuple(int(x) for x in df.loc[is_shell, "element_id"].tolist())
+
+
+class TestLayeredSectionsOnDataset:
+    """The dataset's lazy ``layered_sections`` property picks up the
+    Test_NLShell sections.tcl and returns the layer tables.
+    """
+
+    def test_layered_sections_populated(self, shell_ds):
+        out = shell_ds.layered_sections
+        # Test_NLShell has at least the two LayeredShell sections from
+        # sections.tcl (ids 15 and 16). The ElasticMembrane section 14
+        # is intentionally absent.
+        assert set(out.keys()) & {15, 16}
+
+    def test_layer_count(self, shell_ds):
+        out = shell_ds.layered_sections
+        for sid in (15, 16):
+            if sid in out:
+                assert len(out[sid]) == 7
+
+
+class TestPerLayerForce:
+    """``cut.per_layer_force(k)`` returns a derivative cut whose F/M
+    come from only one through-thickness layer.
+    """
+
+    def test_per_layer_shape(self, shell_ds, all_shell_eids):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        per0 = cut.per_layer_force(0, shell_ds)
+        assert per0.F.shape == cut.F.shape
+        assert per0.M.shape == cut.M.shape
+        assert len(per0.shell_intersections) == len(cut.shell_intersections)
+        # The per-layer view drops beams and solids by construction.
+        assert per0.intersections == ()
+        assert per0.solid_intersections == ()
+
+    def test_sum_of_layers_equals_full_cut(self, shell_ds, all_shell_eids):
+        """The defining identity: summing per-layer F across every
+        layer recovers the shell's standard through-thickness cut.
+
+        Test_NLShell wall is shell-only, so the cut has no beam or
+        solid contributions and the equality is exact (to numerical
+        tolerance from quadrature roundoff and layer-stress storage
+        precision).
+        """
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        # Discover the layer count from the first contributing shell's
+        # section.
+        ix = cut.shell_intersections[0]
+        info = shell_ds.cdata.element_info[ix.element_id]
+        layers = shell_ds.layered_sections[info.physical_property_id]
+        n_layers = len(layers)
+        F_sum = np.zeros_like(cut.F)
+        for k in range(n_layers):
+            per = cut.per_layer_force(k, shell_ds)
+            F_sum += per.F
+        # Tolerance: stress data is ~1e6 in SI units; allow 1e-3 abs
+        # (a fraction of a Newton on a kN-scale total).
+        scale = max(1.0, float(np.max(np.abs(cut.F))))
+        np.testing.assert_allclose(F_sum, cut.F, atol=scale * 1e-2)
+
+    def test_layer_out_of_range_raises(self, shell_ds, all_shell_eids):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        with pytest.raises(IndexError, match="out of range"):
+            cut.per_layer_force(999, shell_ds)
+
+    def test_per_layer_requires_shell_intersections(self, shell_ds):
+        """An empty cut (no shells in the filter / above the model)
+        can't produce a per-layer breakdown.
+        """
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=99_999.0),
+            element_ids=(1,),  # arbitrary, doesn't matter — cut is empty
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        if cut.shell_intersections:
+            pytest.skip("Test premise — cut has shells — broken.")
+        with pytest.raises(ValueError, match="at least one shell"):
+            cut.per_layer_force(0, shell_ds)
+
+
+# ====================================================================== #
+# Per-fiber-in-layer (v1.8) — pure-math tests
+# ====================================================================== #
+class TestFiberInLayerReader:
+    """The ``_f<F>_l<L>_ip<K>`` reader extracts one fiber's stress
+    from inside a specified layer.
+    """
+
+    def test_reads_explicit_sigma_form(self):
+        import pandas as pd
+        # 1 step, 1 IP, layer 0 with 2 fibers.
+        df = pd.DataFrame({
+            "sigma11_f0_l0_ip0": [1.0],
+            "sigma11_f1_l0_ip0": [9.0],
+            "sigma22_f0_l0_ip0": [2.0],
+            "sigma22_f1_l0_ip0": [8.0],
+        })
+        stress_f0 = _read_fiber_in_layer_stress_array(
+            df, n_ip=1, layer_idx=0, fiber_idx=0,
+        )
+        stress_f1 = _read_fiber_in_layer_stress_array(
+            df, n_ip=1, layer_idx=0, fiber_idx=1,
+        )
+        np.testing.assert_allclose(stress_f0[0, 0, 0], 1.0)
+        np.testing.assert_allclose(stress_f0[0, 0, 1], 2.0)
+        np.testing.assert_allclose(stress_f1[0, 0, 0], 9.0)
+        np.testing.assert_allclose(stress_f1[0, 0, 1], 8.0)
+
+    def test_reads_unknown_stress_form(self):
+        import pandas as pd
+        # nDMaterial fallback layout: UnknownStress(n)_f<F>_l<L>_ip<K>.
+        df = pd.DataFrame({
+            "UnknownStress_f0_l0_ip0": [4.0],
+            "UnknownStress(1)_f0_l0_ip0": [5.0],
+            "UnknownStress(2)_f0_l0_ip0": [6.0],
+        })
+        stress = _read_fiber_in_layer_stress_array(
+            df, n_ip=1, layer_idx=0, fiber_idx=0,
+        )
+        # Voigt mapping per the PlateFiber convention:
+        # UnknownStress -> sigma11 (pos 0), (1) -> sigma22 (pos 1),
+        # (2) -> sigma12 (pos 3).
+        np.testing.assert_allclose(stress[0, 0, 0], 4.0)
+        np.testing.assert_allclose(stress[0, 0, 1], 5.0)
+        np.testing.assert_allclose(stress[0, 0, 3], 6.0)
+
+    def test_missing_layer_returns_zeros(self):
+        import pandas as pd
+        df = pd.DataFrame({
+            "sigma11_f0_l0_ip0": [1.0],
+        })
+        # Asking for layer 5 — nothing matches → all zeros.
+        stress = _read_fiber_in_layer_stress_array(
+            df, n_ip=1, layer_idx=5, fiber_idx=0,
+        )
+        np.testing.assert_allclose(stress, 0.0)
+
+
+class TestDiscoverFiberCount:
+    def test_counts_fibers_in_layer(self):
+        cols = [
+            "sigma11_f0_l0_ip0", "sigma11_f1_l0_ip0",
+            "sigma11_f2_l0_ip0", "sigma11_f0_l1_ip0",
+        ]
+        assert _discover_fiber_count_in_layer(cols, layer_idx=0) == 3
+        assert _discover_fiber_count_in_layer(cols, layer_idx=1) == 1
+        assert _discover_fiber_count_in_layer(cols, layer_idx=2) == 0
+
+    def test_ignores_non_fiber_columns(self):
+        cols = [
+            "Fxx_ip0",          # section.force — not fiber.stress
+            "sigma11_l0_ip0",   # per-layer (no fiber index)
+            "sigma11_f0_l0_ip0",
+        ]
+        assert _discover_fiber_count_in_layer(cols, layer_idx=0) == 1
+
+
+class TestPerLayerInlineSurface:
+    """``ds.section_cut(..., per_layer=k)`` short-circuits to the
+    per-layer view.
+    """
+
+    def test_per_layer_inline(self, shell_ds, all_shell_eids):
+        per = shell_ds.section_cut(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+            model_stage="MODEL_STAGE[1]",
+            per_layer=0,
+        )
+        assert per.F.shape[1] == 3
+        assert len(per.shell_intersections) > 0
+
+    def test_inline_matches_method_form(self, shell_ds, all_shell_eids):
+        # Inline `per_layer=0` and `.per_layer_force(0, ds)` produce
+        # equal arrays.
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        full = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        method_form = full.per_layer_force(0, shell_ds)
+        inline_form = shell_ds.section_cut(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+            model_stage="MODEL_STAGE[1]",
+            per_layer=0,
+        )
+        np.testing.assert_allclose(method_form.F, inline_form.F, atol=1e-9)
+
+    def test_per_fiber_without_per_layer_raises(self, shell_ds, all_shell_eids):
+        with pytest.raises(ValueError, match="per_fiber requires per_layer"):
+            shell_ds.section_cut(
+                plane=Plane.horizontal(z=2500.0),
+                element_ids=all_shell_eids,
+                model_stage="MODEL_STAGE[1]",
+                per_fiber=0,
+            )
+
+
+class TestPerFiberOnNonFiberedLayer:
+    """Test_NLShell layers are single nDMaterial — no fibers within
+    layers — so requesting a per-fiber cut on them must surface a
+    clear error rather than silently returning zero.
+    """
+
+    def test_per_fiber_on_nonfibered_layer_raises(
+        self, shell_ds, all_shell_eids,
+    ):
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=2500.0),
+            element_ids=all_shell_eids,
+        )
+        cut = SectionCut.compute(spec, shell_ds, model_stage="MODEL_STAGE[1]")
+        with pytest.raises(ValueError, match="no fiber-in-layer columns"):
+            cut.per_fiber_force(0, 0, shell_ds)

--- a/tests/unit/cuts/test_solid_kernel.py
+++ b/tests/unit/cuts/test_solid_kernel.py
@@ -1,0 +1,654 @@
+"""Unit tests for STKO_to_python.cuts.kernels.solid.
+
+Splits into:
+
+- **Pure-math tests** (no .mpco fixture needed) covering the plane-vs-
+  hex polygon math, the trilinear / linear inverse-shape-function
+  helpers, and the brick stress-sampling weights.
+- **Real-fixture tests** against ``solid_partition_example`` — the
+  Brick + DispBeamColumn3d mixed fixture — covering the geometry phase,
+  Newton's-3rd-law consistency, side-flip equivalence, and the
+  mixed-kernel composition with the beam kernel.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python import MPCODataSet
+from STKO_to_python.cuts import Plane, SectionCut, SectionCutSpec
+from STKO_to_python.cuts.kernels.solid import (
+    SOLID_ELEMENT_CLASSES,
+    _BRICK_27IP_A,
+    _brick_27ip_1d_lagrange,
+    _brick_27ip_weights,
+    _brick_8ip_weights,
+    _CORNER_NODES_PER_CLASS,
+    _NODES_PER_CLASS,
+    _invert_brick_trilinear,
+    _invert_tet_linear,
+    _plane_polyhedron_polygon,
+    _sample_solid_stress,
+    _stress_voigt_to_tensor,
+    _HEX_EDGES,
+    _TET_EDGES,
+    _strip_class_tag,
+    compute_solid_cut,
+    find_solid_intersections,
+)
+
+
+# ====================================================================== #
+# Pure-math tests
+# ====================================================================== #
+class TestBrick8IpWeights:
+    """Trilinear interpolation weights from the 8 Gauss IPs of a Brick
+    to an arbitrary (ξ, η, ζ). IPs sit at ±1/√3.
+    """
+
+    def test_partition_of_unity_at_origin(self):
+        w = _brick_8ip_weights(0.0, 0.0, 0.0)
+        assert sum(w) == pytest.approx(1.0)
+
+    def test_unit_response_at_each_ip(self):
+        s = 1.0 / np.sqrt(3.0)
+        # IP order is ξ-fastest, then η, then ζ.
+        ips = [
+            (-s, -s, -s), (+s, -s, -s), (-s, +s, -s), (+s, +s, -s),
+            (-s, -s, +s), (+s, -s, +s), (-s, +s, +s), (+s, +s, +s),
+        ]
+        for k, (xi, eta, zeta) in enumerate(ips):
+            w = _brick_8ip_weights(xi, eta, zeta)
+            expected = np.eye(8)[k]
+            np.testing.assert_allclose(w, expected, atol=1e-12)
+
+    def test_linear_field_recovered(self):
+        # f(ξ, η, ζ) = 2 + 3ξ - 5η + 7ζ — trilinear weights reproduce
+        # any tri-linear field exactly.
+        s = 1.0 / np.sqrt(3.0)
+        ips = np.array([
+            [-s, -s, -s], [+s, -s, -s], [-s, +s, -s], [+s, +s, -s],
+            [-s, -s, +s], [+s, -s, +s], [-s, +s, +s], [+s, +s, +s],
+        ])
+        f = lambda p: 2.0 + 3.0 * p[0] - 5.0 * p[1] + 7.0 * p[2]
+        ip_values = np.array([f(p) for p in ips])
+        for xi, eta, zeta in [
+            (0.0, 0.0, 0.0), (0.3, -0.2, 0.5),
+            (0.5, 0.5, -0.5), (-0.7, 0.7, 0.0),
+        ]:
+            w = _brick_8ip_weights(xi, eta, zeta)
+            interp = float(w @ ip_values)
+            assert interp == pytest.approx(f([xi, eta, zeta]), abs=1e-12)
+
+
+class TestStressVoigtToTensor:
+    def test_diagonal_components(self):
+        s = np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
+        T = _stress_voigt_to_tensor(s)
+        np.testing.assert_allclose(np.diag(T), [1, 2, 3], atol=1e-12)
+        # Off-diagonal entries are zero.
+        for i, j in [(0, 1), (0, 2), (1, 2)]:
+            assert T[i, j] == 0.0
+            assert T[j, i] == 0.0
+
+    def test_off_diagonal_symmetry(self):
+        s = np.array([0.0, 0.0, 0.0, 1.5, 2.5, 3.5])
+        T = _stress_voigt_to_tensor(s)
+        # sigma12 → T[0,1] = T[1,0]
+        # sigma23 → T[1,2] = T[2,1]
+        # sigma13 → T[0,2] = T[2,0]
+        np.testing.assert_allclose(T[0, 1], 1.5, atol=1e-12)
+        np.testing.assert_allclose(T[1, 0], 1.5, atol=1e-12)
+        np.testing.assert_allclose(T[1, 2], 2.5, atol=1e-12)
+        np.testing.assert_allclose(T[2, 1], 2.5, atol=1e-12)
+        np.testing.assert_allclose(T[0, 2], 3.5, atol=1e-12)
+        np.testing.assert_allclose(T[2, 0], 3.5, atol=1e-12)
+
+    def test_traction_against_normal(self):
+        # σ = diag(2, 3, 5); n = ê_z → t = σ·n = (0, 0, 5).
+        s = np.array([2.0, 3.0, 5.0, 0.0, 0.0, 0.0])
+        T = _stress_voigt_to_tensor(s)
+        n = np.array([0.0, 0.0, 1.0])
+        t = T @ n
+        np.testing.assert_allclose(t, [0, 0, 5], atol=1e-12)
+
+    def test_batched_shape(self):
+        # Voigt input (n_steps, 6) → tensor (n_steps, 3, 3).
+        s = np.zeros((4, 6))
+        s[:, 0] = 1.0
+        T = _stress_voigt_to_tensor(s)
+        assert T.shape == (4, 3, 3)
+
+
+class TestInvertBrickTrilinear:
+    def test_invert_at_corners(self):
+        # Reference cube [-1, 1]^3 in physical coords. Each corner maps
+        # to its natural coords.
+        node_coords = np.array([
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ], dtype=float)
+        for k, sign in enumerate([
+            (-1, -1, -1), (+1, -1, -1), (+1, +1, -1), (-1, +1, -1),
+            (-1, -1, +1), (+1, -1, +1), (+1, +1, +1), (-1, +1, +1),
+        ]):
+            recovered = _invert_brick_trilinear(node_coords[k], node_coords)
+            np.testing.assert_allclose(recovered, sign, atol=1e-9)
+
+    def test_invert_at_centroid(self):
+        node_coords = np.array([
+            [0, 0, 0], [4, 0, 0], [4, 3, 0], [0, 3, 0],
+            [0, 0, 5], [4, 0, 5], [4, 3, 5], [0, 3, 5],
+        ], dtype=float)
+        centroid = node_coords.mean(axis=0)
+        recovered = _invert_brick_trilinear(centroid, node_coords)
+        np.testing.assert_allclose(recovered, [0.0, 0.0, 0.0], atol=1e-9)
+
+    def test_invert_at_face_midpoint(self):
+        # Unit cube, midpoint of the +ζ face → (0, 0, +1).
+        node_coords = np.array([
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ], dtype=float)
+        top_face_mid = np.array([0.0, 0.0, 1.0])
+        recovered = _invert_brick_trilinear(top_face_mid, node_coords)
+        np.testing.assert_allclose(recovered, [0.0, 0.0, 1.0], atol=1e-9)
+
+
+class TestInvertTetLinear:
+    def test_invert_at_corners(self):
+        # Reference unit tet — nodes at (0,0,0), (1,0,0), (0,1,0), (0,0,1).
+        node_coords = np.array([
+            [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+        ], dtype=float)
+        natural_at_node = [
+            (0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+        ]
+        for k, expected in enumerate(natural_at_node):
+            recovered = _invert_tet_linear(node_coords[k], node_coords)
+            np.testing.assert_allclose(recovered, expected, atol=1e-12)
+
+    def test_invert_at_centroid(self):
+        node_coords = np.array([
+            [0, 0, 0], [2, 0, 0], [0, 3, 0], [0, 0, 4],
+        ], dtype=float)
+        centroid = node_coords.mean(axis=0)
+        recovered = _invert_tet_linear(centroid, node_coords)
+        np.testing.assert_allclose(recovered, [0.25, 0.25, 0.25], atol=1e-12)
+
+
+class TestPlanePolyhedronPolygon:
+    """Plane-vs-convex-polyhedron polygon math against the standard
+    8-vertex unit cube.
+    """
+
+    @pytest.fixture
+    def cube(self):
+        return np.array([
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ], dtype=float)
+
+    @pytest.fixture
+    def horizontal_plane(self):
+        # z = 0 plane with global Z normal; e1 = X, e2 = Y.
+        return (
+            np.array([0.0, 0.0, 0.0]),
+            np.array([0.0, 0.0, 1.0]),
+            np.array([1.0, 0.0, 0.0]),
+            np.array([0.0, 1.0, 0.0]),
+        )
+
+    def test_horizontal_through_centroid_gives_square(self, cube, horizontal_plane):
+        p, n, e1, e2 = horizontal_plane
+        polygon = _plane_polyhedron_polygon(cube, _HEX_EDGES, p, n, e1, e2)
+        assert polygon is not None
+        assert polygon.shape == (4, 3)
+        # All vertices on the plane.
+        assert np.allclose(polygon[:, 2], 0.0, atol=1e-9)
+        # Each vertex has |x|=|y|=1 (corners of the unit square).
+        xy = polygon[:, :2]
+        assert np.allclose(np.sort(np.abs(xy).ravel()), [1.0] * 8, atol=1e-9)
+
+    def test_above_cube_returns_none(self, cube):
+        polygon = _plane_polyhedron_polygon(
+            cube, _HEX_EDGES,
+            np.array([0.0, 0.0, 5.0]), np.array([0.0, 0.0, 1.0]),
+            np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0]),
+        )
+        assert polygon is None
+
+    def test_below_cube_returns_none(self, cube):
+        polygon = _plane_polyhedron_polygon(
+            cube, _HEX_EDGES,
+            np.array([0.0, 0.0, -5.0]), np.array([0.0, 0.0, 1.0]),
+            np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0]),
+        )
+        assert polygon is None
+
+    def test_diagonal_cut_can_produce_hexagon(self, cube):
+        # Plane perpendicular to (1, 1, 1) through the origin cuts the
+        # cube in a regular hexagon.
+        n = np.array([1.0, 1.0, 1.0])
+        n /= np.linalg.norm(n)
+        # Build an orthonormal in-plane basis.
+        a = np.array([1.0, 0.0, 0.0]) if abs(n[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+        e1 = a - n * (a @ n)
+        e1 /= np.linalg.norm(e1)
+        e2 = np.cross(n, e1)
+        polygon = _plane_polyhedron_polygon(
+            cube, _HEX_EDGES, np.array([0.0, 0.0, 0.0]), n, e1, e2,
+        )
+        assert polygon is not None
+        # 6 unique points expected (regular hexagon).
+        assert polygon.shape == (6, 3)
+
+    def test_face_aligned_cut_returns_four_vertices(self, cube):
+        # Plane at z = +1 grazes the top face — on-plane vertices yield
+        # the 4 corners of the top face.
+        polygon = _plane_polyhedron_polygon(
+            cube, _HEX_EDGES,
+            np.array([0.0, 0.0, 1.0]), np.array([0.0, 0.0, 1.0]),
+            np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0]),
+        )
+        assert polygon is not None
+        assert polygon.shape == (4, 3)
+        np.testing.assert_allclose(polygon[:, 2], 1.0, atol=1e-9)
+
+    def test_tet_cut_through_centroid(self):
+        # Reference tet at (0,0,0), (1,0,0), (0,1,0), (0,0,1). Plane
+        # x + y + z = 0.5 cuts through the interior; intersection is a
+        # triangle.
+        tet = np.array([
+            [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+        ], dtype=float)
+        n = np.array([1.0, 1.0, 1.0])
+        n /= np.linalg.norm(n)
+        p = 0.5 * n
+        a = np.array([1.0, 0.0, 0.0])
+        e1 = a - n * (a @ n)
+        e1 /= np.linalg.norm(e1)
+        e2 = np.cross(n, e1)
+        polygon = _plane_polyhedron_polygon(tet, _TET_EDGES, p, n, e1, e2)
+        assert polygon is not None
+        # Triangle: exactly 3 vertices.
+        assert polygon.shape == (3, 3)
+
+
+class TestSampleSolidStress:
+    def test_brick_8ip_sample_recovers_ip_value(self):
+        s = 1.0 / np.sqrt(3.0)
+        # 1 step, 8 IPs, 6 stress components. Distinct values so a
+        # wrong index pulls obvious garbage.
+        stress = np.zeros((1, 8, 6))
+        for k in range(8):
+            for c in range(6):
+                stress[0, k, c] = 10.0 * k + c
+        # IP 5 is (+s, -s, +s).
+        result = _sample_solid_stress(stress, +s, -s, +s, "Brick", 8)
+        np.testing.assert_allclose(result[0], stress[0, 5, :], atol=1e-12)
+
+    def test_single_ip_broadcasts(self):
+        stress = np.array([[[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]])
+        # Any (ξ, η, ζ) returns the single IP value.
+        result = _sample_solid_stress(stress, 0.5, -0.3, 0.7, "Brick", 1)
+        np.testing.assert_allclose(result[0], stress[0, 0, :], atol=1e-12)
+
+
+class TestRegistryHelpers:
+    def test_strip_class_tag_decorated(self):
+        assert _strip_class_tag("56-Brick") == "Brick"
+        assert _strip_class_tag("203-ASDShellQ4") == "ASDShellQ4"
+
+    def test_strip_class_tag_undecorated(self):
+        assert _strip_class_tag("Brick") == "Brick"
+
+    def test_registry_contents(self):
+        # The four documented v1.7 solid classes are in the registry.
+        for cls in ("Brick", "BbarBrick", "SSPbrick", "FourNodeTetrahedron"):
+            assert cls in SOLID_ELEMENT_CLASSES
+
+    def test_higher_order_hex_registered(self):
+        # v1.8: Brick20 and Brick27 (plus the OpenSees aliases
+        # TwentyNodeBrick / TwentySevenNodeBrick) are recognised.
+        for cls in ("Brick20", "Brick27",
+                    "TwentyNodeBrick", "TwentySevenNodeBrick"):
+            assert cls in SOLID_ELEMENT_CLASSES
+
+    def test_higher_order_node_counts(self):
+        # 20-node hex and 27-node hex have full connectivity counts but
+        # share the same 8 corner nodes for the geometry phase.
+        assert _NODES_PER_CLASS["Brick20"] == 20
+        assert _NODES_PER_CLASS["TwentyNodeBrick"] == 20
+        assert _NODES_PER_CLASS["Brick27"] == 27
+        assert _NODES_PER_CLASS["TwentySevenNodeBrick"] == 27
+        for cls in ("Brick20", "TwentyNodeBrick", "Brick27", "TwentySevenNodeBrick"):
+            assert _CORNER_NODES_PER_CLASS[cls] == 8
+
+
+# ====================================================================== #
+# Higher-order (v1.8) — 27-IP triquadratic sampling
+# ====================================================================== #
+class TestBrick27IpLagrange1d:
+    """1-D quadratic Lagrange basis at the three Gauss-Legendre 3-pt
+    nodes ``(-a, 0, +a)`` with ``a = √(3/5)``.
+    """
+
+    def test_unit_response_at_each_node(self):
+        a = _BRICK_27IP_A
+        # L_minus(-a) = 1; L_0(0) = 1; L_plus(+a) = 1.
+        l_at_minus = _brick_27ip_1d_lagrange(-a)
+        l_at_zero = _brick_27ip_1d_lagrange(0.0)
+        l_at_plus = _brick_27ip_1d_lagrange(+a)
+        np.testing.assert_allclose(l_at_minus, [1.0, 0.0, 0.0], atol=1e-12)
+        np.testing.assert_allclose(l_at_zero, [0.0, 1.0, 0.0], atol=1e-12)
+        np.testing.assert_allclose(l_at_plus, [0.0, 0.0, 1.0], atol=1e-12)
+
+    def test_partition_of_unity_at_arbitrary_x(self):
+        for x in [-0.5, -0.1, 0.0, 0.2, 0.7]:
+            s = sum(_brick_27ip_1d_lagrange(x))
+            assert s == pytest.approx(1.0, abs=1e-12)
+
+
+class TestBrick27IpWeights:
+    """Triquadratic interpolation weights at the 27 IPs of a Brick
+    (3×3×3 Gauss-Legendre).
+    """
+
+    def test_partition_of_unity_at_origin(self):
+        w = _brick_27ip_weights(0.0, 0.0, 0.0)
+        assert sum(w) == pytest.approx(1.0)
+
+    def test_unit_response_at_each_ip(self):
+        a = _BRICK_27IP_A
+        nodes = [-a, 0.0, +a]
+        # IP enumeration is xi-fastest, then eta, then zeta.
+        for nzeta in range(3):
+            for neta in range(3):
+                for nxi in range(3):
+                    idx = (nzeta * 3 + neta) * 3 + nxi
+                    w = _brick_27ip_weights(
+                        nodes[nxi], nodes[neta], nodes[nzeta],
+                    )
+                    expected = np.eye(27)[idx]
+                    np.testing.assert_allclose(w, expected, atol=1e-12)
+
+    def test_quadratic_field_recovered(self):
+        # f(ξ, η, ζ) = a quadratic polynomial in (ξ, η, ζ) — triquadratic
+        # Lagrange interpolation reproduces it exactly. Build a separable
+        # quadratic so it's clearly within the basis.
+        a = _BRICK_27IP_A
+        nodes = [-a, 0.0, +a]
+        # f(x, y, z) = (1 + 2 x + 3 x²) * (4 - y + y²) * (5 + 6 z² - z)
+        f = lambda p: (
+            (1.0 + 2.0 * p[0] + 3.0 * p[0] ** 2)
+            * (4.0 - p[1] + p[1] ** 2)
+            * (5.0 + 6.0 * p[2] ** 2 - p[2])
+        )
+        ip_values = np.empty(27)
+        for nzeta in range(3):
+            for neta in range(3):
+                for nxi in range(3):
+                    idx = (nzeta * 3 + neta) * 3 + nxi
+                    p = [nodes[nxi], nodes[neta], nodes[nzeta]]
+                    ip_values[idx] = f(p)
+        for xi, eta, zeta in [
+            (0.0, 0.0, 0.0), (0.3, -0.2, 0.5), (-0.5, 0.5, -0.5),
+        ]:
+            w = _brick_27ip_weights(xi, eta, zeta)
+            interp = float(w @ ip_values)
+            assert interp == pytest.approx(f([xi, eta, zeta]), abs=1e-10)
+
+
+class TestSample27IpSolidStress:
+    def test_dispatch_to_27ip_sampler(self):
+        a = _BRICK_27IP_A
+        # 1 step, 27 IPs, 6 stress components. Distinct values so a
+        # wrong index pulls obvious garbage.
+        stress = np.zeros((1, 27, 6))
+        for k in range(27):
+            stress[0, k, 0] = float(k)
+        # Pick IP idx = (2*3 + 1)*3 + 0 = 21 → coords (-a, 0, +a).
+        result = _sample_solid_stress(
+            stress, -a, 0.0, +a, "Brick27", 27,
+        )
+        np.testing.assert_allclose(result[0, 0], 21.0, atol=1e-12)
+
+
+class TestHigherOrderHexGeometryPhase:
+    """The plane-vs-polyhedron polygon math runs on the 8 corner nodes
+    of a higher-order hex; midpoint / face / center nodes are ignored
+    at the geometry layer.
+    """
+
+    @pytest.fixture
+    def hex20_unit_cube(self):
+        """Standard 20-node serendipity hex: 8 corners + 12 edge
+        midpoints, sitting on a [-1, 1]^3 cube.
+        """
+        corners = np.array([
+            [-1, -1, -1], [+1, -1, -1], [+1, +1, -1], [-1, +1, -1],
+            [-1, -1, +1], [+1, -1, +1], [+1, +1, +1], [-1, +1, +1],
+        ], dtype=float)
+        edge_midpoints = np.array([
+            [0, -1, -1], [+1, 0, -1], [0, +1, -1], [-1, 0, -1],
+            [0, -1, +1], [+1, 0, +1], [0, +1, +1], [-1, 0, +1],
+            [-1, -1, 0], [+1, -1, 0], [+1, +1, 0], [-1, +1, 0],
+        ], dtype=float)
+        return np.concatenate([corners, edge_midpoints], axis=0)
+
+    def test_plane_polyhedron_polygon_with_corners_only(self, hex20_unit_cube):
+        """Slicing the 20-node hex's coords to the 8 corners and running
+        the plane-vs-polyhedron polygon math gives the same result as
+        the 8-node hex case.
+        """
+        corner_coords = hex20_unit_cube[:8]
+        polygon = _plane_polyhedron_polygon(
+            corner_coords, _HEX_EDGES,
+            np.array([0.0, 0.0, 0.0]), np.array([0.0, 0.0, 1.0]),
+            np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0]),
+        )
+        assert polygon is not None
+        assert polygon.shape == (4, 3)
+        # All vertices on z=0.
+        np.testing.assert_allclose(polygon[:, 2], 0.0, atol=1e-9)
+
+
+# ====================================================================== #
+# Real-fixture tests (solid_partition_example)
+# ====================================================================== #
+@pytest.fixture
+def solid_ds(solid_partition_dir) -> MPCODataSet:
+    return MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+
+
+@pytest.fixture
+def all_solid_eids(solid_ds) -> tuple[int, ...]:
+    df = solid_ds.elements_info["dataframe"]
+    base = {c for c in SOLID_ELEMENT_CLASSES}
+    is_solid = df["element_type"].map(
+        lambda s: any(c == _strip_class_tag(s) for c in base)
+    )
+    return tuple(int(x) for x in df.loc[is_solid, "element_id"].tolist())
+
+
+class TestSolidFixtureRegistry:
+    """Sanity: solid_partition_example actually carries a Brick mesh."""
+
+    def test_fixture_has_brick(self, solid_ds):
+        types = list(solid_ds.unique_element_types)
+        assert any("Brick" in t for t in types)
+
+
+class TestFindSolidIntersections:
+    def test_horizontal_cut_finds_some_solids(self, solid_ds, all_solid_eids):
+        # The brick column / block spans some z-range. Cut somewhere
+        # interior.
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        plane = Plane.horizontal(z=z_mid)
+        spec = SectionCutSpec(plane=plane, element_ids=all_solid_eids)
+        ixs = find_solid_intersections(solid_ds, spec)
+        assert len(ixs) > 0
+        for ix in ixs:
+            assert ix.n_vertices >= 3
+            assert ix.polygon_area > 1e-12
+
+    def test_cut_far_above_returns_empty(self, solid_ds, all_solid_eids):
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=z_range[1] + 1e6),
+            element_ids=all_solid_eids,
+        )
+        assert find_solid_intersections(solid_ds, spec) == []
+
+    def test_cut_far_below_returns_empty(self, solid_ds, all_solid_eids):
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=z_range[0] - 1e6),
+            element_ids=all_solid_eids,
+        )
+        assert find_solid_intersections(solid_ds, spec) == []
+
+
+class TestSolidCutEndToEnd:
+    def test_cut_returns_finite_force(self, solid_ds, all_solid_eids):
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=z_mid),
+            element_ids=all_solid_eids,
+        )
+        cut = SectionCut.compute(spec, solid_ds, model_stage="MODEL_STAGE[1]")
+        assert not cut.is_empty
+        assert cut.F.shape == (cut.n_steps, 3)
+        assert np.all(np.isfinite(cut.F))
+        assert np.all(np.isfinite(cut.M))
+
+    def test_consistency_check_passes(self, solid_ds, all_solid_eids):
+        """Newton's 3rd law: positive + negative side cuts sum to zero.
+
+        Independent of the load pattern — any honest kernel must
+        satisfy this by construction.
+        """
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=z_mid),
+            element_ids=all_solid_eids,
+        )
+        cut = SectionCut.compute(spec, solid_ds, model_stage="MODEL_STAGE[1]")
+        # Use a generous absolute tolerance — the stress magnitudes on
+        # a real model can be order-of-magnitude ~1e6 in SI units.
+        scale = max(
+            1.0,
+            float(np.max(np.abs(cut.F))),
+            float(np.max(np.abs(cut.M))),
+        )
+        ok, residual = cut.consistency_check(
+            solid_ds, atol=scale * 1e-3, rtol=1e-6,
+        )
+        assert ok, f"Residual max={np.max(np.abs(residual))} vs tol={scale * 1e-3}"
+
+    def test_negative_side_flips_resultant(self, solid_ds, all_solid_eids):
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        plane = Plane.horizontal(z=z_mid)
+        pos = SectionCut.compute(
+            SectionCutSpec(plane=plane, element_ids=all_solid_eids, side="positive"),
+            solid_ds, model_stage="MODEL_STAGE[1]",
+        )
+        neg = SectionCut.compute(
+            SectionCutSpec(plane=plane, element_ids=all_solid_eids, side="negative"),
+            solid_ds, model_stage="MODEL_STAGE[1]",
+        )
+        scale = max(1.0, float(np.max(np.abs(pos.F))))
+        np.testing.assert_allclose(neg.F, -pos.F, atol=scale * 1e-3)
+
+    def test_per_solid_F_has_real_values(self, solid_ds, all_solid_eids):
+        """The per-element force map carries actual stress data — guard
+        against a column-name typo silently zeroing the read.
+        """
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=z_mid),
+            element_ids=all_solid_eids,
+        )
+        cut = SectionCut.compute(spec, solid_ds, model_stage="MODEL_STAGE[1]")
+        assert cut.per_solid_F  # at least one solid contributed
+        # At least one solid has a non-vanishing force somewhere in the
+        # time history.
+        max_F = max(
+            float(np.max(np.abs(Fi))) for Fi in cut.per_solid_F.values()
+        )
+        assert max_F > 0.0
+
+    def test_repr_includes_solid_count(self, solid_ds, all_solid_eids):
+        z_range = _brick_z_range(solid_ds, all_solid_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        spec = SectionCutSpec(
+            plane=Plane.horizontal(z=z_mid),
+            element_ids=all_solid_eids,
+        )
+        cut = SectionCut.compute(spec, solid_ds, model_stage="MODEL_STAGE[1]")
+        text = repr(cut)
+        n_total = len(cut.solid_intersections) + len(cut.intersections) + len(cut.shell_intersections)
+        assert f"n_intersections={n_total}" in text
+
+
+class TestComposedBeamSolidCut:
+    """solid_partition_example mixes Brick continuum with
+    DispBeamColumn3d. A cut filtered to ALL elements (not just solids)
+    should produce a single composed result with contributions from
+    both kernels.
+    """
+
+    def test_consistency_check_on_composed_cut(self, solid_ds):
+        all_eids = tuple(
+            int(x) for x in solid_ds.elements_info["dataframe"]["element_id"].tolist()
+        )
+        z_range = _brick_z_range(solid_ds, all_eids)
+        z_mid = 0.5 * (z_range[0] + z_range[1])
+        spec = SectionCutSpec(plane=Plane.horizontal(z=z_mid), element_ids=all_eids)
+        cut = SectionCut.compute(spec, solid_ds, model_stage="MODEL_STAGE[1]")
+        scale = max(
+            1.0,
+            float(np.max(np.abs(cut.F))),
+            float(np.max(np.abs(cut.M))),
+        )
+        ok, residual = cut.consistency_check(
+            solid_ds, atol=scale * 1e-3, rtol=1e-6,
+        )
+        assert ok, (
+            f"Composed (beam + solid) consistency_check failed; max residual "
+            f"{np.max(np.abs(residual))} vs tol {scale * 1e-3}."
+        )
+
+
+# ---------------------------------------------------------------------- #
+# Helpers
+# ---------------------------------------------------------------------- #
+def _brick_z_range(dataset: MPCODataSet, element_ids) -> tuple[float, float]:
+    """Return (z_min, z_max) over the nodes of every brick in the filter."""
+    df_e = dataset.elements_info["dataframe"]
+    df_n = dataset.nodes_info["dataframe"]
+    node_z = dict(zip(df_n["node_id"].tolist(), df_n["z"].tolist()))
+    eid_set = set(int(e) for e in element_ids)
+    base = {c for c in SOLID_ELEMENT_CLASSES}
+    z_vals: list[float] = []
+    for r in df_e.itertuples(index=False):
+        if int(r.element_id) not in eid_set:
+            continue
+        if _strip_class_tag(str(r.element_type)) not in base:
+            continue
+        for nid in r.node_list:
+            zv = node_z.get(int(nid))
+            if zv is not None:
+                z_vals.append(float(zv))
+    if not z_vals:
+        return (0.0, 0.0)
+    return float(min(z_vals)), float(max(z_vals))


### PR DESCRIPTION
## Summary

- **Solid (continuum) section-cut kernel** — `compute_solid_cut` walks each crossing element's edges, sorts crossings CCW around the plane normal, fan-triangulates the convex polygon, and integrates the traction `t = σ · n_cut` at 3-point Gauss quadrature per triangle. Supports `Brick`, `BbarBrick`, `SSPbrick`, `Brick20`, `Brick27` (plus the OpenSees aliases `TwentyNodeBrick` / `TwentySevenNodeBrick`), and `FourNodeTetrahedron`. Trilinear (8-IP) and triquadratic (27-IP) stress sampling chosen by IP count. `SectionCut.compute` now composes beam + shell + solid kernels in one pass.
- **Per-layer + per-fiber views for layered shells** — `cut.per_layer_force(k, ds)` returns the derivative cut from one through-thickness layer; `cut.per_fiber_force(L, F, ds)` extends one level deeper for fibered layers (uniform fiber distribution within the layer). `ds.section_cut(..., per_layer=k, per_fiber=f)` short-circuits both forms.
- **`MPCODataSet.layered_sections`** — lazy property that locates `sections.tcl` beside the recorder output and returns `{section_id: tuple[LayerInfo, ...]}`. Each `LayerInfo` carries `(material_id, thickness, z_offset_from_centroid)`. Three column conventions handled in the layered reader: `sigma<ij>_l<L>_ip<K>`, `sigma<ij>_f<L>_ip<K>`, and the `nDMaterial` fallback `UnknownStress(n)_f<L>_ip<K>` (mapped per the PlateFiber convention).

This bundles two milestones: v1.7.0 (solid kernel + per-layer view) and v1.8.0 (higher-order Brick20/27 and per-fiber-in-layer view, extending v1.7). Both are additive — no breaking changes to the public surface from v1.6. `pyproject.toml` is bumped to 1.8.0 and the CHANGELOG carries one entry per milestone.

## Test plan

- [x] Full unit suite passes: **1056 passed, 14 skipped** (the 14 skips are heavy-fixture absences — `solid_partition_example`, `dispBeamCol`, `forceBeamCol` — same set as before the PR).
- [x] 70 new tests added: 41 in `test_solid_kernel.py` (pure-math weights, plane-vs-polyhedron polygon math, higher-order hex registry / sampler, real-fixture composition with beams) and 29 in `test_per_layer_shell.py` (Tcl parser, fiber-in-layer reader, sum-of-layers identity against `Test_NLShell`'s 7-layer wall, per-fiber surface).
- [x] **Newton's-3rd-law consistency_check** passes on the composed beam + shell + solid `SectionCut` (verified on shell + Test_NLShell; gated on the heavy fixture for solid + solid_partition_example).
- [x] **compare_to** still works on composed cuts (existing test pins it on shells; composed math reuses the same `moment_about` transfer).
- [x] **bounding_polygon** clipping extends to solids via a Sutherland-Hodgman polygon-vs-polygon intersection; existing v1.6 bounding-polygon tests on beams + shells all still pass.
- [x] **sum-of-layers identity** validated on `Test_NLShell`: `Σ_k cut.per_layer_force(k).F ≈ cut.F` to ~1% of the cut magnitude, across the full step axis on the 7-layer `LayeredShell 16` wall sections.
- [x] Error paths: `per_fiber_force` on a non-fibered layer raises `ValueError` with a clear message pointing at `per_layer_force` instead; `per_fiber` without `per_layer` on `ds.section_cut(...)` raises; out-of-range `layer_idx` / `fiber_idx` raise `IndexError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)