### PR TITLE
Add beam local-frame fallback — viewer math (Phase 1)

### DIFF
--- a/src/STKO_to_python/viewer/math/beam_frame.py
+++ b/src/STKO_to_python/viewer/math/beam_frame.py
@@ -1,0 +1,182 @@
+"""Beam local-axis fallback — OpenSees ``vecxz`` convention.
+
+Adapted from apeGmsh ``viewers/diagrams/_beam_geometry.py``.
+
+This module is the **fallback** path for computing a beam's local frame
+from just its endpoint coordinates and an optional ``vecxz`` reference
+vector. The **primary** path in STKO_to_python — used by
+``plotting/beam_solid.py``, ``cuts/kernels/beam_resultant.py``, and
+``cuts/kernels/shell.py`` — is the quaternion stored in
+``.cdata`` ``*LOCAL_AXES``, read by
+:meth:`STKO_to_python.model.cdata_reader.CDataReader.rotation_matrix`.
+The quaternion path is more accurate (it's the exact frame OpenSees
+used during analysis, including Corotational and user-supplied
+``vecxz``).
+
+Use this module when:
+
+* The dataset has no `.cdata` sidecar (external inputs, partial fixtures).
+* You only have endpoint coordinates (custom datasets, unit tests).
+* You need a *recomputed* frame for a hypothetical beam (e.g. a
+  Phase 3 `DiagramLayer` rendering against a user-supplied vector).
+
+Convention (OpenSees ``Linear`` / ``PDelta`` / ``Corotational``
+``geomTransf``):
+
+* ``x_local = (j - i) / |j - i|``
+* ``z_local = (vecxz - (vecxz · x_local) * x_local) / |…|``
+  (Gram-Schmidt: the part of ``vecxz`` perpendicular to ``x_local``).
+* ``y_local = z_local × x_local`` (right-hand rule).
+
+The user-supplied ``vecxz`` is a vector lying in the local x-z plane.
+When omitted, :func:`default_vecxz` mimics the typical structural
+default: global Z for non-vertical beams, global X for vertical.
+
+This module is pure numpy. It does **not** depend on
+``MPCODataSet`` — a higher-level adapter that prefers the quaternion
+path when available will land in ``viewer/core/datasource.py`` in
+Phase 2.
+"""
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+
+
+# Above this |dot| with global +Z the beam axis is treated as vertical
+# and ``default_vecxz`` switches to global +X so Gram-Schmidt has a
+# non-parallel reference.
+_VERTICAL_TOL: float = 0.99
+
+# Below this magnitude a vector is treated as numerically zero. The
+# value matches apeGmsh; ``1e-12`` is safely below any structural-scale
+# coordinate magnitude we expect.
+_DEGENERATE_EPS: float = 1e-12
+
+
+__all__ = [
+    "default_vecxz",
+    "compute_local_axes",
+    "station_position",
+]
+
+
+def default_vecxz(x_local: ndarray) -> ndarray:
+    """Sensible fallback ``vecxz`` when the user provides none.
+
+    Args:
+        x_local: Unit vector along the beam's local x-axis.
+
+    Returns:
+        ``[0, 0, 1]`` (global Z) for a beam that is not (nearly)
+        parallel to global Z, otherwise ``[1, 0, 0]`` (global X). The
+        switch at the vertical case ensures the subsequent Gram-Schmidt
+        in :func:`compute_local_axes` produces a non-degenerate
+        ``z_local``.
+    """
+    x = np.asarray(x_local, dtype=np.float64)
+    if abs(np.dot(x, np.array([0.0, 0.0, 1.0]))) > _VERTICAL_TOL:
+        return np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    return np.array([0.0, 0.0, 1.0], dtype=np.float64)
+
+
+def compute_local_axes(
+    coord_i: ndarray,
+    coord_j: ndarray,
+    vecxz: ndarray | None = None,
+) -> tuple[ndarray, ndarray, ndarray, float]:
+    """Return ``(x_local, y_local, z_local, length)`` for a beam.
+
+    All returned axes are unit vectors. ``(x, y, z)`` is right-handed.
+
+    Args:
+        coord_i: Endpoint coordinates of node ``i`` — ``(3,)``.
+        coord_j: Endpoint coordinates of node ``j`` — ``(3,)``.
+        vecxz: Reference vector lying in the local x-z plane. ``None``
+            selects :func:`default_vecxz`. When the user-supplied
+            vector is (almost) parallel to ``x_local``, the routine
+            silently falls back to :func:`default_vecxz` and only
+            raises if that *also* fails (unreachable in practice — see
+            note below).
+
+    Returns:
+        ``(x_local, y_local, z_local, length)``:
+
+        * ``x_local`` — unit vector along ``(j - i)``.
+        * ``y_local`` — unit vector perpendicular to ``x_local``,
+          obtained via right-hand rule ``z × x``.
+        * ``z_local`` — unit vector perpendicular to ``x_local``,
+          aligned with the projection of ``vecxz`` onto the plane
+          perpendicular to ``x_local``.
+        * ``length`` — Euclidean distance from ``i`` to ``j``.
+
+    Raises:
+        ValueError: When endpoints coincide (zero beam length), or
+            when both the user's ``vecxz`` and :func:`default_vecxz`
+            are parallel to ``x_local``. The second case is defensive
+            only — :func:`default_vecxz` returns a vector perpendicular
+            to whichever cardinal axis ``x_local`` aligns with, so the
+            inner failure cannot be reached in practice.
+    """
+    ci = np.asarray(coord_i, dtype=np.float64)
+    cj = np.asarray(coord_j, dtype=np.float64)
+    raw_x = cj - ci
+    L = float(np.linalg.norm(raw_x))
+    if L <= _DEGENERATE_EPS:
+        raise ValueError(
+            "Beam endpoints coincide — cannot build a local frame."
+        )
+    x_local = raw_x / L
+
+    if vecxz is None:
+        vecxz = default_vecxz(x_local)
+    v = np.asarray(vecxz, dtype=np.float64)
+
+    # z_local: Gram-Schmidt — part of vecxz perpendicular to x_local.
+    proj = float(np.dot(v, x_local)) * x_local
+    z_raw = v - proj
+    z_norm = float(np.linalg.norm(z_raw))
+    if z_norm < _DEGENERATE_EPS:
+        # vecxz parallel to x_local — try the default reference.
+        fallback = default_vecxz(x_local)
+        proj = float(np.dot(fallback, x_local)) * x_local
+        z_raw = fallback - proj
+        z_norm = float(np.linalg.norm(z_raw))
+        if z_norm < _DEGENERATE_EPS:
+            raise ValueError(
+                "Could not derive a non-degenerate z_local; "
+                f"x_local={x_local}, vecxz={v}."
+            )
+    z_local = z_raw / z_norm
+
+    # y_local: right-hand rule.
+    y_local = np.cross(z_local, x_local)
+    y_local /= float(np.linalg.norm(y_local))
+
+    return x_local, y_local, z_local, L
+
+
+def station_position(
+    coord_i: ndarray,
+    coord_j: ndarray,
+    natural_coord: float,
+) -> ndarray:
+    """Position along the beam at a natural coordinate ``ξ ∈ [-1, +1]``.
+
+    Args:
+        coord_i: Endpoint coordinates of node ``i`` — ``(3,)``.
+        coord_j: Endpoint coordinates of node ``j`` — ``(3,)``.
+        natural_coord: Natural coordinate along the beam axis. ``-1``
+            maps to node ``i``; ``+1`` maps to node ``j``. Values
+            outside ``[-1, +1]`` are allowed and extrapolate linearly
+            — the function does not clamp.
+
+    Returns:
+        ``(3,)`` global-coordinate position. Linear interpolation
+        matches OpenSees integration-point placement on a 1-D parent
+        element with linear shape functions.
+    """
+    ci = np.asarray(coord_i, dtype=np.float64)
+    cj = np.asarray(coord_j, dtype=np.float64)
+    t = (1.0 + float(natural_coord)) / 2.0
+    return ci + t * (cj - ci)

--- a/tests/viewer/math/test_beam_frame.py
+++ b/tests/viewer/math/test_beam_frame.py
@@ -1,0 +1,256 @@
+"""Tests for :mod:`STKO_to_python.viewer.math.beam_frame`.
+
+The module is the apeGmsh-derived ``vecxz`` Gram-Schmidt fallback for
+beams that do not have a ``.cdata`` ``*LOCAL_AXES`` quaternion
+available. Tests cover:
+
+* :func:`default_vecxz` switches between global Z and global X at the
+  vertical threshold.
+* :func:`compute_local_axes` produces a right-handed orthonormal frame
+  for any beam orientation, with the expected geometric properties.
+* :func:`compute_local_axes` raises on coincident endpoints.
+* :func:`compute_local_axes` falls back silently when the user's
+  ``vecxz`` is parallel to ``x_local``.
+* :func:`station_position` linearly interpolates between endpoints.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.viewer.math.beam_frame import (
+    compute_local_axes,
+    default_vecxz,
+    station_position,
+)
+
+
+# --------------------------------------------------------------------- #
+# default_vecxz                                                         #
+# --------------------------------------------------------------------- #
+
+
+def test_default_vecxz_horizontal_beam_returns_global_Z() -> None:
+    x_local = np.array([1.0, 0.0, 0.0])
+    np.testing.assert_array_equal(default_vecxz(x_local), [0.0, 0.0, 1.0])
+
+
+def test_default_vecxz_y_aligned_beam_returns_global_Z() -> None:
+    x_local = np.array([0.0, 1.0, 0.0])
+    np.testing.assert_array_equal(default_vecxz(x_local), [0.0, 0.0, 1.0])
+
+
+def test_default_vecxz_vertical_beam_returns_global_X() -> None:
+    x_local = np.array([0.0, 0.0, 1.0])
+    np.testing.assert_array_equal(default_vecxz(x_local), [1.0, 0.0, 0.0])
+
+
+def test_default_vecxz_near_vertical_beam_returns_global_X() -> None:
+    # cos(0.1 rad) ~ 0.995 > 0.99 threshold
+    x_local = np.array([np.sin(0.1), 0.0, np.cos(0.1)])
+    np.testing.assert_array_equal(default_vecxz(x_local), [1.0, 0.0, 0.0])
+
+
+def test_default_vecxz_tilted_beam_returns_global_Z() -> None:
+    # cos(20 deg) ~ 0.94 < 0.99 threshold — not vertical enough.
+    angle = np.deg2rad(20.0)
+    x_local = np.array([np.sin(angle), 0.0, np.cos(angle)])
+    np.testing.assert_array_equal(default_vecxz(x_local), [0.0, 0.0, 1.0])
+
+
+# --------------------------------------------------------------------- #
+# compute_local_axes — basic geometry                                   #
+# --------------------------------------------------------------------- #
+
+
+def _assert_orthonormal_right_handed(
+    x: np.ndarray, y: np.ndarray, z: np.ndarray, *, atol: float = 1e-12,
+) -> None:
+    """All axes unit-norm; pairwise orthogonal; (x, y, z) right-handed."""
+    np.testing.assert_allclose(np.linalg.norm(x), 1.0, atol=atol)
+    np.testing.assert_allclose(np.linalg.norm(y), 1.0, atol=atol)
+    np.testing.assert_allclose(np.linalg.norm(z), 1.0, atol=atol)
+    np.testing.assert_allclose(np.dot(x, y), 0.0, atol=atol)
+    np.testing.assert_allclose(np.dot(y, z), 0.0, atol=atol)
+    np.testing.assert_allclose(np.dot(x, z), 0.0, atol=atol)
+    # Right-handed: det([x|y|z]) == +1.
+    det = float(np.linalg.det(np.column_stack([x, y, z])))
+    np.testing.assert_allclose(det, 1.0, atol=atol)
+
+
+def test_compute_local_axes_horizontal_beam_along_X() -> None:
+    x, y, z, L = compute_local_axes(
+        np.array([0.0, 0.0, 0.0]),
+        np.array([5.0, 0.0, 0.0]),
+    )
+    np.testing.assert_allclose(x, [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(z, [0.0, 0.0, 1.0])
+    # y = z × x = +Z × +X = +Y
+    np.testing.assert_allclose(y, [0.0, 1.0, 0.0])
+    np.testing.assert_allclose(L, 5.0)
+    _assert_orthonormal_right_handed(x, y, z)
+
+
+def test_compute_local_axes_horizontal_beam_along_Y() -> None:
+    x, y, z, L = compute_local_axes(
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 3.0, 0.0]),
+    )
+    np.testing.assert_allclose(x, [0.0, 1.0, 0.0])
+    np.testing.assert_allclose(z, [0.0, 0.0, 1.0])
+    # y = z × x = +Z × +Y = -X
+    np.testing.assert_allclose(y, [-1.0, 0.0, 0.0])
+    np.testing.assert_allclose(L, 3.0)
+    _assert_orthonormal_right_handed(x, y, z)
+
+
+def test_compute_local_axes_vertical_beam() -> None:
+    x, y, z, L = compute_local_axes(
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 4.0]),
+    )
+    np.testing.assert_allclose(x, [0.0, 0.0, 1.0])
+    # Default vecxz for vertical beam is +X, projected onto plane
+    # perpendicular to +Z stays +X.
+    np.testing.assert_allclose(z, [1.0, 0.0, 0.0])
+    # y = z × x = +X × +Z = -Y
+    np.testing.assert_allclose(y, [0.0, -1.0, 0.0])
+    np.testing.assert_allclose(L, 4.0)
+    _assert_orthonormal_right_handed(x, y, z)
+
+
+def test_compute_local_axes_diagonal_beam_remains_orthonormal() -> None:
+    x, y, z, L = compute_local_axes(
+        np.array([1.0, 2.0, 3.0]),
+        np.array([4.0, 6.0, 9.0]),
+    )
+    expected_length = np.linalg.norm([3.0, 4.0, 6.0])
+    np.testing.assert_allclose(L, expected_length)
+    _assert_orthonormal_right_handed(x, y, z)
+
+
+@pytest.mark.parametrize(
+    "i, j",
+    [
+        ([0, 0, 0], [1, 0, 0]),
+        ([0, 0, 0], [0, 1, 0]),
+        ([0, 0, 0], [1, 1, 0]),
+        ([0, 0, 0], [1, 1, 1]),
+        ([10, -5, 3], [-2, 7, 11]),
+        ([0, 0, 0], [0, 0, -1]),   # downward
+    ],
+)
+def test_compute_local_axes_invariants_for_arbitrary_endpoints(
+    i: list[float], j: list[float],
+) -> None:
+    """For any non-degenerate endpoint pair, the frame is orthonormal RH."""
+    x, y, z, L = compute_local_axes(np.array(i), np.array(j))
+    _assert_orthonormal_right_handed(x, y, z, atol=1e-10)
+    np.testing.assert_allclose(L, np.linalg.norm(np.array(j) - np.array(i)))
+    # x_local must align with (j - i).
+    raw = np.array(j) - np.array(i)
+    np.testing.assert_allclose(x, raw / np.linalg.norm(raw), atol=1e-12)
+
+
+# --------------------------------------------------------------------- #
+# compute_local_axes — custom vecxz                                     #
+# --------------------------------------------------------------------- #
+
+
+def test_compute_local_axes_respects_user_vecxz() -> None:
+    """A user vecxz in the +Y direction tilts z_local for a +X beam."""
+    x, y, z, L = compute_local_axes(
+        np.array([0.0, 0.0, 0.0]),
+        np.array([1.0, 0.0, 0.0]),
+        vecxz=np.array([0.0, 1.0, 0.0]),
+    )
+    np.testing.assert_allclose(x, [1.0, 0.0, 0.0])
+    # vecxz = +Y is already perpendicular to +X, so z_local = +Y.
+    np.testing.assert_allclose(z, [0.0, 1.0, 0.0])
+    # y_local = z × x = +Y × +X = -Z
+    np.testing.assert_allclose(y, [0.0, 0.0, -1.0])
+    _assert_orthonormal_right_handed(x, y, z)
+
+
+def test_compute_local_axes_parallel_vecxz_falls_back_silently() -> None:
+    """User vecxz parallel to x_local triggers the default fallback."""
+    x, y, z, L = compute_local_axes(
+        np.array([0.0, 0.0, 0.0]),
+        np.array([1.0, 0.0, 0.0]),
+        vecxz=np.array([3.0, 0.0, 0.0]),  # parallel to +X (== x_local)
+    )
+    # default_vecxz for horizontal beam is +Z; result should be the
+    # same as if we had passed no vecxz at all.
+    np.testing.assert_allclose(z, [0.0, 0.0, 1.0])
+    np.testing.assert_allclose(y, [0.0, 1.0, 0.0])
+    _assert_orthonormal_right_handed(x, y, z)
+
+
+# --------------------------------------------------------------------- #
+# compute_local_axes — error paths                                      #
+# --------------------------------------------------------------------- #
+
+
+def test_compute_local_axes_coincident_endpoints_raises() -> None:
+    with pytest.raises(ValueError, match="endpoints coincide"):
+        compute_local_axes(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0, 2.0, 3.0]),
+        )
+
+
+def test_compute_local_axes_near_coincident_endpoints_raises() -> None:
+    """Within _DEGENERATE_EPS the beam is treated as zero-length."""
+    with pytest.raises(ValueError, match="endpoints coincide"):
+        compute_local_axes(
+            np.array([0.0, 0.0, 0.0]),
+            np.array([1e-15, 0.0, 0.0]),
+        )
+
+
+# --------------------------------------------------------------------- #
+# station_position                                                      #
+# --------------------------------------------------------------------- #
+
+
+def test_station_position_at_minus_one_returns_node_i() -> None:
+    ci = np.array([1.0, 2.0, 3.0])
+    cj = np.array([4.0, 5.0, 6.0])
+    np.testing.assert_allclose(station_position(ci, cj, -1.0), ci)
+
+
+def test_station_position_at_plus_one_returns_node_j() -> None:
+    ci = np.array([1.0, 2.0, 3.0])
+    cj = np.array([4.0, 5.0, 6.0])
+    np.testing.assert_allclose(station_position(ci, cj, +1.0), cj)
+
+
+def test_station_position_at_zero_returns_midpoint() -> None:
+    ci = np.array([0.0, 0.0, 0.0])
+    cj = np.array([4.0, 6.0, 8.0])
+    np.testing.assert_allclose(station_position(ci, cj, 0.0), [2.0, 3.0, 4.0])
+
+
+@pytest.mark.parametrize(
+    "xi, expected_t",
+    [
+        (-0.5, 0.25),
+        (+0.5, 0.75),
+        (+1.0, 1.0),
+        (-1.0, 0.0),
+    ],
+)
+def test_station_position_t_mapping(xi: float, expected_t: float) -> None:
+    """``ξ -> t = (1 + ξ) / 2`` mapping reproduces OpenSees IP placement."""
+    ci = np.array([0.0, 0.0, 0.0])
+    cj = np.array([10.0, 0.0, 0.0])
+    pos = station_position(ci, cj, xi)
+    np.testing.assert_allclose(pos[0], 10.0 * expected_t)
+
+
+def test_station_position_does_not_clamp_outside_minus_one_plus_one() -> None:
+    """Values outside ``[-1, +1]`` extrapolate linearly without clamping."""
+    ci = np.array([0.0, 0.0, 0.0])
+    cj = np.array([2.0, 0.0, 0.0])
+    # xi = 3 -> t = 2 -> position = ci + 2 * (cj - ci) = (4, 0, 0).
+    np.testing.assert_allclose(station_position(ci, cj, 3.0), [4.0, 0.0, 0.0])


### PR DESCRIPTION
## Summary

Second module of the viewer **algorithm tier** (Phase 1 of [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md)). Ports apeGmsh's `vecxz` Gram-Schmidt local-frame computation as a **fallback** for datasets without STKO `.cdata` `*LOCAL_AXES` quaternions and for unit tests using raw endpoint coordinates.

The **primary** beam-frame path in STKO_to_python is and remains the quaternion-from-cdata approach in `model/transforms.py` + `CDataReader.rotation_matrix`, consumed today by `plotting/beam_solid.py`, `cuts/kernels/beam_resultant.py`, and `cuts/kernels/shell.py`. That's the exact frame OpenSees used during analysis (Corotational, custom `vecxz`, all preserved). This new module is the explicit fallback when that quaternion is unavailable.

Public API in `STKO_to_python.viewer.math.beam_frame`:

- `default_vecxz(x_local)` — vertical vs non-vertical heuristic; returns global Z or global X.
- `compute_local_axes(coord_i, coord_j, vecxz=None)` — Gram-Schmidt local frame from endpoint coords; returns ``(x_local, y_local, z_local, length)``.
- `station_position(coord_i, coord_j, natural_coord)` — linear interpolation along the beam at ``ξ ∈ [-1, +1]``.

Pure numpy. No new dependencies. The convention matches OpenSees `Linear` / `PDelta` / `Corotational` `geomTransf`.

The fill-axis policy from apeGmsh (`COMPONENT_TO_LOCAL_AXIS`, `fill_axis_for`, `resolve_fill_direction`, `normalize_fill_axis_spec`) is **not** included here — it's rendering policy, not geometry, and lands with Phase 3's `DiagramLayer`.

## Test plan

- [x] `pytest tests/viewer/` — **51 passed, 2 skipped** locally (the 2 skipped are extras-gated).
- [x] 27 new unit tests cover:
  - `default_vecxz` switches at the vertical threshold (cos > 0.99).
  - `compute_local_axes` produces a right-handed orthonormal frame for arbitrary beam orientations (parametrized over 6 geometries).
  - User-supplied `vecxz` is honored when non-parallel to `x_local`; falls back silently when parallel.
  - Coincident endpoints (within `_DEGENERATE_EPS`) raise `ValueError`.
  - `station_position` linearly interpolates with the OpenSees ``t = (1 + ξ) / 2`` mapping; does not clamp outside ``[-1, +1]``.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)