### PR TITLE
Add viewer subpackage skeleton + integration plan — v1.9.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,30 @@ jobs:
 
       - name: Run pytest
         run: pytest tests/ -q
+
+  viewer-extras:
+    # Verifies the viewer optional extras resolve and import cleanly.
+    # Runs the same smoke tests as the base matrix above plus the
+    # extras-gated tests that the base matrix skips. Single Python
+    # version is enough for a dep-resolution gate; the base matrix
+    # already covers cross-version compatibility for the library core.
+    name: Viewer extras resolve
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package with viewer + test extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[viewer,test]"
+
+      - name: Run viewer smoke tests
+        run: pytest tests/viewer/ -q

--- a/docs/viewer-refactor-directives.md
+++ b/docs/viewer-refactor-directives.md
@@ -1,6 +1,13 @@
 # Viewer Refactor — Directives
 
-**Status:** brainstorm / design directive. Not a plan yet.
+**Status:** conceptual model — locked. The implementation plan now lives
+under [`docs/viewer/`](viewer/00-roadmap.md):
+
+- [Roadmap](viewer/00-roadmap.md) — phased delivery, semver targets, definition of done per phase.
+- [Architecture](viewer/01-architecture.md) — renderer-agnostic layering, `Backend` protocol, three deployment targets.
+- [Porting from apeGmsh](viewer/02-porting-from-apegmsh.md) — file-by-file lift plan with adaptation notes.
+- [Deployment targets](viewer/03-deployment-targets.md) — local Qt, headless CLI, VNC, Trame web, SSH-cluster guidance.
+
 **Goal:** define the conceptual model for the next-generation STKO_to_python
 viewer so an implementation plan can hang off concrete contracts.
 **Scope:** post-processing only — we render what's in `.mpco`, never edit the model.

--- a/docs/viewer/00-roadmap.md
+++ b/docs/viewer/00-roadmap.md
@@ -1,0 +1,366 @@
+# Viewer Implementation Roadmap
+
+**Status:** plan of record. Graduates `viewer-refactor-directives.md` from
+brainstorm into phased delivery.
+**Anchor docs:**
+[`viewer-refactor-directives.md`](../viewer-refactor-directives.md) (conceptual
+model — Scene/Layer, layer catalog),
+[`01-architecture.md`](01-architecture.md) (renderer-agnostic layering, Backend
+protocol, three deployment targets),
+[`02-porting-from-apegmsh.md`](02-porting-from-apegmsh.md) (concrete file
+lift list and adaptation notes),
+[`03-deployment-targets.md`](03-deployment-targets.md) (local, headless,
+cluster, web).
+
+---
+
+## Vision
+
+Ship a **full desktop post-processing experience** — Qt window with embedded
+3D viewport, time scrubber, diagram settings, picking, animation export — on
+top of the existing matplotlib 2D library, **without** breaking the lightweight
+notebook usage and **without** forcing every user to install Qt/VTK.
+
+The viewer is **opt-in via extras**: `pip install stko_to_python` keeps the
+current numpy/pandas/matplotlib footprint. `pip install stko_to_python[viewer]`
+adds the Qt/PyVista stack.
+
+The architecture is **renderer-agnostic from day one** so the same
+`Scene`/`Layer` graph that drives the Qt window also drives off-screen
+animation export on a cluster, and (later) a Trame-based browser viewer for
+SSH-only workflows.
+
+---
+
+## Current state (anchor: v1.8.0)
+
+What's already shipped on `main`:
+
+- 2D matplotlib plotting: `Plot`, `NodalResultsPlotter`, `ElementResultsPlotter`.
+- `cuts/` section-cut kernels (beam, shell, solid) + their plotting helpers.
+- Per-layer / per-fiber shell views (v1.8.0).
+- Selection sets, query engines, aggregation engine, multi-case `MPCOResults`.
+- No 3D rendering. No animation. No picking. No GUI.
+
+What this plan adds: everything above the "no" line, behind an opt-in extra.
+
+---
+
+## Semver mapping
+
+Adding the viewer subpackage is **purely additive** — no public API of v1.8.0
+changes. New code lives under `STKO_to_python.viewer` (new namespace) and is
+gated behind extras. So everything below stays on the v1.x track until we
+actually break something.
+
+| Phase | Target tag | Why |
+|---|---|---|
+| Phase 0 — Foundation | `v1.9.0` | New optional extras, new empty subpackage. |
+| Phase 1 — Algorithm tier | `v1.10.0` | New pure-numpy modules; matplotlib renderers may opt to use them. |
+| Phase 2 — Backend + 2D layers | `v1.11.0` | Scene/Layer machinery under existing `Plot.*` methods. Convenience API unchanged. |
+| Phase 3 — PyVista backend + 3D layers | `v1.12.0` | New `[viewer-3d]` extra. Qt not yet required. |
+| Phase 4 — Qt desktop | `v1.13.0` | New `[viewer]` extra. Adds CLI entry point `stko-viewer`. |
+| Phase 5 — Headless CLI | `v1.14.0` | New `[viewer-headless]` extra; animation/screenshot CLI. |
+| Phase 6 — Trame web | `v2.0.0` *(optional)* | Only bumps MAJOR if it forces a refactor of the public viewer API. Otherwise stays MINOR. |
+
+A breaking API change anywhere in this plan triggers `v2.0.0` immediately.
+Nothing in the current outline requires that.
+
+---
+
+## Phase 0 — Foundation
+
+**Goal:** stand up the empty viewer subpackage, optional extras, CI gates,
+docs skeleton. No rendering yet.
+
+**Deliverables:**
+
+- `src/STKO_to_python/viewer/__init__.py` — empty namespace, `__all__ = []`.
+- `src/STKO_to_python/viewer/_version.py` — pinned schema versions for
+  saved sessions (forward-compat).
+- `pyproject.toml` — new optional extras:
+  - `viewer-3d` → `pyvista>=0.43`, `vtk>=9.2`
+  - `viewer` → `viewer-3d` + `PySide6>=6.5`, `pyvistaqt>=0.11`, `qtpy`
+  - `viewer-headless` → `viewer-3d` + `imageio>=2.30`, `imageio-ffmpeg>=0.4`
+  - `viewer-web` (placeholder) → `trame>=3.0`, `trame-vtk`, `trame-vuetify`
+- `tests/viewer/` directory with one smoke test (import + `__all__` check).
+- `.github/workflows/test.yml` — add a job matrix entry that installs
+  `[viewer]` and runs the viewer smoke tests under `xvfb-run` on Linux only.
+- `docs/viewer/` — these four planning docs (this PR).
+
+**Definition of done:**
+
+- `pip install -e .[viewer]` succeeds on Linux, macOS, Windows.
+- `python -c "import STKO_to_python.viewer"` succeeds without any heavy
+  imports happening at module-load time.
+- CI green on the new viewer job.
+
+**Estimate:** ~2 days. **Risk:** low.
+
+---
+
+## Phase 1 — Algorithm tier (pure numpy)
+
+**Goal:** lift the math-only pieces from apeGmsh that we'll need later
+(Gauss extrapolation, shape functions for missing element types, shell
+local-axes quaternion, beam local-frame). Wire what's useful into the
+existing `cuts/` and `format/` packages now, ahead of any rendering.
+
+**Deliverables:**
+
+- `src/STKO_to_python/viewer/math/` (new module):
+  - `gauss_extrapolation.py` — pinv-based GP → nodal smoothing with
+    cross-element averaging. Adapted from apeGmsh's
+    `results/_gauss_extrapolation.py`.
+  - `beam_frame.py` — element local frame from endpoint coords + chord
+    vector heuristic. Adapted from `viewers/diagrams/_beam_geometry.py`.
+  - `shell_frame.py` — shell mid-surface local-axes quaternion. Adapted
+    from `results/_shell_geometry.py`.
+- Possible expansion of `src/STKO_to_python/format/shape_functions.py` to
+  cover any element types apeGmsh handles that we don't yet.
+- `tests/viewer/math/` — unit tests against analytic cases and against
+  the existing `cuts/` kernel outputs (regression).
+
+**Definition of done:**
+
+- 100% unit-test coverage on the three new modules.
+- A bench comparing GP → nodal extrapolation cost on the
+  `Test_NLShell` fixture (target: < 50 ms for 10k shell elements).
+- The existing `cuts/kernels/shell.py` optionally consumes the new
+  extrapolation routine (gated by a kwarg, default off) for a follow-up
+  PR to wire in. **Not coupled** to this phase landing.
+
+**Estimate:** ~1 week. **Risk:** low (pure math).
+
+---
+
+## Phase 2 — Backend protocol + 2D layers
+
+**Goal:** introduce `Scene` + `Layer` + `Backend` from
+[`01-architecture.md`](01-architecture.md). Re-implement the current
+matplotlib plotters as layers on top of `MplBackend`. No new user-visible
+features — pure refactor under the existing API.
+
+**Deliverables:**
+
+- `src/STKO_to_python/viewer/core/`:
+  - `backend.py` — `Backend` protocol.
+  - `scene.py` — `Scene`, `MultiScene`.
+  - `layer.py` — `Layer` base class.
+  - `style.py` — hierarchical `SceneStyle` (extends `PlotSettings`).
+  - `datasource.py` — `DataSource` adapter: `MPCODataSet` → layer-ready
+    arrays.
+- `src/STKO_to_python/viewer/backends/mpl/` — `MplBackend` implementation,
+  one file per primitive (`segments.py`, `points.py`, `polygons.py`,
+  `arrows.py`).
+- `src/STKO_to_python/viewer/layers/`:
+  - `mesh.py` — `MeshLayer` (wraps current `plot_mesh`).
+  - `deformed_mesh.py` — `DeformedMeshLayer` (wraps current `plot_deformed_shape`).
+  - `node.py` — `NodeLayer` + `VectorLayer`.
+  - `xy.py` — `XYLayer` (wraps `NodalResultsPlotter.xy`).
+- Existing `Plot.*` / `NodalResultsPlotter.*` / `ElementResultsPlotter.*`
+  rewired to build a `Scene` under the hood. **No signature changes.**
+
+**Definition of done:**
+
+- Every existing test in `tests/integration/test_plotting*.py` still passes
+  byte-identically (visual regression via image diff under tolerance).
+- New `tests/viewer/test_scene_layer.py` covers composition cases
+  (mesh + deformed; mesh + node; multiple scenes in a figure).
+- `docs/cookbook/` — one new recipe demonstrating direct Scene/Layer use
+  (no behavior change to the old recipes).
+
+**Estimate:** ~2 weeks. **Risk:** medium (refactor under live API).
+
+---
+
+## Phase 3 — PyVista backend + 3D layers
+
+**Goal:** add the `PyVistaBackend` and the layer types that require 3D
+rendering. Off-screen mode only — no Qt yet.
+
+**Deliverables:**
+
+- `src/STKO_to_python/viewer/backends/pyvista/` — `PyVistaBackend`,
+  off-screen mode, snapshot/save to PNG, animation as image sequence.
+- `src/STKO_to_python/viewer/scene_3d/`:
+  - `fem_scene.py` — `MPCODataSet` → `pyvista.UnstructuredGrid` builder.
+    Adapted from apeGmsh `viewers/scene/fem_scene.py`.
+- `src/STKO_to_python/viewer/layers/`:
+  - `contour.py` — `ContourLayer` with five-path dispatch (nodal,
+    GP-cell, GP-cell-averaged, GP-node, GP-node-discrete).
+  - `gauss.py` — `GaussLayer` (IP markers in 3D).
+  - `volume.py` — `VolumeLayer` modes `points` and `slice` (3D) plus `iso`
+    (PyVista-only via marching cubes).
+  - `diagram.py` — `DiagramLayer` for line-element M/V/N on 3D mesh.
+  - `fiber.py` — `FiberLayer` for force-based beam fiber sections.
+  - `layer_stack.py` — through-thickness shell view.
+  - `zerolength.py` — `ZeroLengthLayer` symbols.
+  - `clipping.py` — interactive clipping plane (plugs into existing
+    `cuts/` so the viewer's section-cut UI uses the kernels we already have).
+- `tests/viewer/test_pyvista_backend.py` — off-screen render regression
+  tests against golden PNGs (tolerance-bounded image diff).
+
+**Definition of done:**
+
+- All eight layer types render against the
+  `elasticFrame/QuadFrame_results` fixture in off-screen mode.
+- `Scene(backend="pyvista", off_screen=True).save("out.png")` works on CI
+  with `xvfb-run`.
+- Bench: 50k-element 3D mesh under 0.5 s cold render. 200-step animation
+  at ≥ 5 fps as image sequence.
+
+**Estimate:** ~3 weeks. **Risk:** medium (lots of layer types). Mitigated
+because the algorithms are mostly already done by Phase 1.
+
+---
+
+## Phase 4 — Qt desktop UI
+
+**Goal:** the "full experience." Ship the `stko-viewer` GUI: dock layout,
+time scrubber, diagram tree, picking, settings tabs, animation export.
+
+**Deliverables:**
+
+- `src/STKO_to_python/viewer/qt/`:
+  - `app.py` — `QApplication` bootstrap, theming.
+  - `main_window.py` — `ResultsWindow` (QMainWindow, dock layout).
+  - `widgets/`:
+    - `outline_tree.py` — left dock: stages, layers, geometry.
+    - `viewport.py` — center: `QtInteractor` wrapping the PyVista plotter.
+    - `details_panel.py` — right dock: per-layer settings tabs.
+    - `time_scrubber.py` — bottom: play/pause/slider/step count.
+    - `add_layer_dialog.py` — choose layer type + selection + component.
+    - `pick_readout_hud.py` — HUD on picked node/element/GP.
+  - `controllers/`:
+    - `director.py` — step orchestration; layers register for
+      `step_changed` callbacks.
+    - `picking.py` — port of apeGmsh's vectorized box-pick math.
+    - `session.py` — save/restore window layout + layer specs to disk.
+- `pyproject.toml` — add `[project.scripts]` entry: `stko-viewer = STKO_to_python.viewer.qt.cli:main`
+- `stko-viewer <file.mpco>` — open the file in the GUI.
+- `MPCODataSet.viewer()` — open the current dataset in the GUI (blocks).
+
+**Definition of done:**
+
+- Open any committed fixture in the GUI and use every Phase-3 layer
+  interactively.
+- Time scrubber drives layers at ≥ 10 fps on QuadFrame.
+- Box-pick selects ≥ 1k Gauss markers in < 100 ms.
+- Save/restore session produces a byte-stable file across runs.
+- Smoke test on CI under `pytest-qt` + `xvfb-run`.
+
+**Estimate:** ~4 weeks. **Risk:** medium-high (Qt UI breadth, lots of
+small panels).
+
+---
+
+## Phase 5 — Headless / batch CLI
+
+**Goal:** make the viewer usable on an SSH-only cluster for animation
+export, screenshots, and dump-to-image workflows. Same Scene/Layer graph
+as the GUI, no Qt loop.
+
+**Deliverables:**
+
+- `stko-viewer animate run.mpco --config view.toml --out anim.mp4`
+- `stko-viewer screenshot run.mpco --step 250 --out frame.png`
+- `stko-viewer batch run.mpco --config batch.toml --out frames/`
+- `view.toml` schema — declarative spec for layers + camera + step range.
+  Matches the in-memory `Scene` layout 1:1 so the GUI can save → run on
+  cluster → reload result.
+- Cluster docs: how to install `[viewer-headless]` without a display, how
+  to use Xvfb/EGL/Mesa, recommended SLURM stanza.
+
+**Definition of done:**
+
+- Animation runs on a headless Linux box with no `$DISPLAY` set.
+- `stko-viewer screenshot` produces the same PNG (within tolerance) as
+  the GUI's "Save snapshot" button does on the same step.
+
+**Estimate:** ~1.5 weeks. **Risk:** low. Most of the work is CLI wiring;
+rendering uses Phase 3 off-screen mode.
+
+---
+
+## Phase 6 — Trame web viewer *(deferred / optional)*
+
+**Goal:** browser-based viewer for cluster + SSH workflows.
+**Status:** not committed. Land Phase 5 first; revisit only if there's
+demonstrated demand.
+
+**Outline:**
+
+- `src/STKO_to_python/viewer/web/` — Trame server.
+- Same `Scene`/`Layer` model; the renderer is a `TrameBackend` that uses
+  `pyvista.trame` and exposes the scene over WebSocket.
+- One-port SSH tunnel: `ssh -L 8080:localhost:8080 cluster` →
+  `localhost:8080` in browser.
+- Two render modes: server-side rendering (encoded frames over
+  WebSocket) and client-side via `vtk.js` (geometry shipped once).
+
+**Estimate:** ~3–4 weeks **if** the layering from Phase 2/3 stays clean.
+Up to twice that if layers leaked VTK assumptions.
+
+---
+
+## Open questions still gating decisions
+
+Five questions from `viewer-refactor-directives.md` §12 are still open.
+The apeGmsh review settles one of them; the rest still need a call:
+
+| # | Question | Status |
+|---|---|---|
+| 1 | Backend priority — mpl-only v1 or pyvista as Phase 2? | **Settled** by user: full experience, so pyvista is committed. |
+| 2 | Fiber section (y, z) geometry — from `.scd` or user-supplied? | Open. Phase 3 default: user-supplied via a `FiberSection` data object. Read-from-`.scd` is a stretch goal. |
+| 3 | Moment-diagram sign convention — "tension side" or "+y_local"? | Open. Default proposed: tension side, with `flip=True` toggle. |
+| 4 | Contour default — per-element flat or node-averaged smooth? | Open. Default proposed: per-element flat (faithful, fast), smooth opt-in. |
+| 5 | `Part` scope — per-scene or persist across scenes? | Open. Default proposed: per-scene first, promote later if needed. |
+
+Each "default proposed" can be revisited before its phase ships — none
+block Phase 0 or Phase 1.
+
+---
+
+## What this plan does **not** commit to
+
+- Replacing or deprecating the existing matplotlib renderers. They stay,
+  and they get rewired through `Scene`/`Layer` so the public API is
+  unchanged.
+- VTK / XDMF export. Mentioned in the directive as "lives in `io/` if it
+  ever lands" — still not in scope.
+- 3D arrow rendering inside matplotlib. Use PyVista for that.
+- Edit-the-model UI. Pure post-processing; viewer never writes back.
+- A separate viewer process / server architecture for the Qt app. We
+  embed PyVista in Qt; one process.
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| PyVista/VTK version drift breaks rendering | Medium | Pin minor versions in extras; CI matrix covers `pyvista` 0.43 + 0.44. |
+| Qt + matplotlib interactive coexistence (event loop conflicts) | Medium | Keep Qt scenes and mpl scenes in separate windows; never mix in one figure. |
+| Apple Silicon / VTK GL issues | Low | Bench Phase 3 on macOS arm64 before declaring Phase 3 done. |
+| Layer model can't accommodate v1.8.0 section cuts cleanly | Medium | Phase 3 `clipping.py` plugs into existing `cuts/` rather than reimplementing; audit overlap during Phase 2. |
+| Saved session files break across minor releases | High if unchecked | `_version.py` pins schema; session loader rejects unknown majors and warns on minors. |
+| apeGmsh internals we lifted shift under us | Low | We're forking the code, not depending on the package. Track upstream changes manually if they matter. |
+
+---
+
+## Sequencing
+
+```
+Phase 0 ── Phase 1 ── Phase 2 ── Phase 3 ── Phase 4 ── Phase 5
+                                   │
+                                   └── (Phase 6, optional)
+```
+
+Phase 1 and Phase 2 can overlap (different files). Phase 3 strictly
+depends on Phase 2 (`Scene`/`Layer` must exist). Phase 4 depends on
+Phase 3. Phase 5 depends on Phase 3 but **not** on Phase 4.
+
+Total estimate to "full experience" (Phase 4 done): **~10–12 weeks** of
+focused work. Headless CLI (Phase 5) adds ~1.5 weeks. Trame (Phase 6)
+adds ~3–4 weeks beyond that.

--- a/docs/viewer/01-architecture.md
+++ b/docs/viewer/01-architecture.md
@@ -1,0 +1,469 @@
+# Viewer Architecture
+
+**Anchor:** `viewer-refactor-directives.md` fixes the *vocabulary* (Scene,
+Layer, Backend, layer catalog). This doc fixes the *implementation* — the
+concrete protocols, the data flow, the module map, and how the same code
+runs in three deployment targets.
+
+---
+
+## 1. Renderer-agnostic from day one
+
+Three deployment targets, one Scene/Layer graph, three backends:
+
+| Target | What it is | When | Backend |
+|---|---|---|---|
+| **Local Qt desktop** | Full GUI, embedded PyVista viewport, dock layout, time scrubber, picking. | Default for the engineer at their workstation. | `PyVistaBackend(qt_widget=...)` |
+| **Headless / batch** | CLI that produces PNGs, MP4s, GIFs from a saved scene spec. No window, no Qt loop. | Cluster jobs, CI snapshots, automated reports. | `PyVistaBackend(off_screen=True)` |
+| **Trame web** *(deferred)* | Server renders, browser displays. One SSH tunnel, one port. | SSH-only clusters; collaborative review. | `PyVistaBackend(trame=True)` or dedicated `TrameBackend` |
+| *(unchanged)* **Matplotlib 2D** | Today's `Plot.*` / `nr.plot.*` / `er.plot.*`. | Notebooks, lightweight 2D plots, reports. | `MplBackend` |
+
+The contract: **a `Scene` doesn't know its backend**. A layer doesn't know
+its backend. They emit primitives (`segments`, `points`, `polygons`,
+`arrows`, `field`); the backend translates them. Same scene, four render
+targets.
+
+This is **not** what apeGmsh does — apeGmsh is PyVista-only by design.
+Keeping the matplotlib leg is a STKO_to_python improvement: it lets the
+existing 2D notebook workflow stay light while the new 3D pipeline goes
+through a heavier optional dep stack.
+
+---
+
+## 2. Layered design
+
+Five layers, top to bottom. Data flows down on initialization, up on render.
+
+```
+   +----------------------------------+
+   |  Layer 5: User-facing API        |   MPCODataSet.viewer(),
+   |                                  |   ds.scene(), Scene(), MultiScene(),
+   |                                  |   stko-viewer CLI
+   +----------------------------------+
+                   |
+                   v
+   +----------------------------------+
+   |  Layer 4: Scene + Layers         |   Scene, MeshLayer, ContourLayer,
+   |  (backend-neutral)               |   DeformedMeshLayer, GaussLayer,
+   |                                  |   DiagramLayer, FiberLayer, ...
+   +----------------------------------+
+                   |
+                   v
+   +----------------------------------+
+   |  Layer 3: DataSource adapter     |   MPCODataSourceAdapter:
+   |                                  |   MPCODataSet -> Slabs/grids/arrays
+   +----------------------------------+
+                   |
+                   v
+   +----------------------------------+
+   |  Layer 2: Math + algorithms      |   gauss_extrapolation, shape_fns,
+   |  (pure numpy)                    |   beam_frame, shell_frame, picking math
+   +----------------------------------+
+                   |
+                   v
+   +----------------------------------+
+   |  Layer 1: Backends               |   MplBackend, PyVistaBackend,
+   |                                  |   (later) TrameBackend
+   +----------------------------------+
+```
+
+Each upper layer depends only on its immediate neighbor below. No layer
+reaches across.
+
+---
+
+## 3. The `Backend` protocol
+
+Surface every layer in the catalog can express, written so the matplotlib
+backend can either render or `raise BackendCapabilityError`:
+
+```python
+class Backend(Protocol):
+    name: str  # "mpl" | "pyvista" | "trame"
+    is_3d_capable: bool
+    is_interactive: bool
+
+    # Scene lifecycle
+    def make_scene(self, *, is_3d: bool, view: str = "auto",
+                   off_screen: bool = False) -> SceneHandle: ...
+    def set_bounds(self, scene: SceneHandle, bbox: BBox) -> None: ...
+    def set_camera(self, scene: SceneHandle, cam: CameraSpec) -> None: ...
+    def set_style(self, scene: SceneHandle, style: SceneStyle) -> None: ...
+
+    # Primitives — every layer is built from these
+    def add_segments(self, scene, segs, *, color, width, alpha, label) -> ActorRef: ...
+    def add_points(self, scene, pts, *, color, size, scalars=None, cmap=None) -> ActorRef: ...
+    def add_polygons(self, scene, polys, *, values=None, cmap=None,
+                     edge_color=None) -> ActorRef: ...
+    def add_arrows(self, scene, origins, vectors, *, scale, color, cmap) -> ActorRef: ...
+    def add_glyphs(self, scene, pts, glyph_kind, *, color, size, scale_by=None) -> ActorRef: ...
+    def add_field(self, scene, grid, *, scalars, cmap, clim, mode) -> ActorRef:
+        # mode: "points" | "cells" | "smooth"
+        ...
+
+    # 3D-only — may raise BackendCapabilityError on MplBackend
+    def add_clipped(self, scene, actor: ActorRef, plane: Plane) -> None: ...
+    def add_slice(self, scene, grid, plane: Plane, field: str) -> ActorRef: ...
+    def add_iso(self, scene, grid, field: str, level: float) -> ActorRef: ...
+
+    # In-place updates (for animation; no actor recreation)
+    def update_scalars(self, actor: ActorRef, scalars: np.ndarray) -> None: ...
+    def update_points(self, actor: ActorRef, pts: np.ndarray) -> None: ...
+    def set_visible(self, actor: ActorRef, visible: bool) -> None: ...
+    def remove(self, scene: SceneHandle, actor: ActorRef) -> None: ...
+
+    # Output
+    def show(self, scene: SceneHandle) -> None: ...                 # interactive
+    def save(self, scene: SceneHandle, path: Path, *, dpi=300) -> None: ...
+    def snapshot(self, scene: SceneHandle) -> np.ndarray: ...        # H×W×3 uint8
+```
+
+**Hard rules:**
+
+- `update_*` methods must mutate in place and re-render in O(modified
+  data), not O(scene). This is the apeGmsh perf contract from
+  `_contour.py:32-41` — porting it is non-negotiable for animation
+  performance.
+- Layers never import from a backend module. They get a `Backend`
+  instance through the scene.
+- A backend that can't do something raises `BackendCapabilityError`
+  with a precise message ("VolumeLayer mode='iso' requires the pyvista
+  backend"). No silent fallback.
+
+---
+
+## 4. `Scene` and `Layer`
+
+```python
+class Scene:
+    backend: Backend
+    style: SceneStyle
+    layers: list[Layer]
+    current_step: int | None
+    current_stage: str | None
+
+    def add(self, layer: Layer) -> Layer: ...
+    def remove(self, layer: Layer) -> None: ...
+    def set_step(self, step: int) -> None:
+        """Fires layer.update_to_step on every layer in order."""
+    def show(self) -> None: ...
+    def save(self, path: Path) -> None: ...
+    def to_spec(self) -> SceneSpec: ...
+    @classmethod
+    def from_spec(cls, spec: SceneSpec, ds: MPCODataSet) -> "Scene": ...
+
+
+class Layer(ABC):
+    name: str
+    visible: bool
+    z_order: int
+    selection: SelectionSpec
+    style: LayerStyle
+
+    @abstractmethod
+    def attach(self, scene: Scene, source: DataSource) -> None:
+        """Build VTK/mpl actors. Called once."""
+
+    @abstractmethod
+    def update_to_step(self, step: int) -> None:
+        """In-place mutate scalars/points for animation. No recreation."""
+
+    @abstractmethod
+    def detach(self) -> None: ...
+
+    def to_spec(self) -> LayerSpec: ...
+```
+
+**Key contracts (lifted from apeGmsh, adapted):**
+
+1. `attach` is the only place a layer may allocate VTK actors or mpl
+   artists. After attach, the actor set is frozen.
+2. `update_to_step` reads from the `DataSource`, scatters into pre-allocated
+   scalar arrays, and calls `backend.update_scalars` (or
+   `update_points` for deformed shape). It does **not** call
+   `add_*`.
+3. `detach` removes actors and releases references.
+4. `to_spec` / `from_spec` make every layer round-trippable through a
+   TOML/JSON config so the GUI can save → run on cluster.
+
+---
+
+## 5. The `DataSource` adapter
+
+The chokepoint between STKO's DataFrame world and the apeGmsh-style
+Slab-and-array world that the layers expect.
+
+```python
+class DataSource(Protocol):
+    @property
+    def dataset(self) -> MPCODataSet: ...
+
+    # Geometry
+    def grid(self, *, selection: SelectionSpec | None = None) -> Grid:
+        """UnstructuredGrid-shaped: nodes, connectivities by type, ids."""
+
+    def node_coords(self, ids: np.ndarray | None = None) -> np.ndarray: ...
+    def element_centroids(self, ids: np.ndarray | None = None) -> np.ndarray: ...
+    def model_bbox(self) -> BBox: ...
+
+    # Result fields — per step, per topology
+    def nodal_values(self, name: str, component: str | int,
+                     step: int, stage: str | None = None,
+                     selection: SelectionSpec | None = None
+                     ) -> np.ndarray: ...
+
+    def element_values(self, name: str, component: str,
+                       step: int, stage: str | None = None,
+                       selection: SelectionSpec | None = None,
+                       topology: str = "element"  # "element" | "gp" | "fiber" | "layer"
+                       ) -> np.ndarray: ...
+
+    # Time
+    def n_steps(self, stage: str | None = None) -> int: ...
+    def time(self, stage: str | None = None) -> np.ndarray: ...
+
+    # Selection resolution
+    def resolve_selection(self, spec: SelectionSpec) -> ResolvedSelection: ...
+```
+
+The default implementation `MPCODataSourceAdapter` wraps an existing
+`MPCODataSet` and delegates to:
+
+- `ds.nodes` for node geometry,
+- `ds.elements` for connectivity and element results,
+- `ds.cuts` for clipping primitives (reuses Phase v1.8.0 work),
+- `ds.selection_set_resolver` for named groups.
+
+This is the **one** place STKO's pandas DataFrames are converted to
+contiguous numpy arrays shaped how the layers want. Doing it here means
+layers stay backend-agnostic *and* data-source-agnostic — a future
+non-MPCO source (e.g., direct OpenSeesPy stream) just implements
+`DataSource`.
+
+---
+
+## 6. The Director (step orchestration)
+
+```python
+class Director:
+    scene: Scene
+    n_steps: int
+    current_step: int
+
+    def play(self, *, fps: int = 30, step_stride: int = 1) -> None: ...
+    def pause(self) -> None: ...
+    def set_step(self, step: int) -> None: ...
+    def export_animation(self, path: Path, *, fps: int = 30,
+                         step_stride: int = 1, format: str = "mp4") -> None: ...
+
+    # Signals (Qt-style; matplotlib backend uses callbacks)
+    on_step_changed: Signal[int]
+    on_layer_added: Signal[Layer]
+    on_layer_removed: Signal[Layer]
+```
+
+The Director is what the time scrubber drives in Qt and what the headless
+CLI iterates programmatically. **Same class either way.**
+
+The apeGmsh Director ships with TimeMode = SINGLE | RANGE | ENVELOPE |
+ANIMATION (only SINGLE in their Phase 0). Our Phase 4 ships SINGLE only;
+RANGE/ENVELOPE are deferred.
+
+---
+
+## 7. How each deployment target wires up
+
+### 7.1 Local Qt desktop
+
+```
+QApplication
+  └── ResultsWindow (QMainWindow)
+        ├── OutlineTree (left dock)
+        ├── ViewportWidget (center)   ── pyvistaqt.QtInteractor
+        │     │                            │
+        │     │                            └── PyVistaBackend(qt_widget=interactor)
+        │     │
+        │     └── Scene  ── Director ── Layer x N
+        ├── DetailsPanel (right dock)
+        ├── TimeScrubber (bottom dock)
+        └── PickReadoutHud (overlay)
+```
+
+Single process. One scene per main window. Picking and time scrubber
+talk to the Director. Director calls `scene.set_step`, which fans out to
+each layer's `update_to_step`, which mutates VTK arrays in place. Qt
+event loop is the master clock.
+
+### 7.2 Headless / batch
+
+```
+stko-viewer animate run.mpco --config view.toml --out anim.mp4
+        │
+        └── load view.toml -> SceneSpec
+            scene = Scene.from_spec(spec, ds)
+            scene.backend = PyVistaBackend(off_screen=True)
+            director = Director(scene)
+            director.export_animation(out, fps=..., step_stride=...)
+```
+
+No Qt. No window. Backend renders to an off-screen framebuffer (Xvfb on
+Linux, EGL where available, native off-screen on macOS/Windows).
+`export_animation` walks steps, snapshots each, hands the frame stream
+to `imageio-ffmpeg`.
+
+### 7.3 Trame web *(Phase 6)*
+
+```
+trame_app
+  └── VtkRemoteView    ── pyvista.trame.PyVistaRemoteView
+        │                       │
+        │                       └── PyVistaBackend(plotter=...)
+        │
+        └── Scene ── Director ── Layer x N
+```
+
+Trame's reactive state binds UI controls (sliders, layer toggles) to
+the Director and to layer properties. Browser opens
+`http://cluster:8080`; server stream-encodes frames.
+
+The key payoff of the layering: **only the `Backend` instantiation
+changes** between targets. Scene/Layer/Director/DataSource are
+byte-identical.
+
+---
+
+## 8. Proposed module map
+
+```
+src/STKO_to_python/viewer/
+├── __init__.py              # exports Scene, Layer, etc. — lazy
+├── _version.py              # schema versions for SceneSpec
+├── api.py                   # high-level entry: MPCODataSet.viewer()
+│
+├── core/
+│   ├── backend.py           # Backend protocol, BackendCapabilityError
+│   ├── scene.py             # Scene, MultiScene
+│   ├── layer.py             # Layer base class
+│   ├── style.py             # SceneStyle, LayerStyle (extends PlotSettings)
+│   ├── datasource.py        # DataSource protocol + MPCODataSourceAdapter
+│   ├── director.py          # Director + signals
+│   ├── selection.py         # SelectionSpec dataclass; merges with SelectionSetResolver
+│   ├── specs.py             # SceneSpec, LayerSpec — TOML/JSON round-trip
+│   └── errors.py            # BackendCapabilityError, LayerAttachError
+│
+├── math/                    # Phase 1 (pure numpy)
+│   ├── gauss_extrapolation.py
+│   ├── beam_frame.py
+│   ├── shell_frame.py
+│   └── picking.py           # box-pick projection math
+│
+├── backends/
+│   ├── mpl/
+│   │   ├── __init__.py
+│   │   ├── backend.py       # MplBackend
+│   │   ├── segments.py
+│   │   ├── points.py
+│   │   ├── polygons.py
+│   │   └── arrows.py
+│   ├── pyvista/
+│   │   ├── __init__.py
+│   │   ├── backend.py       # PyVistaBackend
+│   │   ├── primitives.py
+│   │   └── offscreen.py
+│   └── trame/               # Phase 6
+│       └── ...
+│
+├── scene_3d/
+│   └── fem_scene.py         # MPCODataSet -> pyvista.UnstructuredGrid
+│
+├── layers/
+│   ├── mesh.py              # MeshLayer
+│   ├── deformed_mesh.py     # DeformedMeshLayer
+│   ├── node.py              # NodeLayer + VectorLayer
+│   ├── contour.py           # ContourLayer (5-path dispatch)
+│   ├── gauss.py             # GaussLayer
+│   ├── diagram.py           # DiagramLayer (line elements)
+│   ├── fiber.py             # FiberLayer
+│   ├── layer_stack.py       # LayerStackLayer (shell through-thickness)
+│   ├── volume.py            # VolumeLayer (points/slice/iso)
+│   ├── zerolength.py        # ZeroLengthLayer
+│   ├── clipping.py          # interactive clipping; plugs into cuts/
+│   └── xy.py                # XYLayer (2D time history)
+│
+├── recipes/                 # high-level helpers (Phase 4+)
+│   ├── pushover.py
+│   ├── drift_profile.py
+│   ├── mode_shape.py
+│   └── section_response.py
+│
+├── qt/                      # Phase 4
+│   ├── app.py
+│   ├── main_window.py
+│   ├── cli.py               # stko-viewer entry point
+│   ├── widgets/
+│   │   ├── outline_tree.py
+│   │   ├── viewport.py
+│   │   ├── details_panel.py
+│   │   ├── time_scrubber.py
+│   │   ├── add_layer_dialog.py
+│   │   └── pick_readout_hud.py
+│   ├── controllers/
+│   │   ├── picking.py
+│   │   └── session.py
+│   └── theme.py
+│
+├── headless/                # Phase 5
+│   ├── cli.py               # stko-viewer animate/screenshot/batch
+│   └── runner.py
+│
+└── web/                     # Phase 6 (deferred)
+    └── ...
+```
+
+---
+
+## 9. What this architecture buys
+
+1. **One scene graph runs in four targets.** Mpl notebook, off-screen
+   batch, Qt desktop, web (eventually). Same layer code, different
+   backend instance.
+2. **Existing API stays.** `ds.plot.*` rewires onto Scene/MplBackend.
+   Cookbook recipes don't break.
+3. **Section cuts already in v1.8.0 plug in cleanly.** `ClippingLayer`
+   wraps `cuts.Plane` + `cuts.SectionCut`; no duplication.
+4. **Animation export and the desktop time scrubber share one Director.**
+   Saving a scene from the GUI and running it on a cluster produces the
+   same frames.
+5. **The matplotlib leg stays usable in notebooks.** Users who don't
+   want Qt/VTK never install it.
+
+---
+
+## 10. Non-goals
+
+- A custom rendering engine. We use VTK via PyVista for all 3D.
+- A web framework other than Trame. (Trame is Kitware's own — same
+  shop as VTK; lowest impedance match.)
+- Edit-the-model UI. Post-processing only.
+- Cross-process viewer (server + remote client over IPC). We have
+  in-process Qt and we have HTTP/Trame; we don't need a third pattern.
+- Replacing the matplotlib renderers. They stay.
+
+---
+
+## 11. Coupling boundaries (don't cross these)
+
+| From → To | Allowed? |
+|---|---|
+| `layers/*` → `backends/*` | **No** (use `Scene.backend` indirection) |
+| `layers/*` → `qt/*` | **No** |
+| `qt/*` → `layers/*` | **Yes** (UI configures layers) |
+| `qt/*` → `backends/*` | **Yes**, but only `pyvista` (Qt embeds PyVista) |
+| `core/*` → `backends/*` | **No** |
+| `headless/*` → `qt/*` | **No** (headless must run without Qt installed) |
+| `web/*` → `qt/*` | **No** |
+| `cuts/*` → `viewer/*` | **No** (viewer wraps cuts, not the other way) |
+
+`pyproject.toml` enforces some of these via optional extras (no Qt
+import survives `pip install stko_to_python[viewer-headless]` without
+the user also installing `[viewer]`). The rest are enforced by review.

--- a/docs/viewer/02-porting-from-apegmsh.md
+++ b/docs/viewer/02-porting-from-apegmsh.md
@@ -1,0 +1,271 @@
+# Porting from apeGmsh
+
+The apeGmsh `ResultsViewer` is a mature ~20k-line PyVista/Qt desktop
+post-processor. We are not vendoring it as a dependency — we're **lifting
+selected pieces** into `STKO_to_python.viewer` and adapting them to our
+data model.
+
+This document is the file-by-file plan, with adapter notes and an
+overlap audit against the work already shipped in v1.8.0.
+
+---
+
+## 1. Scope
+
+**Lifted** = source code copied (or significantly inspired) and adapted
+to STKO_to_python's data model and module layout.
+
+**Not lifted** = either reimplemented from scratch (better fit with our
+existing code) or skipped entirely (out of scope).
+
+Three tiers, increasing in complexity and dep cost:
+
+- **Tier 1** — pure numpy / math. No Qt, no VTK. Lands in Phase 1.
+- **Tier 2** — Scene-builder + diagrams (renderable layers). Needs
+  PyVista. Lands in Phase 2–3.
+- **Tier 3** — Qt UI. Needs PySide6 + pyvistaqt. Lands in Phase 4.
+
+apeGmsh paths below are relative to its `src/apeGmsh/`. STKO_to_python
+target paths are relative to `src/STKO_to_python/viewer/`.
+
+---
+
+## 2. Attribution & license
+
+- apeGmsh is your own codebase, so attribution is informational rather
+  than legal. Still, every lifted file should carry a one-line header:
+
+  ```python
+  # Adapted from apeGmsh viewers/diagrams/_contour.py (commit <sha>).
+  ```
+
+- If apeGmsh ever ships under a different license than STKO_to_python
+  (currently MIT), the lift becomes a license question. Today it is not.
+
+---
+
+## 3. Tier 1 — pure math (Phase 1)
+
+Pure numpy. No rendering dependencies. Most valuable for the section-cut
+work that's already in `cuts/` and for the eventual contour layers.
+
+| apeGmsh source | Target | Adaptation |
+|---|---|---|
+| `results/_gauss_extrapolation.py` | `viewer/math/gauss_extrapolation.py` | Drop apeGmsh's `Slab` typing; accept `(values: np.ndarray, gp_natural: np.ndarray, element_node_coords: np.ndarray)` shaped the same way `ElementResults.physical_coords()` already returns. Reuse `format/shape_functions.py` registries — don't carry apeGmsh's parallel implementation. |
+| `results/_shape_functions.py` | merge into `format/shape_functions.py` | Audit gaps first: STKO has shape fns for the elements in `cuts/` already. If apeGmsh covers a type we don't, port that entry into the existing registry. |
+| `results/_gauss_world_coords.py` | already exists as `format/shape_functions.compute_physical_coords` | **Don't port.** Audit instead — apeGmsh may handle element types we don't. |
+| `results/_shell_geometry.py` | `viewer/math/shell_frame.py` | Adapter point: STKO's shells live in `cuts/kernels/shell.py` and `format/shape_functions.py` — keep the local-axes computation backed by a quaternion (good numerics) but expose it as a free function, not a class. |
+| `viewers/diagrams/_beam_geometry.py` | `viewer/math/beam_frame.py` | apeGmsh derives beam local frame from endpoint coords + a chord-vector heuristic. STKO's beam frame today is handled per-kernel in `cuts/kernels/beam.py`. Port the apeGmsh version once into `viewer/math/` and let both `cuts/` and viewer code consume it. **Audit `cuts/kernels/beam.py` first** to make sure the conventions match. |
+| `viewers/core/results_pick.py` (display-space box-pick only) | `viewer/math/picking.py` | The clever vectorized projection trick: build camera matrix once, batch-multiply all candidate world points to screen space, intersect with the drag rectangle. ~40× faster than per-point `WorldToDisplay`. **Critical for picking thousands of Gauss markers.** Strip out the VTK-specific actor handling — we just need the projection math. |
+
+**Effort:** ~1 week.
+
+**Files NOT to port at Tier 1:**
+
+- `viewers/scene/glyph_points.py` — needs PyVista; defer to Tier 2.
+- `results/_slabs.py` — apeGmsh's frozen Slab dataclasses. Our equivalent
+  is `NodalResults` / `ElementResults`. Don't duplicate the data model.
+
+---
+
+## 4. Tier 2 — Scene builder + diagrams (Phase 2–3)
+
+| apeGmsh source | Target | Adaptation |
+|---|---|---|
+| `viewers/scene/fem_scene.py` | `viewer/scene_3d/fem_scene.py` | Heavy adapter. apeGmsh consumes `FEMData` (custom); we consume `MPCODataSet`. Two changes: (1) input adapter — pull node coords and connectivities from `ds.nodes` and `ds.elements`; (2) linearization table — extend apeGmsh's `GMSH_LINEAR` lookup to cover the STKO element-type-tag set (OpenSees class tags, not Gmsh element codes). |
+| `viewers/diagrams/_base.py` | `viewer/core/layer.py` | Rename `Diagram` → `Layer` to match STKO/directive vocabulary. Keep the `attach` / `update_to_step` / `detach` lifecycle exactly. The `DiagramSpec` becomes `LayerSpec`. |
+| `viewers/diagrams/_director.py` | `viewer/core/director.py` | Slim down — apeGmsh's director has TimeMode = SINGLE/RANGE/ENVELOPE/ANIMATION; Phase 2 ships SINGLE only. Drop the multi-stage "combined" pseudo-stage logic until we know we need it for STKO. |
+| `viewers/diagrams/_contour.py` | `viewer/layers/contour.py` | **High-value port.** Five-path dispatch (nodal, GP-cell, GP-cell-averaged, GP-node-extrap, GP-node-discrete). Adapter: feed it from `ElementResults` instead of apeGmsh slabs. |
+| `viewers/diagrams/_deformed_shape.py` | `viewer/layers/deformed_mesh.py` | Adapter: pull displacements via `NodalResults`. Keep in-place point mutation (perf contract). |
+| `viewers/diagrams/_vector_glyph.py` | `viewer/layers/node.py::VectorLayer` | Direct port. Wrap in our `NodeLayer` / `VectorLayer` split (directive §5.4). |
+| `viewers/diagrams/_line_force.py` | `viewer/layers/diagram.py` | Hatched fill perpendicular to beam axis (M, V, N diagrams). Sign convention — see open question #3 in roadmap. |
+| `viewers/diagrams/_fiber_section.py` | `viewer/layers/fiber.py` | **Compare with v1.8.0 per-fiber shell views first.** Likely a 60–80% port. The 3D fiber cloud + 2D side-panel architecture is good; the data accessor needs to read STKO's fiber slabs. |
+| `viewers/diagrams/_layer_stack.py` | `viewer/layers/layer_stack.py` | **Compare with v1.8.0 per-layer shell views first.** Apeg's aggregation strategies (mid_layer / mean / max_abs) are worth lifting; our v1.8.0 work may already have its own conventions — reconcile before merging. |
+| `viewers/diagrams/_gauss_marker.py` | `viewer/layers/gauss.py` | World-coord mapping via shape functions — but we already have `format/shape_functions.compute_physical_coords`; consume that instead of porting apeGmsh's parallel pathway. Sphere markers as real geometry (not billboards) — keep. |
+| `viewers/diagrams/_spring_force.py` | `viewer/layers/zerolength.py` (partial) | Spring-only flavor of the directive's `ZeroLengthLayer`. Useful starting point for the broader symbol-based renderer. |
+| `viewers/diagrams/_loads.py` | `viewer/layers/loads.py` *(optional)* | Static load glyphs. Lower priority since MPCO doesn't carry the applied loads — would need to read from a separate source. Defer until there's a use case. |
+| `viewers/diagrams/_reactions.py` | `viewer/layers/reactions.py` | Reaction arrows + curved-arrow moment glyphs. Pulls from `NodalResults.REACTION` — direct adapter. |
+| `viewers/diagrams/_scalar_bar_support.py` | `viewer/core/style.py` (extend) | Merge into `LayerStyle` — every layer with a scalar field has a colormap and clim. |
+| `viewers/diagrams/_selectors.py` | `viewer/core/selection.py` | Replace `SlabSelector` with a wrapper around our existing `SelectionSetResolver`. Same grammar (pg / label / selection / ids) maps to ours (selection_set_name / selection_set_id / node_ids / element_ids). |
+| `viewers/diagrams/_compositions.py` | skip | Specific to apeGmsh's CAD geometry manager; not relevant to STKO. |
+| `viewers/diagrams/_kind_catalog.py` | `viewer/layers/__init__.py` (`LAYER_KINDS` dict) | Simple registry; trivial port. |
+| `viewers/diagrams/_registries.py` | `viewer/core/scene.py::Scene.layers` | Absorbed into the `Scene` class — we don't need a separate `DiagramRegistry`. |
+| `viewers/core/clipping_controller.py` | `viewer/layers/clipping.py` | **Audit against `cuts/` first.** v1.8.0 has section-cut kernels and plotting helpers; the interactive clipping plane widget is what's missing. Port the VTK plane-widget glue, but the cut math itself stays in `cuts/`. |
+| `viewers/core/color_manager.py` | `viewer/core/style.py` (extend) | Merge — `SceneStyle` already has theming. |
+| `viewers/core/element_visibility.py` | `viewer/core/layer.py::Layer.set_visible_subset()` | Per-cell vtkGhostType masking. Useful for "hide this element type" controls. |
+| `viewers/core/opacity_controller.py` | `viewer/core/style.py` (extend) | Per-actor alpha + depth-peeling enable. |
+| `viewers/animation.py` | `viewer/headless/runner.py` | Direct port for Phase 5. MP4 via imageio-ffmpeg, GIF via Pillow. |
+
+**Effort:** ~3 weeks for Phase 2 + Phase 3 combined.
+
+**Files NOT to port at Tier 2:**
+
+- `viewers/scene/brep_scene.py` — CAD geometry; not in STKO scope.
+- `viewers/scene/mesh_scene.py` — pre-solve mesh; not in STKO scope (we're
+  post-processing only, by directive).
+- `viewers/results/live/*` — live recording during analysis. Out of scope.
+
+---
+
+## 5. Tier 3 — Qt UI (Phase 4)
+
+Most expensive tier. Doing this is what "full experience" means.
+
+| apeGmsh source | Target | Adaptation |
+|---|---|---|
+| `viewers/results_viewer.py` (orchestrator, 1955 lines) | `viewer/qt/main_window.py` (split) | Don't port as one file. The orchestrator does dock layout + Director wiring + signal plumbing — split into `main_window.py`, `app.py`, and controller files. |
+| `viewers/ui/_results_window.py` | `viewer/qt/main_window.py` | Dock layout. Direct port; rename to match our module naming. |
+| `viewers/ui/_outline_tree.py` | `viewer/qt/widgets/outline_tree.py` | Stage/layer/geometry tree. Drop apeGmsh's geometry section (we don't have pre-solve geometry). |
+| `viewers/ui/_plot_pane.py` | `viewer/qt/widgets/viewport.py` | Embeds the `QtInteractor`. Simple. |
+| `viewers/ui/_details_panel.py` | `viewer/qt/widgets/details_panel.py` | Right-dock; routes to layer-specific settings tabs. |
+| `viewers/ui/_diagram_settings_tab.py` | `viewer/qt/widgets/layer_settings_tab.py` | One tab per active layer. Each layer contributes a `settings_widget()` factory. |
+| `viewers/ui/_geometry_settings_panel.py` | `viewer/qt/widgets/scene_settings_panel.py` | Global scene knobs: deformation scale, show-undeformed toggle, background. |
+| `viewers/ui/_time_scrubber.py` | `viewer/qt/widgets/time_scrubber.py` | Slider + play/pause + step counter. Drives the Director. |
+| `viewers/ui/_time_history.py` | `viewer/qt/widgets/time_history_tab.py` | Matplotlib in a Qt tab. Shows TH for shift-clicked node. Uses our existing `NodalResultsPlotter.xy` machinery. |
+| `viewers/ui/_add_diagram_dialog.py` | `viewer/qt/widgets/add_layer_dialog.py` | Multi-select dialog. Layer kind catalog drives the choices. |
+| `viewers/ui/_session_panel.py` | `viewer/qt/controllers/session.py` | Save/restore window layout + scene specs to disk. Uses QSettings + our `SceneSpec` round-trip. |
+| `viewers/ui/_pick_readout_hud.py` | `viewer/qt/widgets/pick_readout_hud.py` | HUD overlay. Direct port. |
+| `viewers/ui/_viewport_hud.py` | `viewer/qt/widgets/viewport_hud.py` | FPS + mode + key hints. Direct port. |
+| `viewers/ui/theme.py` | `viewer/qt/theme.py` | Qt palette. Direct port; adjust accent colors to match STKO branding if desired. |
+| `viewers/ui/preferences.py` + `preferences_manager.py` | `viewer/qt/preferences.py` | Persisted settings. Drop apeGmsh-specific keys. |
+| `viewers/core/navigation.py` | `viewer/qt/controllers/navigation.py` | Camera presets (front, top, iso). Direct port. |
+| `viewers/core/pick_engine.py` | `viewer/qt/controllers/picking.py` | Click + box-pick controller; uses `viewer/math/picking.py` underneath. |
+| `viewers/core/results_pick_engine.py` | merge into `picking.py` | Combine; the two are very close in apeGmsh. |
+| `viewers/overlays/*` | defer | Probe / measure / constraint overlays. Phase 4+ nice-to-have. |
+
+**Effort:** ~4 weeks.
+
+**Files NOT to port at Tier 3:**
+
+- `viewers/ui/_add_diagram_dialog.py`'s geometry-aware logic. STKO has no
+  pre-solve geometry.
+- `viewers/overlays/constraint_overlay.py` — boundary condition markers.
+  MPCO doesn't carry these; would need a separate input path. Defer.
+
+---
+
+## 6. Non-obvious algorithms worth preserving verbatim
+
+These are the "wouldn't reinvent" tricks. Carry them across with care
+(unit-test them on day one):
+
+1. **Gauss → nodal extrapolation using linear shape functions.** apeGmsh
+   notes that even when the substrate VTK cells are higher-order, using
+   *linear* shape functions for the extrapolation is more stable under
+   `pinv`. Without this insight you get noisy contours on quadratic
+   elements.
+2. **In-place actor scalar mutation.** Every layer pre-allocates its
+   per-step scalar array at attach time and only `Modified()`-flags it
+   on update. Recreating actors per step is what makes naive viewers
+   choke on big models.
+3. **Display-space box pick.** Vectorize via the camera matrix; never
+   loop `WorldToDisplay` per point. 40× speedup at 1M Gauss points.
+4. **Shell local-axes quaternion.** Avoids gimbal lock in the
+   normal-rotation pipeline when shells are deformed.
+5. **Sphere markers, not billboards, for Gauss points.** Avoids
+   z-fighting at glancing angles when the user rotates around dense
+   GP clouds.
+6. **Layer aggregation strategies (mid_layer / mean / max_abs)**
+   precomputed at attach as dot-product weights — per-step cost is one
+   dot per cell.
+
+---
+
+## 7. Overlap audit with v1.8.0 work
+
+We've already shipped section cuts and per-layer/per-fiber shell views.
+Before porting the apeGmsh equivalents, **diff what exists**:
+
+| Topic | STKO_to_python today | apeGmsh equivalent | Action |
+|---|---|---|---|
+| Section cuts (math) | `cuts/kernels/{beam,shell,solid}.py` | none (apeGmsh has only an interactive clipping plane; no resultant integration) | **Keep STKO's** — apeGmsh's clipping is a viz feature, not an integration kernel. |
+| Section cuts (interactive plane) | none | `viewers/core/clipping_controller.py` | **Port apeGmsh's** — wrap STKO's `Plane` so the GUI exposes it. |
+| Per-layer shell views | shipped in v1.8.0 | `viewers/diagrams/_layer_stack.py` | **Audit + reconcile.** Likely keep STKO's data model + lift apeGmsh's aggregation tactics. |
+| Per-fiber views | shipped in v1.8.0 | `viewers/diagrams/_fiber_section.py` | **Audit + reconcile.** Likely keep STKO's data model + lift apeGmsh's 3D-cloud + 2D-side-panel UI pattern. |
+| Beam local frame | `cuts/kernels/beam.py` | `viewers/diagrams/_beam_geometry.py` | **Pick one** — port one canonical implementation into `viewer/math/beam_frame.py` and have both `cuts/` and viewer code consume it. |
+
+**This audit is a precondition for Phase 1 wrap-up.** It's a few hours
+of reading, not a separate phase, but skip it and we end up with two
+parallel implementations of the same physics.
+
+---
+
+## 8. Adapter strategy: STKO DataFrames → array-shaped inputs
+
+apeGmsh layers expect `Slab` objects — numpy arrays with a fixed
+shape per topology (nodes / element / GP / fiber / layer).
+STKO returns pandas DataFrames with MultiIndex columns.
+
+The `MPCODataSourceAdapter` (`viewer/core/datasource.py`) is the *only*
+place this conversion happens:
+
+```python
+def element_values(self, name, component, step, *, topology="element", ...):
+    er = self.dataset.elements.get_element_results(
+        results_name=name,
+        # ... selection ...
+    )
+    df = er.df  # MultiIndex
+    if topology == "gp":
+        return er.gp_values(component, step)         # (sum_gp,) array
+    if topology == "fiber":
+        return er.fiber_values(component, step)      # (sum_fiber,) array
+    # ... etc.
+```
+
+**Rules:**
+
+- Adapter methods return **contiguous numpy arrays** in element order
+  consistent with the grid built by `viewer/scene_3d/fem_scene.py`.
+- The adapter caches array views — every call doesn't trigger a fresh
+  DataFrame query. LRU around `(name, component, step, stage,
+  selection_hash, topology)`.
+- Slab-like dataclasses are an *internal* implementation detail of
+  layers if they need them; they are not part of the DataSource API.
+
+This is where STKO's existing query-engine caching pays off — the
+adapter is mostly a thin shape-translator over an already-cached DataFrame.
+
+---
+
+## 9. Files we explicitly do **not** port
+
+- `viewers/scene/brep_scene.py`, `mesh_scene.py` — pre-solve geometry.
+- `results/live/*` — live recording during analysis.
+- `results/transcoders/_recorder.py` — apeGmsh ingests OpenSees `.out`
+  files. STKO ingests `.mpco` only.
+- `results/readers/_mpco*` — apeGmsh has its own MPCO reader. We have
+  ours; we keep ours. Not the other way around.
+- `viewers/ui/preferences*` — port the *pattern* but write our own
+  config (we're not inheriting apeGmsh's settings keys).
+- `architecture/*.md` docs — they're internal to apeGmsh.
+
+---
+
+## 10. Process for each port
+
+1. Open the apeGmsh source file. Read it. Note the SHA you read from.
+2. Write a STKO_to_python skeleton in the target path with `pass` bodies
+   and the adapted signatures.
+3. Land that skeleton with imports + type stubs only. CI green.
+4. Port the body, swapping apeGmsh data accesses for `DataSource` calls.
+5. Add a unit test against the smallest fixture that exercises the
+   layer (`elasticFrame/results/` for 1D, `QuadFrame_results/` for
+   shells, `solid_partition_example/` for solids).
+6. Add the source-attribution header.
+7. PR — small enough to review in one sitting (≤ 600 LOC diff).
+
+---
+
+## 11. Lift estimates by tier
+
+| Tier | Files | apeGmsh LOC (approx) | Target LOC (after adaptation) | Effort |
+|---|---|---|---|---|
+| Tier 1 — math | 5 | ~600 | ~500 | 1 week |
+| Tier 2 — scene + layers | 18 | ~4000 | ~3500 | 3 weeks (Phase 2 + 3) |
+| Tier 3 — Qt UI | 16 | ~5000 | ~4000 | 4 weeks |
+| **Total** | **~40** | **~9600** | **~8000** | **~8 weeks** |
+
+The total is consistent with the roadmap estimate of ~10–12 weeks to
+Phase 4 (the difference is Phase 0 setup, Phase 2 refactor work that
+isn't a direct port, and integration testing).

--- a/docs/viewer/03-deployment-targets.md
+++ b/docs/viewer/03-deployment-targets.md
@@ -1,0 +1,329 @@
+# Deployment Targets
+
+Where the viewer runs, what works in each setting, and how to install.
+This is the document to point engineers at when they ask "can I run this
+on my cluster?"
+
+---
+
+## 1. Target matrix
+
+| Target | Backend | Display path | Performance | Status |
+|---|---|---|---|---|
+| **Local Qt desktop** | `PyVistaBackend(qt_widget=...)` | Native window on workstation | Full interactive | Phase 4 |
+| **Local notebook (2D)** | `MplBackend` | Inline mpl figures | Same as today | Phase 2 |
+| **Local notebook (3D)** | `PyVistaBackend(jupyter=True)` | Trame/pythreejs in cell | Good for ≤ 50k elem | Phase 3 |
+| **VNC/X2Go to cluster** | `PyVistaBackend(qt_widget=...)` | X server on cluster, compressed pixels back | Acceptable if cluster has GPU or `llvmpipe` | Phase 4 (no extra work) |
+| **SSH + X11 forwarding** | n/a | X11 indirect rendering | **Unusable** — VTK ≥ 9 needs OpenGL ≥ 3.2 core profile | Not supported |
+| **Headless / batch** | `PyVistaBackend(off_screen=True)` | None — renders to memory framebuffer | High throughput | Phase 5 |
+| **Trame web** | `PyVistaBackend(trame=True)` | Browser over WebSocket | Good with client-side `vtk.js`; OK with server-side encoded frames | Phase 6 (deferred) |
+
+---
+
+## 2. The local Qt desktop — the default
+
+The "full experience" target. One process, one main window, embedded
+PyVista viewport.
+
+**Install:**
+
+```bash
+pip install "stko_to_python[viewer]"
+```
+
+This adds: `pyvista>=0.43`, `vtk>=9.2`, `PySide6>=6.5`,
+`pyvistaqt>=0.11`, `qtpy`. About 200 MB on disk.
+
+**Launch:**
+
+```bash
+stko-viewer path/to/results.mpco
+```
+
+or from Python:
+
+```python
+from STKO_to_python import MPCODataSet
+ds = MPCODataSet("path/to/results.mpco")
+ds.viewer()                # blocks until window closed
+ds.viewer(blocking=False)  # spawns a separate process (later phase)
+```
+
+**Platform notes:**
+
+- **Linux:** works on X11 and Wayland (PySide6 6.5+ handles Wayland).
+  GPU helps; software rendering via Mesa `llvmpipe` works but is slow
+  on dense meshes.
+- **macOS:** Apple Silicon + recent VTK works. Bench on M-series before
+  declaring Phase 3 done.
+- **Windows:** ships with OpenGL via WDDM. Tested.
+
+---
+
+## 3. Notebook (2D matplotlib)
+
+This is what `STKO_to_python` already does. Nothing changes.
+
+```bash
+pip install stko_to_python
+```
+
+```python
+ds.plot.deformed_shape(step=100, scale=50)
+ds.plot.mesh_with_contour(component="VonMises", step=100)
+```
+
+After Phase 2, the same calls are powered by `Scene` + `MeshLayer` +
+`MplBackend` under the hood; users don't notice.
+
+---
+
+## 4. Notebook (3D PyVista)
+
+For interactive 3D inside Jupyter without a Qt window.
+
+**Install:**
+
+```bash
+pip install "stko_to_python[viewer-3d]"
+```
+
+This adds PyVista + VTK but **no Qt**. Lighter than `[viewer]`.
+
+**Usage:**
+
+```python
+ds = MPCODataSet("results.mpco")
+scene = ds.scene(backend="pyvista", jupyter=True)
+scene.add(MeshLayer())
+scene.add(ContourLayer(component="VonMises", step=100))
+scene.show()  # renders inline in the notebook cell
+```
+
+Under the hood this uses PyVista's `jupyter_backend="trame"` (the
+default since pyvista 0.40) — which means even the notebook 3D path
+quietly uses a tiny embedded Trame server. Works fine on `localhost`;
+do not point your browser at `0.0.0.0`.
+
+---
+
+## 5. SSH + X11 forwarding — *don't*
+
+We documented this in the planning conversation. Repeating it here so
+the answer lives next to the install docs:
+
+```bash
+ssh -X user@cluster
+stko-viewer ...
+```
+
+What happens:
+
+- Qt UI loads but is laggy (~30–80 ms per event over the wire).
+- VTK fails to create a GL 3.2 core context over X11 indirect
+  rendering, or falls back to software emulation on the client side
+  and is unusable for picking and animation.
+
+**Don't bother.** Use one of the alternatives below.
+
+---
+
+## 6. VNC / X2Go / NoMachine — works, with a caveat
+
+VNC runs an X server on the cluster login node. Your laptop receives
+only compressed pixels — much better than X11 forwarding.
+
+**Requires:**
+
+- An X server on the cluster (the admin's call).
+- Either a GPU with display drivers on the cluster, **or** Mesa with
+  `llvmpipe` for software OpenGL. Compute nodes usually have neither;
+  this only works on login nodes or interactive nodes that admins have
+  configured for graphics.
+- The cluster admin to have enabled VNC/X2Go (rare on locked-down
+  clusters).
+
+**If it's available:**
+
+```bash
+# On laptop:
+vncviewer cluster:1
+# Inside the VNC session:
+pip install "stko_to_python[viewer]"
+stko-viewer results.mpco
+```
+
+Performance: usable for inspection, less smooth than local. Animation
+playback over VNC is rough; export an MP4 with the headless CLI instead.
+
+---
+
+## 7. Headless / batch — the cluster-native answer
+
+When you're on the cluster and you want artifacts (images, animations,
+reports), don't fight for a display. Use the headless CLI.
+
+**Install:**
+
+```bash
+pip install "stko_to_python[viewer-headless]"
+```
+
+Adds: `pyvista`, `vtk`, `imageio`, `imageio-ffmpeg`. **No Qt.** No
+display libraries beyond what PyVista needs for off-screen rendering.
+
+**On Linux, you need one of:**
+
+- VTK built with EGL support (newer wheels, no X needed).
+- `xvfb-run` to give PyVista a virtual framebuffer (`apt install xvfb`).
+- Mesa `llvmpipe` for software rendering when no GPU is available.
+
+PyVista's `pv.start_xvfb()` does the Xvfb dance automatically; the CLI
+calls it for you on Linux when `$DISPLAY` is unset.
+
+**Use:**
+
+```bash
+# Single frame:
+stko-viewer screenshot results.mpco --step 250 --out frame.png
+
+# Animation:
+stko-viewer animate results.mpco --config view.toml --out anim.mp4
+
+# Batch render every Nth step:
+stko-viewer batch results.mpco --config batch.toml --out frames/
+
+# Save a scene in the GUI, then run it on the cluster:
+# (laptop) Edit scene visually, File > Save scene to view.toml
+# (laptop) scp view.toml cluster:~/run/
+# (cluster) stko-viewer animate results.mpco --config view.toml --out anim.mp4
+# (laptop) scp cluster:~/run/anim.mp4 .
+```
+
+This is the workflow most engineers actually use for big runs.
+
+**SLURM stanza (Linux cluster, no GPU):**
+
+```bash
+#!/bin/bash
+#SBATCH --partition=compute
+#SBATCH --time=00:30:00
+#SBATCH --mem=8G
+module load python/3.12
+source ~/venvs/stko/bin/activate   # has stko_to_python[viewer-headless] installed
+xvfb-run -a stko-viewer animate $RESULTS --config view.toml --out anim.mp4
+```
+
+---
+
+## 8. Trame web — the SSH-only answer (Phase 6, deferred)
+
+When the cluster has no VNC, no GUI, and you still want interactive 3D
+without copying gigabytes home — Trame is the standard answer.
+
+**Architecture:**
+
+```
+laptop browser ───── http (WebSocket) ─────► trame server (cluster login node)
+                                                     │
+                                                     └── PyVistaBackend(off_screen=True)
+                                                            renders frames
+                                                            → encodes h264 (server-side)
+                                                            → or ships VTK polydata (client-side)
+```
+
+**One-port SSH tunnel:**
+
+```bash
+ssh -L 8080:localhost:8080 user@cluster
+# In another terminal:
+ssh user@cluster
+stko-viewer web results.mpco --port 8080
+# In laptop browser:
+open http://localhost:8080
+```
+
+**Two rendering modes:**
+
+- **Server-side rendering:** VTK renders on the cluster, h264-encoded
+  frames stream to the browser. Best when the network is fast and the
+  cluster has a GPU.
+- **Client-side rendering (`vtk.js`):** Server ships the
+  `UnstructuredGrid` once, browser renders. Best for slow SSH links;
+  picking and rotation feel native.
+
+The CLI defaults to client-side rendering when the dataset is small
+enough to fit in browser memory, server-side otherwise. Configurable.
+
+**Status:** Phase 6, deferred. Not committed until Phase 5 is shipping.
+
+---
+
+## 9. Decision tree
+
+```
+                           Where am I working?
+                                   │
+              ┌────────────────────┼────────────────────┐
+           workstation         laptop + SSH         CI / batch
+              │                    │                    │
+              │                    │                    │
+   [viewer] + local      What I want?              [viewer-headless]
+   stko-viewer ...           │                     stko-viewer animate ...
+                             ├── interactive 3D
+                             │      │
+                             │      ├── cluster has VNC?
+                             │      │     ├── yes → use VNC + [viewer]
+                             │      │     └── no  → wait for Phase 6 (Trame)
+                             │      │                or use VS Code Remote
+                             │      │                   tunnels + [viewer-3d]
+                             │      │
+                             │      └── small data (< 100 MB)?
+                             │             ├── yes → rsync home + [viewer]
+                             │             └── no  → headless CLI on cluster
+                             │
+                             └── batch artifacts (PNG/MP4)
+                                    └── [viewer-headless] + scp/rsync result
+```
+
+---
+
+## 10. Install matrix (summary)
+
+| Extra | Adds | Use when |
+|---|---|---|
+| *(none)* | nothing — base library | Notebook 2D, CI parsing tests, library consumers. |
+| `[viewer-3d]` | `pyvista`, `vtk` | Notebook 3D, off-screen rendering inside Python scripts. |
+| `[viewer-headless]` | `[viewer-3d]` + `imageio`, `imageio-ffmpeg` | Headless CLI on a cluster. |
+| `[viewer]` | `[viewer-3d]` + `PySide6`, `pyvistaqt`, `qtpy` | Full desktop GUI on a workstation. |
+| `[viewer-web]` *(Phase 6)* | `[viewer-3d]` + `trame`, `trame-vtk`, `trame-vuetify` | Browser-based viewer over SSH tunnel. |
+
+`[viewer]` does **not** imply `[viewer-headless]` and vice versa.
+A workstation install gets `[viewer]`; a cluster install gets
+`[viewer-headless]`. Some users will want both — that's fine,
+`pip install "stko_to_python[viewer,viewer-headless]"` is the spelling.
+
+---
+
+## 11. What we do **not** support
+
+- SSH + X11 forwarding for the Qt viewer. Documented above; mentioned
+  again here because someone will try it.
+- Multi-process Qt viewer with a remote VTK server. Not in scope.
+- Custom display protocols beyond Trame (no VNC over WebSocket, no
+  custom RDP integration, etc.).
+- VTK without OpenGL. PyVista and VTK 9+ assume OpenGL ≥ 3.2 core
+  profile. Pure-CPU VTK builds exist but are not supported by us.
+
+---
+
+## 12. Quick troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `RuntimeError: Could not create GL context` on launch | No display, no Xvfb, no EGL. | Install `xvfb` and run under `xvfb-run`, or set `PYVISTA_OFF_SCREEN=true`. |
+| Black viewport, layers don't appear | Layer attached but not made visible, or scene bounds not set. | `scene.show()` calls `set_bounds(model_bbox)` automatically; if you build a scene manually, do that yourself. |
+| Animation runs at 1 fps over SSH+X | X11 indirect rendering hates this. | Don't use SSH+X. Switch to headless CLI or VNC. |
+| `qt.qpa.plugin: Could not find the Qt platform plugin "xcb"` | Linux container without X libs. | `apt install libxcb-cursor0 libxkbcommon-x11-0 libdbus-1-3` or run under Xvfb. |
+| Picking laggy in Qt | Could be missing the box-pick projection optimization. | Confirm `viewer/math/picking.py` is what's being called, not a naive per-point loop. |
+| MP4 export fails on cluster | `ffmpeg` missing. | `imageio-ffmpeg` ships its own; if it's still failing, install system `ffmpeg`. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,12 @@ nav:
   - Architecture: architecture.md
   - MPCO format conventions: mpco_format_conventions.md
   - Design spec (historical): architecture-refactor-proposal.md
-  - Viewer refactor (design directive): viewer-refactor-directives.md
+  - Viewer:
+      - Design directive: viewer-refactor-directives.md
+      - Roadmap: viewer/00-roadmap.md
+      - Architecture: viewer/01-architecture.md
+      - Porting from apeGmsh: viewer/02-porting-from-apegmsh.md
+      - Deployment targets: viewer/03-deployment-targets.md
   - API reference:
       - Overview: api/index.md
       - MPCODataSet: api/mpco-dataset.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "STKO_to_python"
-version = "1.8.0"
+version = "1.9.0"
 description = "STKO tools for Python"
 readme = "README.md"
 authors = [
@@ -62,6 +62,40 @@ docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.25",
+]
+# Installed with: pip install -e ".[viewer-3d]"
+# 3D rendering stack for the viewer subpackage (PyVista + VTK). Used
+# for off-screen rendering, notebook-embedded scenes, and as the base
+# for the Qt and headless extras below. See docs/viewer/00-roadmap.md.
+viewer-3d = [
+    "pyvista>=0.43",
+    "vtk>=9.2",
+]
+# Installed with: pip install -e ".[viewer-headless]"
+# Off-screen rendering + animation export for cluster / batch use. No
+# display required. See docs/viewer/03-deployment-targets.md.
+viewer-headless = [
+    "STKO_to_python[viewer-3d]",
+    "imageio>=2.30",
+    "imageio-ffmpeg>=0.4",
+]
+# Installed with: pip install -e ".[viewer]"
+# Full desktop GUI: Qt window with embedded PyVista viewport, time
+# scrubber, picking, settings panels. The "full experience" target.
+viewer = [
+    "STKO_to_python[viewer-3d]",
+    "PySide6>=6.5",
+    "pyvistaqt>=0.11",
+    "qtpy",
+]
+# Installed with: pip install -e ".[viewer-web]"
+# Placeholder for the Phase 6 Trame web viewer (deferred). Listed now
+# so the extras matrix is complete in v1.9.0.
+viewer-web = [
+    "STKO_to_python[viewer-3d]",
+    "trame>=3.0",
+    "trame-vtk",
+    "trame-vuetify",
 ]
 
 [project.urls]

--- a/src/STKO_to_python/viewer/__init__.py
+++ b/src/STKO_to_python/viewer/__init__.py
@@ -1,0 +1,21 @@
+"""STKO_to_python viewer subpackage.
+
+The viewer is intentionally empty at v1.9.0 — Phase 0 establishes the
+namespace and optional extras. Subsequent phases land the algorithm
+tier, the ``Scene`` / ``Layer`` / ``Backend`` machinery, and the Qt
+GUI. See ``docs/viewer/00-roadmap.md`` for the phased delivery plan.
+
+Install one of the viewer extras to enable rendering:
+
+    pip install "stko_to_python[viewer]"            # Qt desktop GUI
+    pip install "stko_to_python[viewer-3d]"         # PyVista 3D (notebook)
+    pip install "stko_to_python[viewer-headless]"   # off-screen / CLI
+    pip install "stko_to_python[viewer-web]"        # Trame browser (Phase 6)
+
+This module is lazy-by-design: importing it does **not** import
+``pyvista``, ``vtk``, ``PySide6`` or any other optional dependency. The
+``tests/viewer/test_smoke.py`` suite enforces that contract.
+"""
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/STKO_to_python/viewer/_version.py
+++ b/src/STKO_to_python/viewer/_version.py
@@ -1,0 +1,22 @@
+"""Schema versions for persisted viewer state.
+
+These integers pin the on-disk format of saved scenes and session
+files so that a future viewer can reject — or migrate — a file written
+by an older version. The viewer subpackage has no persisted format at
+v1.9.0 (Phase 0 is namespace-only); pinning the schema versions here
+lets us bump them deliberately as features land.
+
+Bump rules:
+    * Bump ``SCENE_SPEC_SCHEMA`` when the ``SceneSpec`` / ``LayerSpec``
+      on-disk layout changes incompatibly.
+    * Bump ``SESSION_SCHEMA`` when the Qt session-state file (window
+      layout, dock geometry, theme) changes incompatibly.
+    * Add a migration in ``viewer.core.specs`` for every bump.
+
+The current values (``0``) signal "no on-disk format yet"; they will
+move to ``1`` in Phase 2 (``SceneSpec``) and Phase 4 (``SESSION``).
+"""
+from __future__ import annotations
+
+SCENE_SPEC_SCHEMA: int = 0
+SESSION_SCHEMA: int = 0

--- a/tests/viewer/test_smoke.py
+++ b/tests/viewer/test_smoke.py
@@ -1,0 +1,108 @@
+"""Phase 0 smoke tests for the viewer subpackage.
+
+Phase 0 establishes the namespace and optional extras only — no
+rendering, no Qt. These tests guard the contract that
+``import STKO_to_python.viewer`` stays lightweight (does not pull
+``pyvista`` / ``vtk`` / ``PySide6`` / ``trame`` at import time).
+
+The two extras-gated tests (``test_viewer_3d_extra_resolves``,
+``test_viewer_qt_extra_resolves``) only run when the optional deps are
+installed — they verify that the resolved environment is consistent
+with what the extras advertise. In the base CI matrix they skip; in
+the dedicated ``viewer-extras`` CI job they run.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+HEAVY_DEPS = frozenset(
+    {
+        "pyvista",
+        "vtk",
+        "PySide6",
+        "pyvistaqt",
+        "qtpy",
+        "trame",
+        "trame_vtk",
+        "trame_vuetify",
+        "imageio",
+        "imageio_ffmpeg",
+    }
+)
+
+
+def _has(module: str) -> bool:
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        return False
+    return True
+
+
+def test_viewer_imports_without_extras() -> None:
+    """The viewer namespace must import cleanly on the base install."""
+    import STKO_to_python.viewer as viewer
+
+    assert viewer.__all__ == []
+
+
+def test_viewer_import_is_light() -> None:
+    """Importing the viewer must not pull heavy optional deps at import time.
+
+    This is the core Phase 0 contract: ``pip install stko_to_python``
+    (no extras) does not gain ``pyvista`` / ``vtk`` / ``PySide6`` /
+    ``trame`` transitively, so importing the viewer namespace in that
+    environment must not trip an ``ImportError`` — it must succeed and
+    not leak any of those top-level packages into ``sys.modules``.
+    """
+    # Drop any heavy deps that other test modules may have imported,
+    # so we get a clean read on what *the viewer import itself* pulls.
+    for name in list(sys.modules):
+        top = name.split(".")[0]
+        if top in HEAVY_DEPS:
+            del sys.modules[name]
+    sys.modules.pop("STKO_to_python.viewer", None)
+    sys.modules.pop("STKO_to_python.viewer._version", None)
+
+    import STKO_to_python.viewer  # noqa: F401
+
+    leaked = {name.split(".")[0] for name in sys.modules} & HEAVY_DEPS
+    assert not leaked, f"viewer import pulled heavy deps: {sorted(leaked)}"
+
+
+def test_schema_versions_present() -> None:
+    """Schema version constants exist even though no spec format does yet."""
+    from STKO_to_python.viewer import _version
+
+    assert isinstance(_version.SCENE_SPEC_SCHEMA, int)
+    assert isinstance(_version.SESSION_SCHEMA, int)
+    # Phase 0 values: ``0`` means "no on-disk format yet". When Phase 2
+    # lands the ``SceneSpec`` format, ``SCENE_SPEC_SCHEMA`` moves to 1
+    # and this assertion will need bumping.
+    assert _version.SCENE_SPEC_SCHEMA == 0
+    assert _version.SESSION_SCHEMA == 0
+
+
+@pytest.mark.skipif(
+    not (_has("pyvista") and _has("vtk")),
+    reason="viewer-3d extra not installed",
+)
+def test_viewer_3d_extra_resolves() -> None:
+    """When ``[viewer-3d]`` is installed, pyvista + vtk import successfully."""
+    import pyvista  # noqa: F401
+    import vtk  # noqa: F401
+
+
+@pytest.mark.skipif(
+    not (_has("PySide6") and _has("pyvistaqt") and _has("qtpy")),
+    reason="viewer extra not installed",
+)
+def test_viewer_qt_extra_resolves() -> None:
+    """When ``[viewer]`` is installed, the Qt stack imports successfully."""
+    import PySide6  # noqa: F401
+    import pyvistaqt  # noqa: F401
+    import qtpy  # noqa: F401


### PR DESCRIPTION
## Summary

- New `STKO_to_python.viewer` namespace (empty at Phase 0) and four optional extras (`viewer-3d`, `viewer-headless`, `viewer`, `viewer-web`).
- Phased implementation plan + supporting docs under `docs/viewer/` covering the renderer-agnostic architecture, the file-by-file lift from apeGmsh, and the local/headless/cluster/web deployment targets including SSH-cluster guidance.
- New `viewer-extras` CI job that installs `[viewer,test]` and runs the smoke tests to keep the optional-deps matrix honest.
- Version bump to **1.9.0**.

No rendering and no public-API changes at Phase 0 — subsequent phases (per [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md)) land the algorithm tier, ` Scene` / `Layer` / `Backend` machinery, the PyVista backend, and the Qt desktop GUI.

## Test plan
- [x] `pytest tests/viewer/` passes locally (3 passed, 2 skipped — extras-gated)
- [x] Base library still imports cleanly with the new namespace present
- [x] `pyproject.toml` parses; all eight extras resolve
- [ ] New `viewer-extras` CI job green on this PR
- [ ] Existing `test` CI matrix green on this PR
- [ ] mkdocs strict build green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)