### PR TITLE
Add shell local-frame fallback + R→quat — viewer math (Phase 1)

### DIFF
--- a/src/STKO_to_python/viewer/math/shell_frame.py
+++ b/src/STKO_to_python/viewer/math/shell_frame.py
@@ -1,0 +1,232 @@
+"""Shell local-frame fallback + rotation-matrix ↔ quaternion utility.
+
+Adapted from apeGmsh ``results/_shell_geometry.py``.
+
+The **primary** shell-local-frame path in STKO_to_python — used by
+``cuts/kernels/shell.py`` and any other consumer that has a dataset
+in hand — is the per-element quaternion from STKO's `.cdata`
+``*LOCAL_AXES`` section, read by
+:meth:`STKO_to_python.model.cdata_reader.CDataReader.rotation_matrix`.
+That quaternion is the exact frame OpenSees used during analysis.
+
+This module is the **fallback** path: it derives the same frame from
+just the element's corner-node coordinates. Use it when:
+
+* The dataset has no `.cdata` sidecar (external datasets, partial
+  fixtures).
+* You only have node coordinates (custom inputs, unit tests).
+* You want to *recompute* the frame for a hypothetical shell (e.g. a
+  Phase 3 layer-stack viewer rendering against synthetic geometry).
+
+Convention (matches OpenSees ASDShellQ4 / ShellMITC4 / etc.):
+
+* Quads: ``x_local = (n2 − n1) / |…|``, ``z_local = (e1 × e2) / |…|``
+  where ``e2 = n4 − n1``; ``y_local = z_local × x_local``.
+* Triangles: same recipe with ``e2 = n3 − n1``.
+* 9-node shells: use corner nodes 1–4 (internal nodes don't affect the
+  element-local frame).
+
+The returned ``R`` is shape ``(3, 3)`` with **columns** equal to the
+local basis vectors expressed in the global frame — matching STKO's
+existing :func:`STKO_to_python.quaternion_to_rotation_matrix` so
+``v_global = R @ v_local``.
+
+This module is pure numpy. It does **not** depend on
+``MPCODataSet``. A higher-level adapter that prefers the
+quaternion-from-`.cdata` path when available will land in
+``viewer/core/datasource.py`` in Phase 2.
+"""
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+
+
+# Shell class lists kept in sync with ``cuts/kernels/shell.py``.
+_QUAD_SHELL_CLASSES: frozenset[str] = frozenset(
+    {"ShellMITC4", "ShellDKGQ", "ShellNLDKGQ", "ASDShellQ4"}
+)
+_TRI_SHELL_CLASSES: frozenset[str] = frozenset(
+    {"ShellDKGT", "ShellNLDKGT", "ASDShellT3"}
+)
+_QUAD9_SHELL_CLASSES: frozenset[str] = frozenset({"ShellMITC9"})
+
+
+# Below this norm, vectors are treated as numerically degenerate.
+_DEGENERATE_EPS: float = 1e-14
+
+
+__all__ = [
+    "shell_local_axes",
+    "rotation_matrix_to_quaternion",
+    "shell_quaternion",
+]
+
+
+def _frame_edges(
+    node_coords: ndarray, class_name: str,
+) -> tuple[ndarray, ndarray]:
+    """Pick the two edge vectors that define the local frame.
+
+    Quads (incl. 9-node): ``(n2 − n1, n4 − n1)``.
+    Triangles: ``(n2 − n1, n3 − n1)``.
+    """
+    if class_name in _QUAD_SHELL_CLASSES or class_name in _QUAD9_SHELL_CLASSES:
+        if node_coords.shape[0] < 4:
+            raise ValueError(
+                f"{class_name} expects ≥4 corner nodes; got "
+                f"node_coords.shape={node_coords.shape}."
+            )
+        n1 = node_coords[0]
+        n2 = node_coords[1]
+        n4 = node_coords[3]
+        return (n2 - n1, n4 - n1)
+    if class_name in _TRI_SHELL_CLASSES:
+        if node_coords.shape[0] < 3:
+            raise ValueError(
+                f"{class_name} expects ≥3 corner nodes; got "
+                f"node_coords.shape={node_coords.shape}."
+            )
+        n1 = node_coords[0]
+        n2 = node_coords[1]
+        n3 = node_coords[2]
+        return (n2 - n1, n3 - n1)
+    raise ValueError(
+        f"Unsupported shell class for local axes: {class_name!r}. "
+        f"Known classes: {sorted(_QUAD_SHELL_CLASSES | _TRI_SHELL_CLASSES | _QUAD9_SHELL_CLASSES)}."
+    )
+
+
+def shell_local_axes(
+    node_coords: ndarray, class_name: str,
+) -> ndarray:
+    """Return the ``(3, 3)`` rotation matrix for a shell's local frame.
+
+    Args:
+        node_coords: ``(n_nodes, 3)`` global coordinates of the shell's
+            corner nodes, in OpenSees connectivity order.
+        class_name: OpenSees shell class string (e.g.
+            ``"ASDShellQ4"``). Class names with the MPCO tag prefix
+            (e.g. ``"203-ASDShellQ4"``) should be stripped by the
+            caller before calling.
+
+    Returns:
+        Rotation matrix ``R`` of shape ``(3, 3)`` with **columns**
+        equal to the local basis vectors in global coordinates::
+
+            R[:, 0] = x_local in global frame
+            R[:, 1] = y_local in global frame
+            R[:, 2] = z_local in global frame
+
+        Matches the convention of
+        :func:`STKO_to_python.quaternion_to_rotation_matrix` so
+        ``v_global = R @ v_local``.
+
+    Raises:
+        ValueError: When ``class_name`` is not a recognised shell, the
+            node-count is insufficient for the class, the first edge
+            has zero length, or the two edges are collinear (zero
+            cross-product magnitude).
+    """
+    coords = np.asarray(node_coords, dtype=np.float64)
+    e1, e2 = _frame_edges(coords, class_name)
+
+    e1_norm = float(np.linalg.norm(e1))
+    if e1_norm < _DEGENERATE_EPS:
+        raise ValueError(
+            f"Degenerate shell ({class_name}): first edge has zero length."
+        )
+    x_local = e1 / e1_norm
+
+    z_raw = np.cross(e1, e2)
+    z_norm = float(np.linalg.norm(z_raw))
+    if z_norm < _DEGENERATE_EPS:
+        raise ValueError(
+            f"Degenerate shell ({class_name}): edges are collinear "
+            f"(zero normal)."
+        )
+    z_local = z_raw / z_norm
+
+    # y_local is unit by construction (z and x are orthonormal).
+    y_local = np.cross(z_local, x_local)
+
+    # Columns = local basis in global frame (STKO convention).
+    return np.column_stack([x_local, y_local, z_local])
+
+
+def rotation_matrix_to_quaternion(R: ndarray) -> ndarray:
+    """Convert a ``(3, 3)`` rotation matrix to a scalar-first quaternion.
+
+    Inverse of :func:`STKO_to_python.quaternion_to_rotation_matrix`.
+    Round-tripping ``R → q → R`` reproduces the input within numerical
+    precision; the intermediate quaternion is determined up to a global
+    sign (``q`` and ``−q`` represent the same rotation, so the
+    intermediate value may flip sign without affecting the round trip).
+
+    Uses the Shepperd trace-pivot algorithm: pick the branch whose
+    pivot is largest in magnitude to maximise numerical stability
+    across all four quadrant cases (near-identity, near-180° about
+    each principal axis).
+
+    Args:
+        R: ``(3, 3)`` rotation matrix in STKO convention — columns are
+            the body-frame basis vectors expressed in the world frame,
+            so ``v_world = R @ v_body``.
+
+    Returns:
+        ``(4,)`` ``float64`` quaternion ``(qw, qx, qy, qz)`` — same
+        component order as STKO's `.cdata` ``*LOCAL_AXES`` storage.
+
+    Raises:
+        ValueError: If ``R`` is not shape ``(3, 3)``.
+    """
+    R_arr = np.asarray(R, dtype=np.float64)
+    if R_arr.shape != (3, 3):
+        raise ValueError(f"R must be (3, 3); got {R_arr.shape}.")
+
+    trace = R_arr[0, 0] + R_arr[1, 1] + R_arr[2, 2]
+    if trace > 0.0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (R_arr[2, 1] - R_arr[1, 2]) * s
+        y = (R_arr[0, 2] - R_arr[2, 0]) * s
+        z = (R_arr[1, 0] - R_arr[0, 1]) * s
+    elif R_arr[0, 0] > R_arr[1, 1] and R_arr[0, 0] > R_arr[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R_arr[0, 0] - R_arr[1, 1] - R_arr[2, 2])
+        w = (R_arr[2, 1] - R_arr[1, 2]) / s
+        x = 0.25 * s
+        y = (R_arr[0, 1] + R_arr[1, 0]) / s
+        z = (R_arr[0, 2] + R_arr[2, 0]) / s
+    elif R_arr[1, 1] > R_arr[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R_arr[1, 1] - R_arr[0, 0] - R_arr[2, 2])
+        w = (R_arr[0, 2] - R_arr[2, 0]) / s
+        x = (R_arr[0, 1] + R_arr[1, 0]) / s
+        y = 0.25 * s
+        z = (R_arr[1, 2] + R_arr[2, 1]) / s
+    else:
+        s = 2.0 * np.sqrt(1.0 + R_arr[2, 2] - R_arr[0, 0] - R_arr[1, 1])
+        w = (R_arr[1, 0] - R_arr[0, 1]) / s
+        x = (R_arr[0, 2] + R_arr[2, 0]) / s
+        y = (R_arr[1, 2] + R_arr[2, 1]) / s
+        z = 0.25 * s
+    return np.array([w, x, y, z], dtype=np.float64)
+
+
+def shell_quaternion(
+    node_coords: ndarray, class_name: str,
+) -> ndarray:
+    """Shell local-frame as a quaternion in one call.
+
+    Composition of :func:`shell_local_axes` and
+    :func:`rotation_matrix_to_quaternion`.
+
+    Args:
+        node_coords: ``(n_nodes, 3)`` global corner coordinates.
+        class_name: OpenSees shell class string.
+
+    Returns:
+        ``(4,)`` ``float64`` quaternion ``(qw, qx, qy, qz)`` matching
+        STKO's `.cdata` ``*LOCAL_AXES`` storage convention.
+    """
+    R = shell_local_axes(node_coords, class_name)
+    return rotation_matrix_to_quaternion(R)

--- a/tests/viewer/math/test_shell_frame.py
+++ b/tests/viewer/math/test_shell_frame.py
@@ -1,0 +1,314 @@
+"""Tests for :mod:`STKO_to_python.viewer.math.shell_frame`.
+
+The module is the apeGmsh-derived shell-local-frame **fallback** for
+shells that do not have a ``.cdata`` ``*LOCAL_AXES`` quaternion
+available, plus the inverse of
+:func:`STKO_to_python.quaternion_to_rotation_matrix`.
+
+Coverage:
+
+* :func:`shell_local_axes` produces a right-handed orthonormal frame
+  for quads and triangles in arbitrary orientations.
+* The convention matches STKO — columns are the local basis in global
+  coordinates, so ``v_global = R @ v_local``.
+* Degenerate geometries (collinear edges, zero-length first edge)
+  raise ``ValueError``.
+* :func:`rotation_matrix_to_quaternion` round-trips through STKO's
+  :func:`quaternion_to_rotation_matrix` for the identity rotation, a
+  90° rotation about each principal axis (trace > 0 branch), and a
+  180° rotation about each principal axis (one of the three diagonal
+  branches each).
+* :func:`shell_quaternion` composes the two correctly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python import quaternion_to_rotation_matrix
+from STKO_to_python.viewer.math.shell_frame import (
+    rotation_matrix_to_quaternion,
+    shell_local_axes,
+    shell_quaternion,
+)
+
+
+# --------------------------------------------------------------------- #
+# shell_local_axes — basic geometry                                     #
+# --------------------------------------------------------------------- #
+
+
+def _assert_orthonormal_right_handed(
+    R: np.ndarray, *, atol: float = 1e-12,
+) -> None:
+    """Check ``R`` is a proper rotation matrix (orthonormal, det = +1)."""
+    x, y, z = R[:, 0], R[:, 1], R[:, 2]
+    np.testing.assert_allclose(np.linalg.norm(x), 1.0, atol=atol)
+    np.testing.assert_allclose(np.linalg.norm(y), 1.0, atol=atol)
+    np.testing.assert_allclose(np.linalg.norm(z), 1.0, atol=atol)
+    np.testing.assert_allclose(np.dot(x, y), 0.0, atol=atol)
+    np.testing.assert_allclose(np.dot(y, z), 0.0, atol=atol)
+    np.testing.assert_allclose(np.dot(x, z), 0.0, atol=atol)
+    np.testing.assert_allclose(np.linalg.det(R), 1.0, atol=atol)
+
+
+def test_shell_local_axes_quad_in_xy_plane_is_identity() -> None:
+    """A unit-square ASDShellQ4 in the xy-plane gives the identity matrix."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    R = shell_local_axes(coords, "ASDShellQ4")
+    np.testing.assert_allclose(R, np.eye(3), atol=1e-12)
+
+
+def test_shell_local_axes_tri_in_xy_plane_is_identity() -> None:
+    """A unit-right-triangle ASDShellT3 in the xy-plane gives identity."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    R = shell_local_axes(coords, "ASDShellT3")
+    np.testing.assert_allclose(R, np.eye(3), atol=1e-12)
+
+
+def test_shell_local_axes_quad_in_xz_plane() -> None:
+    """A quad in the xz-plane: x_local = +X, z_local = −Y, y_local = +Z."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    R = shell_local_axes(coords, "ASDShellQ4")
+    # e1 = +X, e2 = +Z. z_raw = e1 × e2 = +X × +Z = −Y. z_local = −Y.
+    # y_local = z × x = −Y × +X = +Z.
+    np.testing.assert_allclose(R[:, 0], [1.0, 0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(R[:, 1], [0.0, 0.0, 1.0], atol=1e-12)
+    np.testing.assert_allclose(R[:, 2], [0.0, -1.0, 0.0], atol=1e-12)
+    _assert_orthonormal_right_handed(R)
+
+
+@pytest.mark.parametrize(
+    "class_name, nodes",
+    [
+        # Quad variants
+        ("ASDShellQ4", [[0,0,0], [1,0,0], [1,1,0], [0,1,0]]),
+        ("ShellMITC4", [[0,0,0], [2,0,0], [2,3,1], [0,3,1]]),
+        ("ShellDKGQ",  [[1,2,3], [4,5,3], [4,5,6], [1,2,6]]),
+        # Tri variants
+        ("ASDShellT3", [[0,0,0], [1,0,0], [0,1,0]]),
+        ("ShellDKGT",  [[1,1,1], [2,1,1], [1,2,1]]),
+        # 9-node uses corners 1..4 only
+        ("ShellMITC9", [[0,0,0], [1,0,0], [1,1,0], [0,1,0],
+                        [0.5,0,0], [1,0.5,0], [0.5,1,0], [0,0.5,0],
+                        [0.5,0.5,0]]),
+    ],
+)
+def test_shell_local_axes_orthonormal_for_all_classes(
+    class_name: str, nodes: list[list[float]],
+) -> None:
+    R = shell_local_axes(np.array(nodes, dtype=np.float64), class_name)
+    _assert_orthonormal_right_handed(R, atol=1e-10)
+
+
+def test_shell_local_axes_v_global_equals_R_times_v_local() -> None:
+    """STKO convention: applying ``R`` to a local vector gives global."""
+    # Quad rotated so x_local = +Y, y_local = -X, z_local = +Z
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    R = shell_local_axes(coords, "ASDShellQ4")
+    # x_local in local frame is (1, 0, 0). Its global expression must
+    # equal column 0 of R.
+    v_local_x = np.array([1.0, 0.0, 0.0])
+    v_global_x = R @ v_local_x
+    np.testing.assert_allclose(v_global_x, R[:, 0], atol=1e-12)
+    # And R[:, 0] should be +Y for this configuration.
+    np.testing.assert_allclose(R[:, 0], [0.0, 1.0, 0.0], atol=1e-12)
+
+
+# --------------------------------------------------------------------- #
+# shell_local_axes — error paths                                        #
+# --------------------------------------------------------------------- #
+
+
+def test_shell_local_axes_collinear_quad_raises() -> None:
+    """Nodes on a single line have a zero cross-product → ValueError."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="collinear"):
+        shell_local_axes(coords, "ASDShellQ4")
+
+
+def test_shell_local_axes_zero_first_edge_raises() -> None:
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="zero length"):
+        shell_local_axes(coords, "ASDShellQ4")
+
+
+def test_shell_local_axes_unknown_class_raises() -> None:
+    coords = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="Unsupported shell class"):
+        shell_local_axes(coords, "999-NotAShellClass")
+
+
+def test_shell_local_axes_too_few_nodes_for_quad_raises() -> None:
+    coords = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],   # only 3 nodes
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="≥4 corner nodes"):
+        shell_local_axes(coords, "ASDShellQ4")
+
+
+def test_shell_local_axes_too_few_nodes_for_tri_raises() -> None:
+    coords = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],   # only 2 nodes
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="≥3 corner nodes"):
+        shell_local_axes(coords, "ASDShellT3")
+
+
+# --------------------------------------------------------------------- #
+# rotation_matrix_to_quaternion — branch coverage + round-trip           #
+# --------------------------------------------------------------------- #
+
+
+def _round_trip(R: np.ndarray) -> np.ndarray:
+    """``R → q → R``; result should equal the input."""
+    q = rotation_matrix_to_quaternion(R)
+    return quaternion_to_rotation_matrix(q)
+
+
+def test_rotation_matrix_to_quaternion_identity() -> None:
+    q = rotation_matrix_to_quaternion(np.eye(3))
+    np.testing.assert_allclose(q, [1.0, 0.0, 0.0, 0.0], atol=1e-12)
+
+
+def test_rotation_matrix_to_quaternion_round_trips_identity() -> None:
+    np.testing.assert_allclose(_round_trip(np.eye(3)), np.eye(3), atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "axis_name, R",
+    [
+        # 90° about +x: trace > 0 branch
+        ("90 about +x",
+         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]])),
+        # 90° about +y
+        ("90 about +y",
+         np.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]])),
+        # 90° about +z
+        ("90 about +z",
+         np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
+        # 180° about +x: triggers R[0,0]-max branch (R[0,0]=1, others=-1, trace=-1)
+        ("180 about +x",
+         np.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]])),
+        # 180° about +y: triggers R[1,1]-max branch
+        ("180 about +y",
+         np.array([[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]])),
+        # 180° about +z: triggers R[2,2]-max branch
+        ("180 about +z",
+         np.array([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])),
+    ],
+)
+def test_rotation_matrix_to_quaternion_round_trips_all_branches(
+    axis_name: str, R: np.ndarray,
+) -> None:
+    """All four Shepperd branches reproduce the input under round-trip."""
+    np.testing.assert_allclose(_round_trip(R), R, atol=1e-12)
+
+
+def test_rotation_matrix_to_quaternion_round_trips_random_rotations() -> None:
+    """Compose three axis rotations into a non-trivial R; round-trip closes."""
+    # Build R = Rz @ Ry @ Rx for some non-special angles.
+    a, b, c = 0.3, 0.7, 1.1
+    Rx = np.array([[1, 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
+    Ry = np.array([[np.cos(b), 0, np.sin(b)], [0, 1, 0], [-np.sin(b), 0, np.cos(b)]])
+    Rz = np.array([[np.cos(c), -np.sin(c), 0], [np.sin(c), np.cos(c), 0], [0, 0, 1]])
+    R = Rz @ Ry @ Rx
+    np.testing.assert_allclose(_round_trip(R), R, atol=1e-12)
+
+
+def test_rotation_matrix_to_quaternion_wrong_shape_raises() -> None:
+    with pytest.raises(ValueError, match=r"R must be \(3, 3\)"):
+        rotation_matrix_to_quaternion(np.eye(4))
+
+
+def test_rotation_matrix_to_quaternion_returns_unit_quaternion() -> None:
+    """Output quaternion has unit norm for any rotation matrix."""
+    R = np.array(
+        [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],   # 120° about (1,1,1)
+        dtype=np.float64,
+    )
+    q = rotation_matrix_to_quaternion(R)
+    np.testing.assert_allclose(np.linalg.norm(q), 1.0, atol=1e-12)
+
+
+# --------------------------------------------------------------------- #
+# shell_quaternion — composition                                        #
+# --------------------------------------------------------------------- #
+
+
+def test_shell_quaternion_identity_for_quad_in_xy_plane() -> None:
+    coords = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=np.float64,
+    )
+    q = shell_quaternion(coords, "ASDShellQ4")
+    np.testing.assert_allclose(q, [1.0, 0.0, 0.0, 0.0], atol=1e-12)
+
+
+def test_shell_quaternion_round_trips_to_local_axes() -> None:
+    """``shell_quaternion → quaternion_to_rotation_matrix`` recovers R."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [2.0, 1.0, 0.5],
+            [1.5, 2.5, 1.0],
+            [-0.5, 1.5, 0.5],
+        ],
+        dtype=np.float64,
+    )
+    R = shell_local_axes(coords, "ASDShellQ4")
+    q = shell_quaternion(coords, "ASDShellQ4")
+    R_check = quaternion_to_rotation_matrix(q)
+    np.testing.assert_allclose(R_check, R, atol=1e-12)


### PR DESCRIPTION
## Summary

Final module of the viewer **algorithm tier** — **Phase 1 is now complete** per [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md).

Ports apeGmsh's shell-local-axes math as a **fallback** for shells that don't have a STKO `.cdata` `*LOCAL_AXES` quaternion available. Mirrors the [beam_frame Phase 1 pattern](https://github.com/nmorabowen/STKO_to_python/pull/82): STKO's quaternion path remains primary (used by `cuts/kernels/shell.py`, etc.); this module covers external datasets, unit tests, and synthetic geometry.

Also lands `rotation_matrix_to_quaternion` — the inverse of STKO's existing `quaternion_to_rotation_matrix` using the Shepperd trace-pivot algorithm for stability across all four quadrant cases. Round-trip tests pin `R → q → R` to the input across identity, 90° and 180° about each principal axis, and composed rotations.

### Convention note (read carefully if you maintain this)

apeGmsh's `shell_local_axes` returns *rows* = local-in-global (world-to-body). STKO uses *columns* = local-in-global (body-to-world: `v_global = R @ v_local`). The port transposes to match STKO so the new function composes cleanly with `quaternion_to_rotation_matrix`. The round-trip tests verify this end-to-end.

Public API in `STKO_to_python.viewer.math.shell_frame`:

- `shell_local_axes(node_coords, class_name) → R(3, 3)` — fallback rotation matrix from corner coords. Supports `ASDShellQ4`, `ShellMITC4`, `ShellDKGQ`, `ShellNLDKGQ`, `ASDShellT3`, `ShellDKGT`, `ShellNLDKGT`, `ShellMITC9`.
- `rotation_matrix_to_quaternion(R) → q(4,)` — scalar-first `(qw, qx, qy, qz)` matching STKO's `.cdata` storage.
- `shell_quaternion(node_coords, class_name) → q(4,)` — composition for one-call usage.

Pure numpy. No new dependencies.

## Test plan

- [x] `pytest tests/viewer/` — **95 passed, 2 skipped** locally (the 2 skipped are extras-gated).
- [x] 28 new unit tests cover:
  - Quad / tri orthonormality across 6 shell variants in arbitrary orientations.
  - The STKO convention: `R[:, 0] = x_local` in global, verified by applying R to a local unit vector.
  - Degenerate geometry (collinear quad, zero first edge, too-few nodes, unknown class) raises.
  - All four Shepperd branches verified by round-trip `R → q → R` (90° and 180° about each principal axis + composed rotation).
  - `q` returned with unit norm; wrong-shape input raises.
- [ ] CI green on this PR.

## Phase 1 closeout

Algorithm tier — all four PRs landed (this one closes the set):

| PR | Module | Tests |
|---|---|---|
| [#81](https://github.com/nmorabowen/STKO_to_python/pull/81) | `gauss_extrapolation.py` | 21 |
| [#82](https://github.com/nmorabowen/STKO_to_python/pull/82) | `beam_frame.py` | 27 |
| [#83](https://github.com/nmorabowen/STKO_to_python/pull/83) | `picking.py` | 14 |
| this PR | `shell_frame.py` | 28 |
| | **total** | **90** |

Phase 2 (Backend protocol + `Scene` / `Layer` + `MplBackend` wiring) is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)