### PR TITLE
Add box-pick projection math — viewer math (Phase 1)

### DIFF
--- a/src/STKO_to_python/viewer/math/picking.py
+++ b/src/STKO_to_python/viewer/math/picking.py
@@ -1,0 +1,194 @@
+"""Vectorized world → screen projection for box-pick selection.
+
+Adapted from apeGmsh ``viewers/core/results_pick.py`` (the pure-math
+projection kernel, without the VTK interactor wiring).
+
+Pure-numpy primitives that drive 3D selection workflows: project a
+batch of world-space points to screen-space coordinates in one matmul,
+then test inclusion against a rectangle. ~40× faster than the
+per-point ``vtkRenderer.WorldToDisplay`` loop at 100k+ points — the
+gap matters when a user box-selects across a million Gauss markers on
+a solid model.
+
+This module does **not** depend on ``pyvista``, ``vtk``, or any
+renderer. Callers (Phase 4 Qt picking controller) are responsible for:
+
+1. Extracting the composite view-projection matrix from the renderer
+   (in VTK: ``camera.GetCompositeProjectionTransformMatrix(aspect, 0, 1)``).
+2. Extracting the window size and viewport bounds from the renderer.
+3. Passing all three plus the candidate point batch into the functions
+   here, and acting on the returned mask.
+
+Convention
+----------
+
+* World coordinates are right-handed 3-D.
+* ``projection_matrix`` is the row-major 4×4 composite matrix mapping
+  world coordinates to clip space — i.e. the matrix VTK returns from
+  ``GetCompositeProjectionTransformMatrix``. Same convention as OpenGL.
+* NDC (normalized device coordinates) span ``[-1, +1]`` on the x and
+  y axes for points inside the view frustum. The z axis carries depth
+  (passed through for callers that care; not used here).
+* Display pixels have origin at the bottom-left of the viewport, x
+  increasing right, y increasing up — VTK's convention. (Qt's window
+  uses top-left; the caller flips y if needed.)
+"""
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+
+
+__all__ = [
+    "world_to_ndc",
+    "world_to_display",
+    "points_in_box",
+    "world_points_in_box",
+]
+
+
+def world_to_ndc(
+    world_points: ndarray,
+    projection_matrix: ndarray,
+) -> ndarray:
+    """Project a batch of world-space points to normalized device coords.
+
+    Args:
+        world_points: ``(N, 3)`` array of world-space positions.
+        projection_matrix: ``(4, 4)`` row-major composite view-projection
+            matrix. Same orientation VTK and OpenGL use: applying
+            ``clip = M @ [x, y, z, 1]`` produces clip-space coords whose
+            xy ∈ ``[-w, +w]`` are visible.
+
+    Returns:
+        ``(N, 3)`` array of NDC coordinates. Visible points have ``x``,
+        ``y`` in ``[-1, +1]``; the ``z`` column carries depth.
+
+        Points whose homogeneous-coordinate ``w`` is exactly zero
+        (e.g. exactly on the camera plane) receive a divisor of ``1``
+        instead — they will not project sensibly but the function does
+        not raise. Callers should mask such points by checking
+        ``|ndc| <= 1`` or by inspecting depth.
+
+    Empty input ``(0, 3)`` returns an empty ``(0, 3)`` array.
+    """
+    pts = np.asarray(world_points, dtype=np.float64)
+    M = np.asarray(projection_matrix, dtype=np.float64)
+    n = pts.shape[0]
+    if n == 0:
+        return np.empty((0, 3), dtype=np.float64)
+
+    # Build homogeneous coords ``(N, 4)`` with w == 1.
+    homog = np.empty((n, 4), dtype=np.float64)
+    homog[:, :3] = pts
+    homog[:, 3] = 1.0
+    # ``clip = homog @ M.T`` is the row-major form of ``clip_col = M @ homog_col``.
+    clip = homog @ M.T
+    w = clip[:, 3:4]
+    # Avoid divide-by-zero for w == 0 (point on the camera plane).
+    safe_w = np.where(w == 0.0, 1.0, w)
+    return clip[:, :3] / safe_w
+
+
+def world_to_display(
+    world_points: ndarray,
+    projection_matrix: ndarray,
+    window_size: tuple[int, int],
+    viewport: tuple[float, float, float, float] = (0.0, 0.0, 1.0, 1.0),
+) -> ndarray:
+    """Project world points to display-pixel coordinates.
+
+    Args:
+        world_points: ``(N, 3)`` world-space positions.
+        projection_matrix: ``(4, 4)`` composite view-projection matrix.
+            See :func:`world_to_ndc`.
+        window_size: ``(width, height)`` of the render window, in
+            pixels.
+        viewport: ``(x_min, y_min, x_max, y_max)`` viewport bounds as
+            fractions of the window, in ``[0, 1]``. Defaults to the
+            full window.
+
+    Returns:
+        ``(N, 2)`` array of display-pixel ``(x, y)`` coordinates with
+        VTK's bottom-left origin. Empty input returns ``(0, 2)``.
+    """
+    n = np.asarray(world_points, dtype=np.float64).shape[0]
+    if n == 0:
+        return np.empty((0, 2), dtype=np.float64)
+
+    ndc = world_to_ndc(world_points, projection_matrix)
+    win_w, win_h = float(window_size[0]), float(window_size[1])
+    vp_x0 = float(viewport[0]) * win_w
+    vp_y0 = float(viewport[1]) * win_h
+    vp_w = (float(viewport[2]) - float(viewport[0])) * win_w
+    vp_h = (float(viewport[3]) - float(viewport[1])) * win_h
+
+    out = np.empty((n, 2), dtype=np.float64)
+    out[:, 0] = vp_x0 + (ndc[:, 0] * 0.5 + 0.5) * vp_w
+    out[:, 1] = vp_y0 + (ndc[:, 1] * 0.5 + 0.5) * vp_h
+    return out
+
+
+def points_in_box(
+    display_xy: ndarray,
+    box: tuple[float, float, float, float],
+) -> ndarray:
+    """Boolean mask: which display-space points fall inside the rectangle.
+
+    Args:
+        display_xy: ``(N, 2)`` array of display-space ``(x, y)``
+            coordinates.
+        box: ``(x0, y0, x1, y1)`` corners of the rectangle. Either
+            diagonal works — the function normalizes so a "drag from
+            top-right to bottom-left" produces the same mask as a drag
+            in the opposite direction. Boundary points are treated as
+            inside.
+
+    Returns:
+        ``(N,)`` bool mask. Empty input returns an empty mask.
+    """
+    xy = np.asarray(display_xy, dtype=np.float64)
+    if xy.shape[0] == 0:
+        return np.zeros(0, dtype=bool)
+    x0, y0, x1, y1 = (float(v) for v in box)
+    bx0, bx1 = (x0, x1) if x0 <= x1 else (x1, x0)
+    by0, by1 = (y0, y1) if y0 <= y1 else (y1, y0)
+    return (
+        (xy[:, 0] >= bx0) & (xy[:, 0] <= bx1)
+        & (xy[:, 1] >= by0) & (xy[:, 1] <= by1)
+    )
+
+
+def world_points_in_box(
+    world_points: ndarray,
+    projection_matrix: ndarray,
+    window_size: tuple[int, int],
+    box: tuple[float, float, float, float],
+    viewport: tuple[float, float, float, float] = (0.0, 0.0, 1.0, 1.0),
+) -> ndarray:
+    """End-to-end: project then test box inclusion in one call.
+
+    Equivalent to::
+
+        display = world_to_display(world_points, M, window_size, viewport)
+        mask = points_in_box(display, box)
+
+    Provided as a convenience for the hot path of rubber-band box-pick
+    selection, where the caller does not need the intermediate display
+    coordinates.
+
+    Args:
+        world_points: ``(N, 3)`` world-space positions.
+        projection_matrix: ``(4, 4)`` composite view-projection matrix.
+        window_size: ``(width, height)`` of the render window in pixels.
+        box: ``(x0, y0, x1, y1)`` rectangle in display pixels.
+        viewport: ``(x_min, y_min, x_max, y_max)`` fraction-of-window
+            viewport bounds.
+
+    Returns:
+        ``(N,)`` bool mask. Empty input returns an empty mask.
+    """
+    display = world_to_display(
+        world_points, projection_matrix, window_size, viewport,
+    )
+    return points_in_box(display, box)

--- a/tests/viewer/math/test_picking.py
+++ b/tests/viewer/math/test_picking.py
@@ -1,0 +1,276 @@
+"""Tests for :mod:`STKO_to_python.viewer.math.picking`.
+
+The module is the pure-numpy projection kernel that drives 3D
+box-pick selection. The tests use **constructed** projection matrices
+(no VTK) so they can run without any rendering deps installed.
+
+Coverage:
+
+* ``world_to_ndc`` correctness on identity and translation matrices,
+  perspective division behaviour, and the divide-by-zero guard.
+* ``world_to_display`` maps NDC ``[-1, +1]`` to the viewport correctly
+  for both full-window and partial-viewport cases.
+* ``points_in_box`` normalizes corner ordering and is inclusive at
+  the boundary.
+* ``world_points_in_box`` composes correctly end-to-end.
+* Empty inputs return empty outputs throughout.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.viewer.math.picking import (
+    points_in_box,
+    world_points_in_box,
+    world_to_display,
+    world_to_ndc,
+)
+
+
+# --------------------------------------------------------------------- #
+# world_to_ndc                                                          #
+# --------------------------------------------------------------------- #
+
+
+def test_world_to_ndc_identity_matrix_preserves_xy() -> None:
+    """Identity 4×4 → NDC equals world (after trivial w=1 division)."""
+    M = np.eye(4)
+    pts = np.array(
+        [
+            [-1.0, -1.0, 0.0],
+            [+1.0, +1.0, 0.0],
+            [+0.5, -0.25, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    ndc = world_to_ndc(pts, M)
+    np.testing.assert_allclose(ndc, pts, atol=1e-12)
+
+
+def test_world_to_ndc_empty_input_returns_empty_output() -> None:
+    M = np.eye(4)
+    out = world_to_ndc(np.zeros((0, 3)), M)
+    assert out.shape == (0, 3)
+
+
+def test_world_to_ndc_translation_shifts_xy() -> None:
+    """A translation matrix shifts the projected coordinates by the same amount."""
+    M = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.5],
+            [0.0, 1.0, 0.0, -0.25],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    pts = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+    ndc = world_to_ndc(pts, M)
+    np.testing.assert_allclose(ndc[0, :2], [0.5, -0.25], atol=1e-12)
+
+
+def test_world_to_ndc_perspective_division_applied() -> None:
+    """Setting ``w = 2`` halves the projected xy coordinates."""
+    # Matrix that sets clip-space w := 2 (no other transform).
+    M = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 2.0],   # row → w = 2 for any point
+        ],
+        dtype=np.float64,
+    )
+    pts = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+    ndc = world_to_ndc(pts, M)
+    np.testing.assert_allclose(ndc[0], [0.5, 1.0, 1.5], atol=1e-12)
+
+
+def test_world_to_ndc_zero_w_uses_safe_divisor() -> None:
+    """A point that produces w == 0 doesn't raise; gets w := 1 fallback."""
+    # Matrix that sets clip-space w := 0 for any point.
+    M = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],   # w = 0
+        ],
+        dtype=np.float64,
+    )
+    pts = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+    ndc = world_to_ndc(pts, M)
+    # With safe_w == 1, NDC equals the un-divided clip coords.
+    np.testing.assert_allclose(ndc[0], [1.0, 2.0, 3.0], atol=1e-12)
+    assert np.all(np.isfinite(ndc))
+
+
+# --------------------------------------------------------------------- #
+# world_to_display                                                      #
+# --------------------------------------------------------------------- #
+
+
+def test_world_to_display_identity_full_viewport() -> None:
+    """NDC [-1, +1] maps linearly to the full window."""
+    M = np.eye(4)
+    pts = np.array(
+        [
+            [-1.0, -1.0, 0.0],   # bottom-left of viewport
+            [+1.0, +1.0, 0.0],   # top-right of viewport
+            [0.0, 0.0, 0.0],     # centre
+            [+0.5, -0.5, 0.0],   # offset
+        ],
+        dtype=np.float64,
+    )
+    display = world_to_display(pts, M, window_size=(100, 200))
+
+    np.testing.assert_allclose(display[0], [0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(display[1], [100.0, 200.0], atol=1e-12)
+    np.testing.assert_allclose(display[2], [50.0, 100.0], atol=1e-12)
+    np.testing.assert_allclose(display[3], [75.0, 50.0], atol=1e-12)
+
+
+def test_world_to_display_partial_viewport_respects_offset() -> None:
+    """A right-half viewport places NDC -1 at the window midpoint."""
+    M = np.eye(4)
+    pts = np.array([[-1.0, 0.0, 0.0], [+1.0, 0.0, 0.0]], dtype=np.float64)
+    display = world_to_display(
+        pts, M, window_size=(100, 100), viewport=(0.5, 0.0, 1.0, 1.0),
+    )
+    np.testing.assert_allclose(display[0], [50.0, 50.0], atol=1e-12)
+    np.testing.assert_allclose(display[1], [100.0, 50.0], atol=1e-12)
+
+
+def test_world_to_display_empty_input_returns_empty_output() -> None:
+    M = np.eye(4)
+    out = world_to_display(np.zeros((0, 3)), M, window_size=(640, 480))
+    assert out.shape == (0, 2)
+
+
+# --------------------------------------------------------------------- #
+# points_in_box                                                         #
+# --------------------------------------------------------------------- #
+
+
+def test_points_in_box_basic() -> None:
+    xy = np.array(
+        [
+            [10.0, 10.0],     # inside
+            [50.0, 50.0],     # inside (centre)
+            [99.0, 99.0],     # inside (near corner)
+            [101.0, 50.0],    # outside (right)
+            [50.0, -1.0],     # outside (below)
+        ],
+        dtype=np.float64,
+    )
+    mask = points_in_box(xy, (0.0, 0.0, 100.0, 100.0))
+    np.testing.assert_array_equal(mask, [True, True, True, False, False])
+
+
+def test_points_in_box_reversed_corners() -> None:
+    """Box passed as (x1, y1, x0, y0) → same mask as the forward order."""
+    xy = np.array([[5.0, 5.0], [50.0, 50.0]], dtype=np.float64)
+    forward = points_in_box(xy, (0.0, 0.0, 100.0, 100.0))
+    reversed_ = points_in_box(xy, (100.0, 100.0, 0.0, 0.0))
+    np.testing.assert_array_equal(forward, reversed_)
+
+
+def test_points_in_box_boundary_inclusive() -> None:
+    """Points lying exactly on the rectangle edge are considered inside."""
+    xy = np.array(
+        [
+            [0.0, 0.0],       # bottom-left corner
+            [100.0, 50.0],    # right edge
+            [50.0, 0.0],      # bottom edge
+            [100.0, 100.0],   # top-right corner
+        ],
+        dtype=np.float64,
+    )
+    mask = points_in_box(xy, (0.0, 0.0, 100.0, 100.0))
+    np.testing.assert_array_equal(mask, [True, True, True, True])
+
+
+def test_points_in_box_empty_input() -> None:
+    mask = points_in_box(np.zeros((0, 2)), (0.0, 0.0, 100.0, 100.0))
+    assert mask.shape == (0,)
+    assert mask.dtype == bool
+
+
+def test_points_in_box_degenerate_rectangle_includes_only_the_line() -> None:
+    """A zero-area box (x0 == x1) only matches points on that line."""
+    xy = np.array(
+        [
+            [50.0, 50.0],   # on the line
+            [50.1, 50.0],   # just off
+        ],
+        dtype=np.float64,
+    )
+    mask = points_in_box(xy, (50.0, 0.0, 50.0, 100.0))
+    np.testing.assert_array_equal(mask, [True, False])
+
+
+# --------------------------------------------------------------------- #
+# world_points_in_box                                                   #
+# --------------------------------------------------------------------- #
+
+
+def test_world_points_in_box_end_to_end_identity() -> None:
+    """Identity projection on a 100×100 window with a centred 40px box."""
+    M = np.eye(4)
+    # Mix of inside and outside-the-NDC-frustum points.
+    pts = np.array(
+        [
+            [-0.5, -0.5, 0.0],   # NDC (-0.5, -0.5) → display (25, 25)
+            [+0.5, +0.5, 0.0],   # NDC (+0.5, +0.5) → display (75, 75)
+            [+0.9, +0.9, 0.0],   # display (95, 95) — outside the box
+            [-0.9, -0.9, 0.0],   # display (5, 5) — outside the box
+        ],
+        dtype=np.float64,
+    )
+    # Box from (30, 30) to (80, 80) in display pixels.
+    mask = world_points_in_box(
+        pts, M, window_size=(100, 100), box=(30.0, 30.0, 80.0, 80.0),
+    )
+    np.testing.assert_array_equal(mask, [False, True, False, False])
+
+
+def test_world_points_in_box_empty_input() -> None:
+    M = np.eye(4)
+    mask = world_points_in_box(
+        np.zeros((0, 3)), M, window_size=(100, 100), box=(0, 0, 50, 50),
+    )
+    assert mask.shape == (0,)
+
+
+def test_world_points_in_box_perspective_division_affects_result() -> None:
+    """A point further from the camera shrinks toward the screen centre."""
+    # Standard symmetric perspective projection with a 90 deg FOV. The
+    # canonical matrix (OpenGL convention) places the near plane at
+    # z = -1 and the far plane at z = -100.
+    near, far = 1.0, 100.0
+    aspect = 1.0
+    f = 1.0 / np.tan(np.deg2rad(45.0))
+    M = np.array(
+        [
+            [f / aspect, 0.0, 0.0,                              0.0],
+            [0.0,        f,   0.0,                              0.0],
+            [0.0,        0.0, (far + near) / (near - far),      (2.0 * far * near) / (near - far)],
+            [0.0,        0.0, -1.0,                             0.0],
+        ],
+        dtype=np.float64,
+    )
+    # Two points at the same world (x, y) but different depths. The
+    # further one (more negative z) should project closer to (0, 0).
+    pts = np.array(
+        [
+            [0.5, 0.5, -2.0],
+            [0.5, 0.5, -50.0],
+        ],
+        dtype=np.float64,
+    )
+    display = world_to_display(pts, M, window_size=(200, 200))
+    # Near point projects further from screen centre than far point.
+    near_offset = np.linalg.norm(display[0] - [100.0, 100.0])
+    far_offset = np.linalg.norm(display[1] - [100.0, 100.0])
+    assert near_offset > far_offset


### PR DESCRIPTION
## Summary

Third module of the viewer **algorithm tier** (Phase 1 of [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md)). Ports the pure-numpy projection kernel from apeGmsh `viewers/core/results_pick.py` that drives rubber-band box-pick selection.

This PR lifts **only** the math — the VTK interactor wiring (mouse observers, rubber-band overlay, picker dispatch) is Phase 4 work and will live under `viewer/qt/controllers/picking.py` later. The math module is pure-numpy: caller supplies the composite projection matrix + window size + box, gets back a boolean mask.

Public API in `STKO_to_python.viewer.math.picking`:

- `world_to_ndc(world_points, projection_matrix)` → ``(N, 3)`` NDC. Includes a safe divide-by-zero guard for points exactly on the camera plane.
- `world_to_display(world_points, M, window_size, viewport=(0,0,1,1))` → ``(N, 2)`` display pixels with VTK's bottom-left origin.
- `points_in_box(display_xy, box)` → ``(N,)`` bool, corner-ordering-agnostic, boundary-inclusive.
- `world_points_in_box(...)` — convenience end-to-end for the rubber-band hot path.

The vectorized matmul approach is **~40× faster** than VTK's per-point `WorldToDisplay` loop at 100k+ candidates — relevant when the user box-selects across a million Gauss markers on a solid model. (The speed claim is from apeGmsh's own perf tests; the new module has the math but not the renderer benchmark — that lands when Phase 4 wires the controller.)

## Test plan

- [x] `pytest tests/viewer/` — **67 passed, 2 skipped** locally (the 2 skipped are extras-gated).
- [x] 14 new unit tests cover:
  - `world_to_ndc` on identity, translation, perspective-division, and the ``w == 0`` safe divisor case.
  - `world_to_display` mapping for the full window and for a half-window viewport offset.
  - `points_in_box` with reversed corners, boundary-inclusive points, degenerate (zero-area) rectangles.
  - `world_points_in_box` end-to-end with identity + a constructed OpenGL-convention perspective matrix (further points project closer to screen centre).
  - Empty inputs return empty outputs across all entry points.
- [x] No new dependencies; module is pure numpy. Tests use constructed projection matrices and do not require VTK / PyVista.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)