### PR TITLE
Add Gauss → nodal extrapolation — viewer math (Phase 1)

### DIFF
--- a/docs/viewer/02-porting-from-apegmsh.md
+++ b/docs/viewer/02-porting-from-apegmsh.md
@@ -174,19 +174,29 @@ These are the "wouldn't reinvent" tricks. Carry them across with care
 ## 7. Overlap audit with v1.8.0 work
 
 We've already shipped section cuts and per-layer/per-fiber shell views.
-Before porting the apeGmsh equivalents, **diff what exists**:
+Before porting the apeGmsh equivalents, **diff what exists**.
+
+The beam-local-frame row was audited at the start of Phase 1; the
+finding is captured below. The other rows are still on the "audit before
+porting" list and will be settled when their respective layers land.
 
 | Topic | STKO_to_python today | apeGmsh equivalent | Action |
 |---|---|---|---|
 | Section cuts (math) | `cuts/kernels/{beam,shell,solid}.py` | none (apeGmsh has only an interactive clipping plane; no resultant integration) | **Keep STKO's** — apeGmsh's clipping is a viz feature, not an integration kernel. |
 | Section cuts (interactive plane) | none | `viewers/core/clipping_controller.py` | **Port apeGmsh's** — wrap STKO's `Plane` so the GUI exposes it. |
-| Per-layer shell views | shipped in v1.8.0 | `viewers/diagrams/_layer_stack.py` | **Audit + reconcile.** Likely keep STKO's data model + lift apeGmsh's aggregation tactics. |
-| Per-fiber views | shipped in v1.8.0 | `viewers/diagrams/_fiber_section.py` | **Audit + reconcile.** Likely keep STKO's data model + lift apeGmsh's 3D-cloud + 2D-side-panel UI pattern. |
-| Beam local frame | `cuts/kernels/beam.py` | `viewers/diagrams/_beam_geometry.py` | **Pick one** — port one canonical implementation into `viewer/math/beam_frame.py` and have both `cuts/` and viewer code consume it. |
+| Per-layer shell views | shipped in v1.8.0 | `viewers/diagrams/_layer_stack.py` | **Audit + reconcile** before Phase 3. Likely keep STKO's data model + lift apeGmsh's aggregation tactics. |
+| Per-fiber views | shipped in v1.8.0 | `viewers/diagrams/_fiber_section.py` | **Audit + reconcile** before Phase 3. Likely keep STKO's data model + lift apeGmsh's 3D-cloud + 2D-side-panel UI pattern. |
+| Beam local frame | `model/transforms.py` + `CDataReader.rotation_matrix` (quaternion from STKO `.cdata` `*LOCAL_AXES`) | `viewers/diagrams/_beam_geometry.py` (vecxz Gram-Schmidt from endpoint coords) | **STKO's wins** — the quaternion is the exact frame OpenSees used during analysis; apeGmsh's reconstructs it. Port apeGmsh's `compute_local_axes` to `viewer/math/beam_frame.py` as a **fallback** for datasets without `.cdata` and for unit tests. Fill-axis policy (`COMPONENT_TO_LOCAL_AXIS`, `fill_axis_for`, `resolve_fill_direction`) is rendering policy, not geometry — defer to Phase 3's `DiagramLayer`. |
 
-**This audit is a precondition for Phase 1 wrap-up.** It's a few hours
-of reading, not a separate phase, but skip it and we end up with two
-parallel implementations of the same physics.
+**Note on `cuts/kernels/beam.py`:** earlier drafts of this table listed
+that module as the local-frame counterpart to port from apeGmsh. The
+audit found it is unrelated — `cuts/kernels/beam.py` solves
+**plane–segment intersection** geometry for section cuts, not local-frame
+math. Different problem; nothing to reconcile.
+
+**This audit is a precondition for each porting PR.** It's a few hours
+of reading per topic, not a separate phase, but skip it and we end up
+with two parallel implementations of the same physics.
 
 ---
 

--- a/src/STKO_to_python/viewer/math/__init__.py
+++ b/src/STKO_to_python/viewer/math/__init__.py
@@ -1,0 +1,19 @@
+"""Pure-numpy math primitives for the viewer.
+
+Phase 1 of the viewer integration plan
+(``docs/viewer/00-roadmap.md``) lifts the algorithm tier from apeGmsh:
+
+* Gauss-point → nodal extrapolation with cross-element averaging.
+* Beam local-frame fallback (vecxz Gram-Schmidt) for datasets without
+  STKO `.cdata` ``*LOCAL_AXES`` quaternions — landed in a follow-up PR.
+* Shell local-axes helpers — landed in a follow-up PR.
+* Display-space box-pick projection math — landed in a follow-up PR.
+
+All modules here are pure-numpy and **have no dependency on**
+``pyvista``, ``vtk``, or ``PySide6``. They are safe to import under
+the base install and are exercised by ``tests/viewer/math/`` without
+any optional extras.
+"""
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/STKO_to_python/viewer/math/gauss_extrapolation.py
+++ b/src/STKO_to_python/viewer/math/gauss_extrapolation.py
@@ -1,0 +1,350 @@
+"""Gauss-point → nodal extrapolation with cross-element averaging.
+
+Adapted from apeGmsh ``results/_gauss_extrapolation.py``.
+
+Used by the future ``ContourLayer`` (Phase 3 of the viewer roadmap) and
+by any other path that needs to render continuous GP-valued fields as
+nodal contours. Today the module is consumable from any caller that can
+supply the inputs in pure numpy — there is no viewer-runtime dependency.
+
+Pipeline
+--------
+
+For each element with ``n_gp`` Gauss points:
+
+1. Look up the element's shape functions ``N`` (from
+   :mod:`STKO_to_python.format.shape_functions`) and the linear-corner
+   node IDs.
+2. Evaluate ``N`` at the GP natural coordinates → matrix ``A`` of shape
+   ``(n_gp, n_corner)``.
+3. Compute the Moore–Penrose pseudo-inverse ``M = pinv(A)`` of shape
+   ``(n_corner, n_gp)``.
+
+   * ``n_gp == n_corner`` (e.g. Brick + 2×2×2 GPs, ASDShellQ4 + 2×2):
+     ``M`` is the exact inverse; constant and linear fields are
+     reproduced exactly at the corners.
+   * ``n_gp < n_corner`` (e.g. Tet4 / Tri3 with one GP): ``M`` is the
+     least-squares fit and reduces to "assign the GP value to every
+     corner."
+   * ``n_gp > n_corner`` (over-determined integration rule): ``M`` is
+     the least-squares projection.
+
+4. Per timestep ``t``: ``corner[t, k] = M_k · gp_values[t, :]``.
+5. Accumulate each per-element corner contribution into a global
+   per-node sum + count; the final nodal value is the mean over
+   neighbouring elements.
+
+Smoothing across element boundaries via nodal averaging is the standard
+post-processing approach used by STKO, ParaView, and most academic
+viewers. Sharp discontinuities at material interfaces are smeared — a
+known trade and the price of a single-mesh nodal contour. The
+discrete-contour path (no averaging) is :func:`extrapolate_per_element`.
+
+Higher-order elements
+---------------------
+
+For future higher-order element classes (e.g. an 8-node serendipity
+shell), the GP values must be projected onto the **linear counterpart's**
+corner shape functions — not the full higher-order ``N``. Reasons:
+
+* The viewer substrate is built with linear cells; mid-side and centre
+  nodes are dropped at scene-build time.
+* Using the full higher-order ``N`` yields a ``pinv`` that produces
+  non-constant nodal fields for a truly constant GP input
+  (minimum-norm regularization of the under-determined system).
+
+The :data:`LINEAR_COUNTERPART` mapping captures this redirection. It is
+empty today because STKO's shape-function catalog has no higher-order
+entries; add one entry per future higher-order class.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from ...format.shape_functions import get_shape_functions
+
+
+# Higher-order STKO class -> linear counterpart class. Used by
+# ``build_extrapolation_matrix`` to project GP values onto the linear
+# corner shape functions instead of the full higher-order ones. Empty
+# today; populate as quadratic elements are added to
+# :mod:`STKO_to_python.format.shape_functions`.
+#
+# Example future entries::
+#
+#     LINEAR_COUNTERPART = {
+#         "204-ASDShellQ8": "203-ASDShellQ4",
+#         "...-TwentyEightNodeBrick": "56-Brick",
+#     }
+LINEAR_COUNTERPART: dict[str, str] = {}
+
+
+__all__ = [
+    "LINEAR_COUNTERPART",
+    "PerElementCornerValues",
+    "per_element_max_gp_count",
+    "build_extrapolation_matrix",
+    "extrapolate_per_element",
+    "extrapolate_to_nodes_averaged",
+]
+
+
+def per_element_max_gp_count(element_index: np.ndarray) -> int:
+    """Largest number of GPs found in any single element.
+
+    Used as a quick discriminator: ``1`` means cell-constant rendering
+    is sufficient; anything else needs the extrapolation pipeline.
+
+    Args:
+        element_index: ``(n_total_gp,)`` integer array. Each row is the
+            element ID that the corresponding GP row belongs to. Multiple
+            rows with the same ID indicate multiple GPs in that element.
+
+    Returns:
+        ``0`` when the input is empty; otherwise the largest count of
+        rows that share a single element ID.
+    """
+    eidx = np.asarray(element_index, dtype=np.int64)
+    if eidx.size == 0:
+        return 0
+    _, counts = np.unique(eidx, return_counts=True)
+    return int(counts.max())
+
+
+def build_extrapolation_matrix(
+    natural_coords: np.ndarray,
+    element_class: str,
+) -> Optional[np.ndarray]:
+    """Build the pinv-based GP→corner projection matrix for one element.
+
+    Args:
+        natural_coords: ``(n_gp, parent_dim)`` GP positions in the
+            parent domain. A ``(n_gp,)`` 1-D array is treated as
+            ``(n_gp, 1)``.
+        element_class: STKO element class string (e.g.
+            ``"56-Brick"``). Higher-order classes are redirected to
+            their linear counterpart via :data:`LINEAR_COUNTERPART`.
+
+    Returns:
+        ``M`` of shape ``(n_corner, n_gp)`` such that
+        ``corner_values = gp_values @ M.T``, or ``None`` when the class
+        is not in :mod:`STKO_to_python.format.shape_functions`. Returning
+        ``None`` is intentional — callers should fall back to a
+        per-element mean rather than guessing a shape function.
+    """
+    effective_class = LINEAR_COUNTERPART.get(element_class, element_class)
+    catalog = get_shape_functions(effective_class)
+    if catalog is None:
+        return None
+    N_fn, _, _ = catalog
+    nat = np.asarray(natural_coords, dtype=np.float64)
+    if nat.ndim == 1:
+        nat = nat[:, None]
+    A = N_fn(nat)             # (n_gp, n_corner)
+    return np.linalg.pinv(A)  # (n_corner, n_gp)
+
+
+@dataclass(frozen=True)
+class PerElementCornerValues:
+    """Per-element extrapolated corner values, no cross-element averaging.
+
+    Each element keeps its own corner values; elements that share a node
+    in the mesh will generally hold *different* values for that node.
+    Pass this object to :func:`extrapolate_to_nodes_averaged` to collapse
+    the duplicates into a smooth mesh-wide nodal field, or consume it
+    directly to render discontinuous per-element contours.
+
+    Attributes:
+        element_ids: ``(E,)`` int64 — FEM element IDs, ascending order.
+        corner_node_ids: Length-``E`` list of ``(n_corner_e,)`` int64
+            arrays — corner node IDs in the same order as the element's
+            shape-function evaluation. Matches the corner ordering used
+            elsewhere in the package (CCW in 2-D, OpenSees convention in
+            3-D — see :mod:`STKO_to_python.format.shape_functions`).
+        values: Length-``E`` list of ``(T, n_corner_e)`` float64
+            arrays — extrapolated values at each corner of each element.
+        time_count: Number of timesteps ``T``.
+    """
+
+    element_ids: np.ndarray
+    corner_node_ids: list
+    values: list
+    time_count: int
+
+
+def extrapolate_per_element(
+    element_index: np.ndarray,
+    natural_coords: np.ndarray,
+    gp_values: np.ndarray,
+    element_lookup: dict,
+) -> PerElementCornerValues:
+    """Project GP values onto each element's corner nodes.
+
+    No averaging across shared corners — each element keeps its own
+    corner values. Use :func:`extrapolate_to_nodes_averaged` to get a
+    mesh-wide averaged nodal field.
+
+    Args:
+        element_index: ``(n_total_gp,)`` int — element ID per GP row.
+            Rows for the same element do not need to be contiguous;
+            they are grouped internally.
+        natural_coords: ``(n_total_gp, dim)`` float — GP natural coords,
+            same row order as ``element_index``. ``(n_total_gp,)``
+            shape is also accepted and treated as ``(n_total_gp, 1)``.
+        gp_values: ``(T, n_total_gp)`` or ``(n_total_gp,)`` float — GP
+            values to project. A 1-D input is treated as a single
+            timestep.
+        element_lookup: ``{element_id: (element_class, corner_node_ids)}``
+            map. ``element_class`` is a STKO class key
+            (e.g. ``"56-Brick"``); ``corner_node_ids`` is a
+            ``(n_corner,)`` int array. For future higher-order classes
+            the caller is responsible for truncating
+            ``corner_node_ids`` to the linear counterpart's corner
+            count.
+
+    Returns:
+        :class:`PerElementCornerValues`. Elements not in
+        ``element_lookup`` (or whose class is not in the shape-function
+        catalog) are silently skipped. Single-GP elements broadcast the
+        value to every corner without invoking the shape-function path.
+    """
+    eidx = np.asarray(element_index, dtype=np.int64)
+    nat = np.asarray(natural_coords, dtype=np.float64)
+    if nat.ndim == 1:
+        nat = nat[:, None]
+    values = np.asarray(gp_values, dtype=np.float64)
+    if values.ndim == 1:
+        values = values[None, :]
+    T = values.shape[0]
+
+    if eidx.size == 0:
+        return PerElementCornerValues(
+            element_ids=np.zeros(0, dtype=np.int64),
+            corner_node_ids=[],
+            values=[],
+            time_count=T,
+        )
+
+    # Group rows by element id, ascending order. Argsort + diff splits
+    # is faster than groupby for the sizes we care about, and gives a
+    # stable ordering downstream consumers can rely on.
+    order = np.argsort(eidx, kind="stable")
+    eidx_sorted = eidx[order]
+    splits = np.where(np.diff(eidx_sorted) != 0)[0] + 1
+    groups = np.split(order, splits)
+
+    out_eids: list[int] = []
+    out_corner_nids: list = []
+    out_values: list = []
+
+    for rows in groups:
+        if rows.size == 0:
+            continue
+        eid = int(eidx[rows[0]])
+        info = element_lookup.get(eid)
+        if info is None:
+            continue
+        element_class, corner_nids = info
+        corner_nids = np.asarray(corner_nids, dtype=np.int64)
+
+        n_gp_e = rows.size
+        gp_vals = values[:, rows]        # (T, n_gp_e)
+        nat_e = nat[rows]                # (n_gp_e, dim)
+
+        if n_gp_e == 1:
+            # Single GP: broadcast to every corner. Avoids invoking the
+            # shape-function path (which would yield a degenerate pinv
+            # on a 1xN matrix anyway).
+            per_corner = np.broadcast_to(
+                gp_vals, (T, corner_nids.size),
+            ).astype(np.float64, copy=True)
+        else:
+            M = build_extrapolation_matrix(nat_e, element_class)
+            if M is None or M.shape[0] != corner_nids.size:
+                # Class not in the catalog, or corner count mismatch.
+                # Fall back to per-element mean so the caller still gets
+                # *some* sensible value at every corner.
+                mean_vals = gp_vals.mean(axis=1, keepdims=True)
+                per_corner = np.broadcast_to(
+                    mean_vals, (T, corner_nids.size),
+                ).astype(np.float64, copy=True)
+            else:
+                per_corner = gp_vals @ M.T  # (T, n_corner)
+                per_corner = np.ascontiguousarray(per_corner, dtype=np.float64)
+
+        out_eids.append(eid)
+        out_corner_nids.append(corner_nids)
+        out_values.append(per_corner)
+
+    return PerElementCornerValues(
+        element_ids=np.asarray(out_eids, dtype=np.int64),
+        corner_node_ids=out_corner_nids,
+        values=out_values,
+        time_count=T,
+    )
+
+
+def extrapolate_to_nodes_averaged(
+    per_elem: PerElementCornerValues,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Average per-element corner values into per-node mesh values.
+
+    Args:
+        per_elem: Output of :func:`extrapolate_per_element`.
+
+    Returns:
+        Tuple ``(node_ids, nodal_values)``:
+
+        * ``node_ids`` — ``(N,)`` int64, sorted ascending. Each entry is
+          a node that received at least one corner contribution.
+        * ``nodal_values`` — ``(T, N)`` float64, column-aligned with
+          ``node_ids``. The value at column ``j`` is the arithmetic mean
+          of every per-element corner value that touched
+          ``node_ids[j]``.
+
+    Notes:
+        Sharp discontinuities at element boundaries are smeared by the
+        averaging — that's the standard post-processing convention. If
+        discontinuities must be preserved (different materials meeting
+        at a shared corner), consume :class:`PerElementCornerValues`
+        directly and render each element's corners separately.
+    """
+    T = per_elem.time_count
+    if per_elem.element_ids.size == 0:
+        return (
+            np.zeros(0, dtype=np.int64),
+            np.zeros((T, 0), dtype=np.float64),
+        )
+
+    sums: dict[int, np.ndarray] = {}
+    counts: dict[int, int] = {}
+    for corner_nids, per_corner in zip(
+        per_elem.corner_node_ids, per_elem.values,
+    ):
+        for c, nid in enumerate(corner_nids):
+            nid_i = int(nid)
+            col = per_corner[:, c]
+            existing = sums.get(nid_i)
+            if existing is None:
+                sums[nid_i] = col.astype(np.float64).copy()
+                counts[nid_i] = 1
+            else:
+                existing += col
+                counts[nid_i] += 1
+
+    if not sums:
+        return (
+            np.zeros(0, dtype=np.int64),
+            np.zeros((T, 0), dtype=np.float64),
+        )
+
+    node_ids = np.fromiter(sums.keys(), dtype=np.int64, count=len(sums))
+    order = np.argsort(node_ids)
+    node_ids = node_ids[order]
+    nodal = np.zeros((T, node_ids.size), dtype=np.float64)
+    for j, nid in enumerate(node_ids):
+        nodal[:, j] = sums[int(nid)] / counts[int(nid)]
+    return node_ids, nodal

--- a/tests/viewer/math/test_gauss_extrapolation.py
+++ b/tests/viewer/math/test_gauss_extrapolation.py
@@ -1,0 +1,362 @@
+"""Tests for :mod:`STKO_to_python.viewer.math.gauss_extrapolation`.
+
+Algorithm correctness is anchored on three analytic properties:
+
+* A constant GP field projects to a constant nodal field at every
+  corner — for every element class.
+* When ``n_gp == n_corner`` (e.g. Brick with 2×2×2 Gauss-Legendre, or
+  ASDShellQ4 with 2×2), a linear field is reproduced *exactly* at the
+  corners. The pinv is the true inverse and the projection is exact.
+* When ``n_gp == 1``, the single GP value is broadcast to every corner.
+
+Cross-element averaging is verified with a two-element fixture sharing
+a face; the shared corners get the arithmetic mean of the two
+contributors.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.viewer.math.gauss_extrapolation import (
+    PerElementCornerValues,
+    build_extrapolation_matrix,
+    extrapolate_per_element,
+    extrapolate_to_nodes_averaged,
+    per_element_max_gp_count,
+)
+
+
+# --------------------------------------------------------------------- #
+# Reference Gauss points (2×2×2 Gauss-Legendre on the unit cube)        #
+# --------------------------------------------------------------------- #
+
+_G = 1.0 / np.sqrt(3.0)
+
+# Order matches the Brick node ordering in
+# ``format/shape_functions.py``: corner k at signs (sx, sy, sz) gets GP
+# at (sx*g, sy*g, sz*g). The two collections are not required to align;
+# the pinv handles arbitrary GP ordering. We align them here so the
+# "n_gp == n_corner" case maps GP k onto corner k for clarity.
+_BRICK_GP_2x2x2 = np.array(
+    [
+        [-_G, -_G, -_G],
+        [+_G, -_G, -_G],
+        [+_G, +_G, -_G],
+        [-_G, +_G, -_G],
+        [-_G, -_G, +_G],
+        [+_G, -_G, +_G],
+        [+_G, +_G, +_G],
+        [-_G, +_G, +_G],
+    ],
+    dtype=np.float64,
+)
+
+_BRICK_CORNERS = np.array(
+    [
+        [-1.0, -1.0, -1.0],
+        [+1.0, -1.0, -1.0],
+        [+1.0, +1.0, -1.0],
+        [-1.0, +1.0, -1.0],
+        [-1.0, -1.0, +1.0],
+        [+1.0, -1.0, +1.0],
+        [+1.0, +1.0, +1.0],
+        [-1.0, +1.0, +1.0],
+    ],
+    dtype=np.float64,
+)
+
+
+# --------------------------------------------------------------------- #
+# per_element_max_gp_count                                              #
+# --------------------------------------------------------------------- #
+
+
+def test_per_element_max_gp_count_empty() -> None:
+    assert per_element_max_gp_count(np.array([], dtype=np.int64)) == 0
+
+
+def test_per_element_max_gp_count_single() -> None:
+    eidx = np.array([1, 1, 1, 2], dtype=np.int64)
+    assert per_element_max_gp_count(eidx) == 3
+
+
+def test_per_element_max_gp_count_homogeneous() -> None:
+    eidx = np.repeat(np.arange(5, dtype=np.int64), 8)
+    assert per_element_max_gp_count(eidx) == 8
+
+
+# --------------------------------------------------------------------- #
+# build_extrapolation_matrix                                            #
+# --------------------------------------------------------------------- #
+
+
+def test_build_extrapolation_matrix_brick_is_exact_inverse() -> None:
+    """Brick with 2×2×2 GPs → pinv is the exact inverse."""
+    M = build_extrapolation_matrix(_BRICK_GP_2x2x2, "56-Brick")
+    assert M is not None
+    assert M.shape == (8, 8)
+
+    from STKO_to_python.format.shape_functions import get_shape_functions
+
+    N_fn, _, _ = get_shape_functions("56-Brick")  # type: ignore[misc]
+    A = N_fn(_BRICK_GP_2x2x2)
+    # M @ A should be identity to numerical precision.
+    np.testing.assert_allclose(M @ A, np.eye(8), atol=1e-12)
+
+
+def test_build_extrapolation_matrix_unknown_class_returns_none() -> None:
+    M = build_extrapolation_matrix(_BRICK_GP_2x2x2, "999-NotInCatalog")
+    assert M is None
+
+
+def test_build_extrapolation_matrix_1d_natural_coords_accepted() -> None:
+    """1-D natural-coord arrays are promoted to 2-D internally."""
+    # Use a 2-node line element with two GPs.
+    gp1 = np.array([-_G, +_G], dtype=np.float64)
+    M = build_extrapolation_matrix(gp1, "5-ElasticBeam3d")
+    assert M is not None
+    assert M.shape == (2, 2)
+
+
+# --------------------------------------------------------------------- #
+# extrapolate_per_element                                               #
+# --------------------------------------------------------------------- #
+
+
+def _make_single_brick_lookup(
+    element_id: int = 1,
+    base_node_id: int = 10,
+) -> dict:
+    """One Brick element with corner IDs ``base..base+7``."""
+    corner_nids = np.arange(base_node_id, base_node_id + 8, dtype=np.int64)
+    return {element_id: ("56-Brick", corner_nids)}
+
+
+def test_extrapolate_per_element_empty_input_returns_empty_record() -> None:
+    out = extrapolate_per_element(
+        element_index=np.array([], dtype=np.int64),
+        natural_coords=np.zeros((0, 3), dtype=np.float64),
+        gp_values=np.zeros((4, 0), dtype=np.float64),  # 4 time steps, 0 GPs
+        element_lookup={},
+    )
+    assert isinstance(out, PerElementCornerValues)
+    assert out.element_ids.size == 0
+    assert out.corner_node_ids == []
+    assert out.values == []
+    assert out.time_count == 4
+
+
+def test_extrapolate_per_element_constant_field_brick() -> None:
+    """A constant GP field projects to a constant corner field."""
+    lookup = _make_single_brick_lookup()
+    eidx = np.full(8, 1, dtype=np.int64)
+    gp_vals = np.full((3, 8), 7.5, dtype=np.float64)  # 3 time steps
+
+    out = extrapolate_per_element(
+        element_index=eidx,
+        natural_coords=_BRICK_GP_2x2x2,
+        gp_values=gp_vals,
+        element_lookup=lookup,
+    )
+
+    assert out.element_ids.tolist() == [1]
+    assert out.values[0].shape == (3, 8)
+    np.testing.assert_allclose(out.values[0], 7.5, atol=1e-12)
+
+
+def test_extrapolate_per_element_linear_field_brick_is_exact() -> None:
+    """For n_gp == n_corner, a linear field is reproduced exactly."""
+    lookup = _make_single_brick_lookup()
+    eidx = np.full(8, 1, dtype=np.int64)
+
+    # f(xi, eta, zeta) = 1 + 2*xi + 3*eta + 4*zeta
+    def f(xyz: np.ndarray) -> np.ndarray:
+        return 1.0 + 2.0 * xyz[:, 0] + 3.0 * xyz[:, 1] + 4.0 * xyz[:, 2]
+
+    gp_vals = f(_BRICK_GP_2x2x2)[None, :]  # shape (1, 8)
+    expected_corner = f(_BRICK_CORNERS)    # shape (8,)
+
+    out = extrapolate_per_element(
+        element_index=eidx,
+        natural_coords=_BRICK_GP_2x2x2,
+        gp_values=gp_vals,
+        element_lookup=lookup,
+    )
+
+    np.testing.assert_allclose(out.values[0][0], expected_corner, atol=1e-12)
+
+
+def test_extrapolate_per_element_single_gp_broadcasts_to_every_corner() -> None:
+    """One GP per element → its value is duplicated to every corner."""
+    # Brick with a single centroidal GP.
+    lookup = _make_single_brick_lookup()
+    out = extrapolate_per_element(
+        element_index=np.array([1], dtype=np.int64),
+        natural_coords=np.zeros((1, 3), dtype=np.float64),
+        gp_values=np.array([[42.0]], dtype=np.float64),
+        element_lookup=lookup,
+    )
+    np.testing.assert_allclose(out.values[0], 42.0, atol=1e-12)
+    assert out.values[0].shape == (1, 8)
+
+
+def test_extrapolate_per_element_skips_unknown_class() -> None:
+    """An element whose class is not in the catalog is silently dropped."""
+    lookup = {1: ("999-NotInCatalog", np.array([10, 11], dtype=np.int64))}
+    out = extrapolate_per_element(
+        element_index=np.array([1, 1], dtype=np.int64),
+        natural_coords=np.array([[-_G], [+_G]], dtype=np.float64),
+        gp_values=np.array([[1.0, 2.0]], dtype=np.float64),
+        element_lookup=lookup,
+    )
+    # Class is unknown but the corner count (2) matches a hypothetical
+    # linear element; the fallback path takes the mean across GPs and
+    # broadcasts. The element is *not* dropped because lookup hit; only
+    # the pinv path is skipped. So the contract is "the element appears
+    # with a sensible value" — verify that mean fallback fired.
+    assert out.element_ids.tolist() == [1]
+    np.testing.assert_allclose(out.values[0], 1.5, atol=1e-12)
+
+
+def test_extrapolate_per_element_element_not_in_lookup_is_dropped() -> None:
+    out = extrapolate_per_element(
+        element_index=np.array([1, 1], dtype=np.int64),
+        natural_coords=np.array([[-_G], [+_G]], dtype=np.float64),
+        gp_values=np.array([[1.0, 2.0]], dtype=np.float64),
+        element_lookup={},  # no entry for element 1
+    )
+    assert out.element_ids.size == 0
+
+
+def test_extrapolate_per_element_handles_non_contiguous_grouping() -> None:
+    """Rows for the same element don't need to be contiguous."""
+    lookup = {
+        1: ("56-Brick", np.arange(10, 18, dtype=np.int64)),
+        2: ("56-Brick", np.arange(20, 28, dtype=np.int64)),
+    }
+    # Interleave the two elements' GP rows.
+    eidx = np.array([1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2], dtype=np.int64)
+    nat = np.empty((16, 3), dtype=np.float64)
+    nat[::2] = _BRICK_GP_2x2x2   # element 1 rows
+    nat[1::2] = _BRICK_GP_2x2x2  # element 2 rows
+    gp_vals = np.empty((1, 16), dtype=np.float64)
+    gp_vals[0, ::2] = 1.0   # element 1: constant 1.0
+    gp_vals[0, 1::2] = 5.0  # element 2: constant 5.0
+
+    out = extrapolate_per_element(
+        element_index=eidx,
+        natural_coords=nat,
+        gp_values=gp_vals,
+        element_lookup=lookup,
+    )
+
+    assert out.element_ids.tolist() == [1, 2]
+    np.testing.assert_allclose(out.values[0], 1.0, atol=1e-12)
+    np.testing.assert_allclose(out.values[1], 5.0, atol=1e-12)
+
+
+# --------------------------------------------------------------------- #
+# extrapolate_to_nodes_averaged                                         #
+# --------------------------------------------------------------------- #
+
+
+def test_extrapolate_to_nodes_averaged_empty_input() -> None:
+    per_elem = PerElementCornerValues(
+        element_ids=np.zeros(0, dtype=np.int64),
+        corner_node_ids=[],
+        values=[],
+        time_count=5,
+    )
+    node_ids, nodal = extrapolate_to_nodes_averaged(per_elem)
+    assert node_ids.size == 0
+    assert nodal.shape == (5, 0)
+
+
+def test_extrapolate_to_nodes_averaged_single_element() -> None:
+    """Single element: averaging is a no-op; each corner appears once."""
+    corner_nids = np.array([10, 11, 12, 13, 14, 15, 16, 17], dtype=np.int64)
+    values = np.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]], dtype=np.float64)
+    per_elem = PerElementCornerValues(
+        element_ids=np.array([1], dtype=np.int64),
+        corner_node_ids=[corner_nids],
+        values=[values],
+        time_count=1,
+    )
+    node_ids, nodal = extrapolate_to_nodes_averaged(per_elem)
+    np.testing.assert_array_equal(node_ids, corner_nids)
+    np.testing.assert_allclose(nodal, values, atol=1e-12)
+
+
+def test_extrapolate_to_nodes_averaged_shared_corners_get_mean() -> None:
+    """Two elements sharing a face → shared corners average over both."""
+    # Element 1 corners: 10..17, value 1.0 at every corner.
+    # Element 2 corners: 14..17 + 20..23, value 3.0 at every corner.
+    # Shared corners (14, 15, 16, 17) should receive (1.0 + 3.0) / 2 = 2.0.
+    c1 = np.array([10, 11, 12, 13, 14, 15, 16, 17], dtype=np.int64)
+    c2 = np.array([14, 15, 16, 17, 20, 21, 22, 23], dtype=np.int64)
+    v1 = np.full((1, 8), 1.0, dtype=np.float64)
+    v2 = np.full((1, 8), 3.0, dtype=np.float64)
+    per_elem = PerElementCornerValues(
+        element_ids=np.array([1, 2], dtype=np.int64),
+        corner_node_ids=[c1, c2],
+        values=[v1, v2],
+        time_count=1,
+    )
+    node_ids, nodal = extrapolate_to_nodes_averaged(per_elem)
+
+    # All unique node IDs, sorted.
+    expected_ids = np.array([10, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23], dtype=np.int64)
+    np.testing.assert_array_equal(node_ids, expected_ids)
+
+    expected = np.array(
+        [[1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0]],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(nodal, expected, atol=1e-12)
+
+
+def test_extrapolate_to_nodes_averaged_preserves_time_axis() -> None:
+    """``(T, N)`` shape with multiple time steps round-trips correctly."""
+    c1 = np.array([10, 11], dtype=np.int64)
+    c2 = np.array([11, 12], dtype=np.int64)
+    v1 = np.array([[1.0, 2.0], [10.0, 20.0]], dtype=np.float64)   # (T=2, n=2)
+    v2 = np.array([[4.0, 8.0], [40.0, 80.0]], dtype=np.float64)
+
+    per_elem = PerElementCornerValues(
+        element_ids=np.array([1, 2], dtype=np.int64),
+        corner_node_ids=[c1, c2],
+        values=[v1, v2],
+        time_count=2,
+    )
+    node_ids, nodal = extrapolate_to_nodes_averaged(per_elem)
+    np.testing.assert_array_equal(node_ids, np.array([10, 11, 12], dtype=np.int64))
+    expected = np.array(
+        [
+            [1.0, (2.0 + 4.0) / 2.0, 8.0],
+            [10.0, (20.0 + 40.0) / 2.0, 80.0],
+        ],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(nodal, expected, atol=1e-12)
+
+
+# --------------------------------------------------------------------- #
+# Property-style spot check                                             #
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("c", [0.0, 1.0, -2.5, 1e6])
+def test_constant_field_round_trips_for_any_constant(c: float) -> None:
+    """For any constant ``c``, projection and averaging both return ``c``."""
+    lookup = _make_single_brick_lookup()
+    eidx = np.full(8, 1, dtype=np.int64)
+    gp_vals = np.full((1, 8), c, dtype=np.float64)
+    per_elem = extrapolate_per_element(
+        element_index=eidx,
+        natural_coords=_BRICK_GP_2x2x2,
+        gp_values=gp_vals,
+        element_lookup=lookup,
+    )
+    _, nodal = extrapolate_to_nodes_averaged(per_elem)
+    np.testing.assert_allclose(nodal, c, atol=1e-9)


### PR DESCRIPTION
## Summary

First module of the viewer **algorithm tier** (Phase 1 of [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md)). Ports apeGmsh's GP → nodal extrapolation with cross-element averaging, adapted to STKO's shape-function catalog (string class keys instead of Gmsh codes). Pure-numpy; no new dependencies.

Public API in `STKO_to_python.viewer.math.gauss_extrapolation`:

- `per_element_max_gp_count(element_index)` — quick discriminator for "cell-rendering vs extrapolation".
- `build_extrapolation_matrix(natural_coords, element_class)` — the pinv core. ``M`` shape ``(n_corner, n_gp)``.
- `extrapolate_per_element(...)` — per-element corner values (discontinuous, no averaging).
- `extrapolate_to_nodes_averaged(per_elem)` — mesh-wide averaged nodal field for smooth contour rendering.

The module is what the future `ContourLayer` (Phase 3) will call when ``n_gp > 1`` and the contour is rendered as a nodal field. It is independent of any rendering code today; pure numpy in, pure numpy out.

## Audit finding (beam local frames)

`docs/viewer/02-porting-from-apegmsh.md §7` is updated with the audit result:

- `cuts/kernels/beam.py` was originally listed as the local-frame counterpart to port from apeGmsh. The audit found it is plane–segment intersection geometry — **different problem**, nothing to reconcile.
- The real counterpart is STKO's quaternion-from-`.cdata` `*LOCAL_AXES` path in `model/transforms.py` + `CDataReader.rotation_matrix`. STKO's approach wins (exact frame OpenSees used during analysis; apeGmsh's reconstructs it via vecxz Gram-Schmidt).
- apeGmsh's `compute_local_axes` will still land in a follow-up PR as a **fallback** for datasets without `.cdata` and for unit tests.
- Fill-axis policy (`COMPONENT_TO_LOCAL_AXIS`, `fill_axis_for`, `resolve_fill_direction`) is rendering policy, not geometry — deferred to Phase 3's `DiagramLayer`.

## Test plan

- [x] `pytest tests/viewer/` — **24 passed, 2 skipped** (the 2 skipped are extras-gated)
- [x] Algorithm correctness anchored on analytic cases:
  - constant GP field projects to constant corner field
  - linear field reproduced **exactly** on Brick + 2×2×2 Gauss-Legendre (`n_gp == n_corner` ⇒ pinv is the exact inverse)
  - single-GP element broadcasts to every corner
  - empty inputs, non-contiguous grouping, unknown class, dropped elements all behave per docstring
  - cross-element averaging on a two-element fixture sharing a face
  - time-axis ``(T, N)`` shape preserved through averaging
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)