### PR TITLE
Add Scene/Layer/Backend skeletons — viewer core (Phase 2.1)

### DIFF
--- a/src/STKO_to_python/viewer/core/__init__.py
+++ b/src/STKO_to_python/viewer/core/__init__.py
@@ -1,0 +1,49 @@
+"""Viewer core — Backend / Scene / Layer / DataSource skeletons.
+
+Phase 2 step 1 of the viewer integration plan (see
+``docs/viewer/00-roadmap.md``). This subpackage defines the
+backend-neutral contracts that every renderer implementation
+satisfies. No rendering happens here; concrete backends and layer
+types ride on top in subsequent steps.
+
+Public API:
+
+* :class:`Scene` — concrete orchestrator (Backend + DataSource + Layers).
+* :class:`Layer` — abstract base every renderable subclasses.
+* :class:`Backend` — runtime-checkable protocol concrete renderers implement.
+* :class:`DataSource` — runtime-checkable protocol the adapter implements.
+* :class:`SceneStyle`, :class:`LayerStyle` — hierarchical style dataclasses.
+* :class:`SelectionSpec` — frozen, hashable selection filter.
+* :class:`BBox`, :class:`CameraSpec` — geometric value types.
+* :class:`BackendCapabilityError`, :class:`LayerAttachError` — exceptions.
+
+The subpackage is pure-Python and has **no** runtime dependency on
+``pyvista``, ``vtk``, ``PySide6``, or any optional extra. The viewer
+smoke test (``tests/viewer/test_smoke.py``) keeps that contract honest.
+"""
+from __future__ import annotations
+
+from .backend import Backend
+from .datasource import DataSource
+from .errors import BackendCapabilityError, LayerAttachError
+from .layer import Layer
+from .scene import Scene
+from .selection import SelectionSpec
+from .style import LayerStyle, SceneStyle
+from .types import ActorRef, BBox, CameraSpec, SceneHandle
+
+__all__ = [
+    "ActorRef",
+    "Backend",
+    "BBox",
+    "BackendCapabilityError",
+    "CameraSpec",
+    "DataSource",
+    "Layer",
+    "LayerAttachError",
+    "LayerStyle",
+    "Scene",
+    "SceneHandle",
+    "SceneStyle",
+    "SelectionSpec",
+]

--- a/src/STKO_to_python/viewer/core/backend.py
+++ b/src/STKO_to_python/viewer/core/backend.py
@@ -1,0 +1,137 @@
+"""Renderer-agnostic ``Backend`` protocol.
+
+See ``docs/viewer/01-architecture.md`` §3 for the full design
+rationale. Three hard rules every concrete backend must honour:
+
+1. Layers never import from a backend module. They reach the backend
+   only through :attr:`Scene.backend`.
+2. A backend that cannot do something raises
+   :class:`STKO_to_python.viewer.core.errors.BackendCapabilityError`
+   with a precise message. No silent fallback.
+3. ``update_*`` methods mutate in place and re-render in
+   O(modified data), not O(scene). This is the perf contract that
+   keeps animation playback usable on big models.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import numpy as np
+
+from .types import ActorRef, BBox, CameraSpec, SceneHandle
+
+if TYPE_CHECKING:
+    from .style import SceneStyle
+
+
+@runtime_checkable
+class Backend(Protocol):
+    """Protocol that every renderer implements.
+
+    Concrete implementations (``MplBackend`` in step 2,
+    ``PyVistaBackend`` in step 6, ``TrameBackend`` in Phase 6) all
+    satisfy this interface. The :class:`Scene` only ever calls methods
+    declared here.
+    """
+
+    name: str
+    is_3d_capable: bool
+    is_interactive: bool
+
+    # ----- Scene lifecycle ------------------------------------------- #
+
+    def make_scene(
+        self, *, is_3d: bool = False, off_screen: bool = False,
+    ) -> SceneHandle:
+        """Allocate the renderer-side state for a new scene."""
+
+    def set_bounds(self, scene: SceneHandle, bbox: BBox) -> None:
+        """Set the model bounding box (drives default camera framing)."""
+
+    def set_camera(self, scene: SceneHandle, cam: CameraSpec) -> None:
+        """Apply a saved camera state."""
+
+    def set_style(self, scene: SceneHandle, style: "SceneStyle") -> None:
+        """Apply scene-wide styling (background, grid, theme)."""
+
+    # ----- Primitives ------------------------------------------------ #
+    #
+    # Every layer is composed from these primitives. Backends that
+    # cannot render a primitive raise BackendCapabilityError rather
+    # than degrade silently.
+
+    def add_segments(
+        self,
+        scene: SceneHandle,
+        segments: np.ndarray,
+        *,
+        color: Any = None,
+        width: float | None = None,
+        alpha: float | None = None,
+        label: str | None = None,
+    ) -> ActorRef:
+        """Add a line-segment batch. ``segments`` shape ``(N, 2, 3)``."""
+
+    def add_points(
+        self,
+        scene: SceneHandle,
+        points: np.ndarray,
+        *,
+        color: Any = None,
+        size: float | None = None,
+        scalars: np.ndarray | None = None,
+        cmap: str | None = None,
+    ) -> ActorRef:
+        """Add a point cloud. ``points`` shape ``(N, 3)``."""
+
+    def add_polygons(
+        self,
+        scene: SceneHandle,
+        polygons: np.ndarray,
+        *,
+        values: np.ndarray | None = None,
+        cmap: str | None = None,
+        edge_color: Any = None,
+    ) -> ActorRef:
+        """Add filled polygons. ``polygons`` is a ``(N, M, 3)`` array
+        of M-sided polygon vertices, or backend-specific equivalent."""
+
+    def add_arrows(
+        self,
+        scene: SceneHandle,
+        origins: np.ndarray,
+        vectors: np.ndarray,
+        *,
+        scale: float = 1.0,
+        color: Any = None,
+        cmap: str | None = None,
+    ) -> ActorRef:
+        """Add an arrow glyph batch. Shapes: ``(N, 3)`` each."""
+
+    # ----- In-place actor updates ------------------------------------ #
+    #
+    # The perf contract: animation calls update_* only, never add_*.
+
+    def update_scalars(self, actor: ActorRef, scalars: np.ndarray) -> None:
+        """Mutate the scalars of an existing actor in place."""
+
+    def update_points(self, actor: ActorRef, points: np.ndarray) -> None:
+        """Mutate the vertex positions of an existing actor in place."""
+
+    def set_visible(self, actor: ActorRef, visible: bool) -> None:
+        """Toggle the visibility of an actor."""
+
+    def remove(self, scene: SceneHandle, actor: ActorRef) -> None:
+        """Detach and dispose of an actor."""
+
+    # ----- Output ---------------------------------------------------- #
+
+    def show(self, scene: SceneHandle) -> None:
+        """Hand off to the renderer's interactive show loop (if any)."""
+
+    def save(self, scene: SceneHandle, path: Path, *, dpi: int = 300) -> None:
+        """Persist the current frame to disk."""
+
+    def snapshot(self, scene: SceneHandle) -> np.ndarray:
+        """Return the current frame as an ``(H, W, 3)`` uint8 RGB array."""

--- a/src/STKO_to_python/viewer/core/datasource.py
+++ b/src/STKO_to_python/viewer/core/datasource.py
@@ -1,0 +1,72 @@
+"""``DataSource`` protocol — adapter between :class:`MPCODataSet` and layers.
+
+The :class:`DataSource` is the **one** place where the viewer's
+backend-agnostic Layer/Scene code touches anything STKO-specific.
+Defining the protocol here lets every layer be written against the
+protocol — a future viewer source (e.g. a streaming OpenSeesPy
+adapter) only has to implement the protocol; the layers don't change.
+
+The concrete :class:`MPCODataSourceAdapter` lives in
+``viewer/core/_mpco_adapter.py`` and lands in Phase 2 step 2 alongside
+the first layer that consumes it.
+
+See ``docs/viewer/01-architecture.md`` §5.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+from .selection import SelectionSpec
+from .types import BBox
+
+if TYPE_CHECKING:
+    from ...core.dataset import MPCODataSet
+
+
+@runtime_checkable
+class DataSource(Protocol):
+    """Adapter that exposes :class:`MPCODataSet` queries as layer inputs.
+
+    Methods return numpy arrays in shapes the layers expect, hiding the
+    DataFrame / MultiIndex assembly that lives inside the existing
+    query engines.
+    """
+
+    @property
+    def dataset(self) -> "MPCODataSet":
+        """Underlying dataset, exposed for layers that need richer access."""
+
+    # ----- Geometry -------------------------------------------------- #
+
+    def node_coords(self, ids: np.ndarray | None = None) -> np.ndarray:
+        """``(N, 3)`` node coordinates. ``ids=None`` returns every node."""
+
+    def element_centroids(self, ids: np.ndarray | None = None) -> np.ndarray:
+        """``(E, 3)`` element centroids in element-id order."""
+
+    def model_bbox(self) -> BBox:
+        """Axis-aligned bounding box over every node in the model."""
+
+    # ----- Time axis ------------------------------------------------- #
+
+    def n_steps(self, stage: str | None = None) -> int:
+        """Number of time steps in the requested stage (or current)."""
+
+    def time(self, stage: str | None = None) -> np.ndarray:
+        """``(T,)`` time values for the requested stage (or current)."""
+
+    # ----- Selection resolution -------------------------------------- #
+
+    def resolve_node_ids(self, spec: SelectionSpec) -> np.ndarray:
+        """Return the node IDs matching ``spec`` as a ``(K,)`` int64 array.
+
+        Empty input ``SelectionSpec.empty()`` returns every node.
+        """
+
+    def resolve_element_ids(self, spec: SelectionSpec) -> np.ndarray:
+        """Return the element IDs matching ``spec`` as a ``(K,)`` int64 array.
+
+        Empty input ``SelectionSpec.empty()`` returns every element.
+        """

--- a/src/STKO_to_python/viewer/core/errors.py
+++ b/src/STKO_to_python/viewer/core/errors.py
@@ -1,0 +1,24 @@
+"""Viewer-specific exception types.
+
+Defined here so callers can catch them without importing concrete
+renderer modules (which may not be installed).
+"""
+from __future__ import annotations
+
+
+class BackendCapabilityError(NotImplementedError):
+    """Raised when a layer asks for a primitive its backend cannot render.
+
+    Example: a ``VolumeLayer`` with ``mode='iso'`` against the matplotlib
+    backend will surface this — the layer cannot silently downgrade, so
+    the caller learns immediately and can switch backends or change the
+    mode.
+    """
+
+
+class LayerAttachError(RuntimeError):
+    """Raised when ``Layer.attach`` cannot bind the layer to its scene.
+
+    Typical causes: the requested data source does not expose a result
+    the layer needs, or a selection does not match any entities.
+    """

--- a/src/STKO_to_python/viewer/core/layer.py
+++ b/src/STKO_to_python/viewer/core/layer.py
@@ -1,0 +1,99 @@
+"""``Layer`` abstract base — every renderable in a :class:`Scene`.
+
+Lifecycle (see ``docs/viewer/01-architecture.md`` §4):
+
+1. ``__init__`` — construct with frozen config (name, selection, style,
+   visibility, z-order).
+2. ``attach(scene, source)`` — bind to a :class:`Scene`; build actors
+   via the scene's :class:`Backend`. Called once by :meth:`Scene.add`.
+3. ``update_to_step(step)`` — read from the :class:`DataSource` at the
+   new step; scatter into pre-allocated actor data via in-place
+   updates. **Must not** call ``backend.add_*``.
+4. ``detach()`` — release actor references; the layer becomes inert.
+
+The "no actor recreation per step" rule is the perf contract that
+keeps animation playback usable on big models. Tests in step 2 onward
+pin specific layers to that contract.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from .selection import SelectionSpec
+from .style import LayerStyle
+
+if TYPE_CHECKING:
+    from .datasource import DataSource
+    from .scene import Scene
+
+
+class Layer(ABC):
+    """Base for every viewer layer.
+
+    Attributes:
+        kind: Stable string used by ``LAYER_KINDS`` catalog,
+            :attr:`SceneStyle.layer_defaults`, and the
+            ``SceneSpec`` round-trip. Subclasses must override this.
+        name: Human-readable name (defaults to class name).
+        selection: :class:`SelectionSpec` filtering which entities the
+            layer renders.
+        style: Per-layer :class:`LayerStyle` overrides; ``None`` fields
+            inherit from the scene defaults at attach time.
+        visible: Whether the layer is rendered. Toggling does **not**
+            re-fetch data — flip and call ``Scene.set_step`` (or
+            re-render) to refresh.
+        z_order: Render order within the scene; higher = on top.
+    """
+
+    kind: str = "layer"
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        selection: SelectionSpec | None = None,
+        style: LayerStyle | None = None,
+        visible: bool = True,
+        z_order: int = 0,
+    ) -> None:
+        self.name = name if name is not None else self.__class__.__name__
+        self.selection = selection if selection is not None else SelectionSpec.empty()
+        self.style = style if style is not None else LayerStyle()
+        self.visible = visible
+        self.z_order = z_order
+        self._scene: "Scene | None" = None
+        self._source: "DataSource | None" = None
+
+    @property
+    def is_attached(self) -> bool:
+        """True once :meth:`attach` has run and before :meth:`detach`."""
+        return self._scene is not None
+
+    # ----- Subclass contract ----------------------------------------- #
+
+    @abstractmethod
+    def attach(self, scene: "Scene", source: "DataSource") -> None:
+        """Bind to ``scene`` and ``source``; build initial actors.
+
+        Concrete implementations set ``self._scene = scene`` and
+        ``self._source = source`` then issue ``scene.backend.add_*``
+        calls. After this method returns, the actor set is frozen.
+
+        Raises:
+            STKO_to_python.viewer.core.errors.LayerAttachError:
+                When required inputs are missing on ``source``.
+        """
+
+    @abstractmethod
+    def update_to_step(self, step: int) -> None:
+        """In-place scalar / point mutation for animation.
+
+        Must not call any ``backend.add_*`` method. Use
+        ``backend.update_*`` to mutate pre-allocated actor data; this
+        keeps the per-step cost O(modified data).
+        """
+
+    @abstractmethod
+    def detach(self) -> None:
+        """Release every actor reference; the layer becomes inert."""

--- a/src/STKO_to_python/viewer/core/scene.py
+++ b/src/STKO_to_python/viewer/core/scene.py
@@ -1,0 +1,158 @@
+"""``Scene`` — orchestrates a Backend, a DataSource, and a list of Layers.
+
+One scene is **one drawable region** — either a single 2-D axes or a
+single 3-D viewport. A figure with multiple panels is built from
+multiple scenes (see ``docs/viewer/01-architecture.md`` §4).
+
+This class is concrete; it contains the bookkeeping that every viewer
+implementation needs. It does **not** hold any rendering code — that
+lives in the concrete :class:`Backend`. Likewise it does not pull data
+itself — that's the :class:`DataSource`'s job.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .style import SceneStyle
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from .backend import Backend
+    from .datasource import DataSource
+    from .layer import Layer
+    from .types import SceneHandle
+
+
+class Scene:
+    """A drawable region with an ordered layer stack.
+
+    Args:
+        backend: Renderer implementation (matplotlib, pyvista, …).
+        source: Data adapter the layers will query.
+        is_3d: Whether this scene wants a 3-D viewport. The backend
+            may downgrade silently (or raise on backends that lack 3-D
+            capability — see :attr:`Backend.is_3d_capable`).
+        off_screen: When ``True`` the backend renders without showing
+            a window — used by the headless CLI and CI snapshots.
+        style: Scene-wide style. Defaults to a fresh
+            :class:`SceneStyle()`.
+
+    The opaque :attr:`handle` is allocated lazily on first access so
+    that constructing a Scene does not yet require a renderer to be
+    available; the handle is created when the first layer is added or
+    when :meth:`show` / :meth:`save` is called.
+    """
+
+    def __init__(
+        self,
+        backend: "Backend",
+        source: "DataSource",
+        *,
+        is_3d: bool = False,
+        off_screen: bool = False,
+        style: SceneStyle | None = None,
+    ) -> None:
+        self.backend = backend
+        self.source = source
+        self.is_3d = is_3d
+        self.style = style if style is not None else SceneStyle()
+        self.layers: list["Layer"] = []
+        self._handle: "SceneHandle | None" = None
+        self._off_screen = off_screen
+        self._current_step: int | None = None
+        self._current_stage: str | None = None
+
+    @property
+    def handle(self) -> "SceneHandle":
+        """Backend-allocated scene handle. Created on first access."""
+        if self._handle is None:
+            self._handle = self.backend.make_scene(
+                is_3d=self.is_3d, off_screen=self._off_screen,
+            )
+            self.backend.set_style(self._handle, self.style)
+        return self._handle
+
+    @property
+    def current_step(self) -> int | None:
+        return self._current_step
+
+    @property
+    def current_stage(self) -> str | None:
+        return self._current_stage
+
+    # ----- Layer management ------------------------------------------ #
+
+    def add(self, layer: "Layer") -> "Layer":
+        """Attach ``layer`` to the scene and return it (for chaining).
+
+        If the scene already has a current step, the newly added layer
+        is immediately advanced to that step so it shows up in sync
+        with the rest.
+        """
+        # Force the backend to allocate the scene handle now, so the
+        # layer's attach() can safely call backend.add_*.
+        _ = self.handle
+        layer.attach(self, self.source)
+        self.layers.append(layer)
+        if self._current_step is not None:
+            layer.update_to_step(self._current_step)
+        return layer
+
+    def remove(self, layer: "Layer") -> None:
+        """Detach ``layer`` and drop it from the stack."""
+        if layer not in self.layers:
+            raise ValueError(f"Layer {layer.name!r} is not in this scene.")
+        layer.detach()
+        self.layers.remove(layer)
+
+    # ----- Time / stage cursor --------------------------------------- #
+
+    def set_step(self, step: int) -> None:
+        """Advance every layer to ``step`` via in-place actor updates.
+
+        Fires :meth:`Layer.update_to_step` on **every** layer, including
+        invisible ones — that's the apeGmsh perf contract: each layer
+        keeps its per-step data ready, the backend just toggles
+        visibility.
+        """
+        self._current_step = step
+        for layer in self.layers:
+            layer.update_to_step(step)
+
+    def set_stage(self, stage: str | None) -> None:
+        """Switch the active stage. Does not refresh — call ``set_step`` after."""
+        self._current_stage = stage
+
+    # ----- Camera / bounds ------------------------------------------- #
+
+    def fit_bounds(self) -> None:
+        """Pull the model bbox from the data source and apply to the backend."""
+        bbox = self.source.model_bbox()
+        self.backend.set_bounds(self.handle, bbox)
+
+    # ----- Output ---------------------------------------------------- #
+
+    def show(self) -> None:
+        """Hand off to the backend's interactive show loop."""
+        self.backend.show(self.handle)
+
+    def save(self, path: Path, *, dpi: int = 300) -> None:
+        """Persist the current frame to disk via the backend."""
+        self.backend.save(self.handle, path, dpi=dpi)
+
+    def snapshot(self) -> "np.ndarray":
+        """Return the current frame as an ``(H, W, 3)`` uint8 RGB array."""
+        return self.backend.snapshot(self.handle)
+
+    # ----- Container protocol ---------------------------------------- #
+
+    def __len__(self) -> int:
+        return len(self.layers)
+
+    def __iter__(self):
+        return iter(self.layers)
+
+    def __contains__(self, layer: object) -> bool:
+        return layer in self.layers

--- a/src/STKO_to_python/viewer/core/selection.py
+++ b/src/STKO_to_python/viewer/core/selection.py
@@ -1,0 +1,46 @@
+"""Layer-level selection spec.
+
+A frozen, hashable specification of "which entities does this layer
+render". The grammar mirrors the existing
+:class:`STKO_to_python.selection.resolver.SelectionSetResolver` API so
+the Phase 2 step 2 adapter (``MPCODataSourceAdapter``) can translate
+1-to-1.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+
+@dataclass(frozen=True)
+class SelectionSpec:
+    """Selection criteria for a layer.
+
+    All fields are **AND-combined**: a layer renders only the entities
+    that match every non-``None`` criterion. The fields are explicit
+    tuples (not arrays) so the dataclass stays hashable — selection
+    specs are cache keys downstream.
+
+    Attributes:
+        selection_set_name: One or more named selection sets (e.g.
+            ``"slab"`` or ``("slab", "perimeter")``).
+        selection_set_id: One or more selection-set IDs.
+        node_ids: Explicit node IDs to include.
+        element_ids: Explicit element IDs to include.
+        element_type: One or more decorated element type strings (e.g.
+            ``"203-ASDShellQ4"``).
+    """
+
+    selection_set_name: str | tuple[str, ...] | None = None
+    selection_set_id: int | tuple[int, ...] | None = None
+    node_ids: tuple[int, ...] | None = None
+    element_ids: tuple[int, ...] | None = None
+    element_type: str | tuple[str, ...] | None = None
+
+    @classmethod
+    def empty(cls) -> "SelectionSpec":
+        """Empty spec — matches every entity."""
+        return cls()
+
+    def is_empty(self) -> bool:
+        """True if every field is ``None`` (the empty / match-all spec)."""
+        return all(getattr(self, f.name) is None for f in fields(self))

--- a/src/STKO_to_python/viewer/core/style.py
+++ b/src/STKO_to_python/viewer/core/style.py
@@ -1,0 +1,92 @@
+"""Hierarchical style: scene-wide defaults + per-layer overrides.
+
+Three-level precedence ladder (matches the existing
+:class:`STKO_to_python.PlotSettings` model that
+``NodalResultsPlotter`` already uses):
+
+1. **Project / dataset default** — set once on the dataset.
+2. **Scene default** — :class:`SceneStyle.layer_defaults` per layer kind.
+3. **Layer override** — :class:`LayerStyle` passed at construction.
+
+Each level only sets the fields it cares about; ``None`` inherits from
+the next level up. The merge semantics are the same as ``dict.update``
+but field-aware.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields, replace
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LayerStyle:
+    """Style overrides for a single layer.
+
+    Every field is ``None`` by default — that signals "inherit from the
+    scene-level default." See :meth:`merge` for how the precedence
+    cascade is resolved.
+
+    Attributes:
+        color: Solid colour name, hex string, or ``(r, g, b)`` tuple.
+        linewidth: Line / edge width.
+        linestyle: Matplotlib-style linestyle (``"-"``, ``"--"``, …).
+        marker: Matplotlib-style marker (``"."``, ``"o"``, …).
+        alpha: Opacity in ``[0, 1]``.
+        cmap: Colormap name for scalar-valued layers.
+        clim: ``(min, max)`` colour-range overrides; ``None`` = auto.
+        label: Legend label / scalar-bar title override.
+    """
+
+    color: str | tuple[float, float, float] | None = None
+    linewidth: float | None = None
+    linestyle: str | None = None
+    marker: str | None = None
+    alpha: float | None = None
+    cmap: str | None = None
+    clim: tuple[float, float] | None = None
+    label: str | None = None
+
+    def merge(self, base: "LayerStyle") -> "LayerStyle":
+        """Return a new style with this layer's overrides applied over ``base``.
+
+        Fields that are ``None`` on ``self`` inherit from ``base``;
+        every other field overrides ``base``.
+        """
+        merged: dict[str, Any] = {}
+        for f in fields(self):
+            override = getattr(self, f.name)
+            merged[f.name] = override if override is not None else getattr(base, f.name)
+        return LayerStyle(**merged)
+
+
+@dataclass(frozen=True)
+class SceneStyle:
+    """Scene-wide style settings.
+
+    Attributes:
+        background: Background colour (any value matplotlib / pyvista
+            accepts).
+        grid: Whether to render coordinate grid lines.
+        font_size: Base font size for labels, titles, scalar bars.
+        theme: ``"light"`` or ``"dark"`` — informs default palettes.
+        layer_defaults: Per-layer-kind default :class:`LayerStyle`,
+            keyed on the layer's ``kind`` attribute.
+    """
+
+    background: str = "white"
+    grid: bool = False
+    font_size: int = 10
+    theme: str = "light"
+    layer_defaults: dict[str, LayerStyle] = field(default_factory=dict)
+
+    def get_defaults_for(self, layer_kind: str) -> LayerStyle:
+        """Lookup helper — returns an empty :class:`LayerStyle` when absent."""
+        return self.layer_defaults.get(layer_kind, LayerStyle())
+
+    def with_layer_default(
+        self, layer_kind: str, style: LayerStyle,
+    ) -> "SceneStyle":
+        """Return a new :class:`SceneStyle` with one layer-kind default replaced."""
+        new_defaults = dict(self.layer_defaults)
+        new_defaults[layer_kind] = style
+        return replace(self, layer_defaults=new_defaults)

--- a/src/STKO_to_python/viewer/core/types.py
+++ b/src/STKO_to_python/viewer/core/types.py
@@ -1,0 +1,76 @@
+"""Shared concrete types for the viewer core.
+
+These are deliberately small (one dataclass per concept) so they have
+no runtime dependency on any backend. ``SceneHandle`` and ``ActorRef``
+are opaque aliases — the backend casts them to its native types.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Any
+
+
+# Opaque renderer-specific handles. Concrete backends pass these through
+# unchanged; layer code treats them as opaque cookies.
+SceneHandle = Any
+ActorRef = Any
+
+
+@dataclass(frozen=True)
+class BBox:
+    """Axis-aligned 3-D bounding box.
+
+    Attributes:
+        x_min, y_min, z_min: Minimum corner coordinates.
+        x_max, y_max, z_max: Maximum corner coordinates.
+    """
+
+    x_min: float
+    y_min: float
+    z_min: float
+    x_max: float
+    y_max: float
+    z_max: float
+
+    @property
+    def size(self) -> tuple[float, float, float]:
+        """``(dx, dy, dz)`` side lengths."""
+        return (
+            self.x_max - self.x_min,
+            self.y_max - self.y_min,
+            self.z_max - self.z_min,
+        )
+
+    @property
+    def center(self) -> tuple[float, float, float]:
+        """Geometric centre of the box."""
+        return (
+            0.5 * (self.x_min + self.x_max),
+            0.5 * (self.y_min + self.y_max),
+            0.5 * (self.z_min + self.z_max),
+        )
+
+    @property
+    def diagonal(self) -> float:
+        """Euclidean diagonal length — useful as a scale reference."""
+        dx, dy, dz = self.size
+        return sqrt(dx * dx + dy * dy + dz * dz)
+
+
+@dataclass(frozen=True)
+class CameraSpec:
+    """Camera state — enough to save / restore a view orientation.
+
+    Attributes:
+        position: Camera position in world space.
+        focal_point: Point the camera looks at.
+        view_up: Up vector for the camera.
+        parallel_projection: ``True`` for orthographic, ``False`` for
+            perspective.
+    """
+
+    position: tuple[float, float, float]
+    focal_point: tuple[float, float, float]
+    view_up: tuple[float, float, float]
+    parallel_projection: bool = False

--- a/tests/viewer/core/conftest.py
+++ b/tests/viewer/core/conftest.py
@@ -1,0 +1,173 @@
+"""Shared stubs for viewer-core unit tests.
+
+The protocols (:class:`Backend`, :class:`DataSource`) are
+``runtime_checkable``, so a hand-written stub class that implements
+the right methods passes ``isinstance(stub, Protocol)`` checks. These
+stubs let the Scene / Layer plumbing be tested without pulling any
+optional renderer dependency.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from STKO_to_python.viewer.core import (
+    BBox,
+    Layer,
+    SelectionSpec,
+)
+
+
+class StubBackend:
+    """Minimal :class:`Backend` implementation that records every call."""
+
+    name = "stub"
+    is_3d_capable = False
+    is_interactive = False
+
+    def __init__(self) -> None:
+        self.make_scene_calls: int = 0
+        self.set_bounds_calls: list = []
+        self.set_style_calls: list = []
+        self.add_segments_calls: list = []
+        self.add_points_calls: list = []
+        self.update_scalars_calls: list = []
+        self.update_points_calls: list = []
+        self.show_calls: int = 0
+        self.save_calls: list = []
+        self._next_actor_id: int = 0
+
+    # ----- scene lifecycle ----- #
+
+    def make_scene(self, *, is_3d: bool = False, off_screen: bool = False) -> Any:
+        self.make_scene_calls += 1
+        return ("scene", self.make_scene_calls)
+
+    def set_bounds(self, scene: Any, bbox: BBox) -> None:
+        self.set_bounds_calls.append((scene, bbox))
+
+    def set_camera(self, scene: Any, cam: Any) -> None:
+        pass
+
+    def set_style(self, scene: Any, style: Any) -> None:
+        self.set_style_calls.append((scene, style))
+
+    # ----- primitives ----- #
+
+    def _new_actor(self, kind: str) -> Any:
+        self._next_actor_id += 1
+        return (kind, self._next_actor_id)
+
+    def add_segments(self, scene, segments, **kwargs):  # type: ignore[no-untyped-def]
+        self.add_segments_calls.append((scene, segments, kwargs))
+        return self._new_actor("seg")
+
+    def add_points(self, scene, points, **kwargs):  # type: ignore[no-untyped-def]
+        self.add_points_calls.append((scene, points, kwargs))
+        return self._new_actor("pts")
+
+    def add_polygons(self, scene, polygons, **kwargs):  # type: ignore[no-untyped-def]
+        return self._new_actor("poly")
+
+    def add_arrows(self, scene, origins, vectors, **kwargs):  # type: ignore[no-untyped-def]
+        return self._new_actor("arr")
+
+    # ----- in-place updates ----- #
+
+    def update_scalars(self, actor: Any, scalars: np.ndarray) -> None:
+        self.update_scalars_calls.append((actor, scalars))
+
+    def update_points(self, actor: Any, points: np.ndarray) -> None:
+        self.update_points_calls.append((actor, points))
+
+    def set_visible(self, actor: Any, visible: bool) -> None:
+        pass
+
+    def remove(self, scene: Any, actor: Any) -> None:
+        pass
+
+    # ----- output ----- #
+
+    def show(self, scene: Any) -> None:
+        self.show_calls += 1
+
+    def save(self, scene: Any, path: Any, *, dpi: int = 300) -> None:
+        self.save_calls.append((scene, path, dpi))
+
+    def snapshot(self, scene: Any) -> np.ndarray:
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+
+class StubDataSource:
+    """Minimal :class:`DataSource` implementation backed by static arrays."""
+
+    def __init__(
+        self,
+        *,
+        bbox: BBox | None = None,
+        n_steps: int = 0,
+    ) -> None:
+        self._bbox = bbox if bbox is not None else BBox(0, 0, 0, 1, 1, 1)
+        self._n_steps = n_steps
+
+    @property
+    def dataset(self) -> Any:
+        return None  # unused by the stubs; layers don't need it here
+
+    def node_coords(self, ids: np.ndarray | None = None) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.float64)
+
+    def element_centroids(self, ids: np.ndarray | None = None) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.float64)
+
+    def model_bbox(self) -> BBox:
+        return self._bbox
+
+    def n_steps(self, stage: str | None = None) -> int:
+        return self._n_steps
+
+    def time(self, stage: str | None = None) -> np.ndarray:
+        return np.zeros(self._n_steps, dtype=np.float64)
+
+    def resolve_node_ids(self, spec: SelectionSpec) -> np.ndarray:
+        return np.zeros(0, dtype=np.int64)
+
+    def resolve_element_ids(self, spec: SelectionSpec) -> np.ndarray:
+        return np.zeros(0, dtype=np.int64)
+
+
+class RecordingLayer(Layer):
+    """Concrete :class:`Layer` that records every lifecycle event."""
+
+    kind = "recording"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.attach_calls: list = []
+        self.update_calls: list[int] = []
+        self.detach_calls: int = 0
+
+    def attach(self, scene: Any, source: Any) -> None:
+        self._scene = scene
+        self._source = source
+        self.attach_calls.append((scene, source))
+
+    def update_to_step(self, step: int) -> None:
+        self.update_calls.append(step)
+
+    def detach(self) -> None:
+        self._scene = None
+        self._source = None
+        self.detach_calls += 1
+
+
+@pytest.fixture
+def stub_backend() -> StubBackend:
+    return StubBackend()
+
+
+@pytest.fixture
+def stub_source() -> StubDataSource:
+    return StubDataSource(bbox=BBox(-1, -2, -3, 4, 5, 6))

--- a/tests/viewer/core/test_layer.py
+++ b/tests/viewer/core/test_layer.py
@@ -1,0 +1,87 @@
+"""Tests for the :class:`Layer` abstract base."""
+from __future__ import annotations
+
+import pytest
+
+from STKO_to_python.viewer.core import Layer, LayerStyle, SelectionSpec
+
+from .conftest import RecordingLayer
+
+
+def test_layer_cannot_be_instantiated_directly() -> None:
+    """``Layer`` is abstract; instantiating it must fail."""
+    with pytest.raises(TypeError):
+        Layer()  # type: ignore[abstract]
+
+
+def test_recording_layer_is_concrete_and_instantiable() -> None:
+    layer = RecordingLayer()
+    assert isinstance(layer, Layer)
+
+
+def test_layer_default_name_is_class_name() -> None:
+    layer = RecordingLayer()
+    assert layer.name == "RecordingLayer"
+
+
+def test_layer_explicit_name_overrides_default() -> None:
+    layer = RecordingLayer(name="my-mesh")
+    assert layer.name == "my-mesh"
+
+
+def test_layer_default_selection_is_empty_spec() -> None:
+    layer = RecordingLayer()
+    assert layer.selection == SelectionSpec.empty()
+    assert layer.selection.is_empty()
+
+
+def test_layer_explicit_selection_is_preserved() -> None:
+    spec = SelectionSpec(node_ids=(1, 2, 3))
+    layer = RecordingLayer(selection=spec)
+    assert layer.selection == spec
+
+
+def test_layer_default_style_is_empty_layer_style() -> None:
+    layer = RecordingLayer()
+    assert layer.style == LayerStyle()
+
+
+def test_layer_visibility_defaults_true() -> None:
+    layer = RecordingLayer()
+    assert layer.visible is True
+
+
+def test_layer_z_order_defaults_zero() -> None:
+    layer = RecordingLayer()
+    assert layer.z_order == 0
+
+
+def test_layer_is_attached_property_reflects_lifecycle() -> None:
+    layer = RecordingLayer()
+    assert layer.is_attached is False
+    layer.attach(scene="fake-scene", source="fake-source")  # type: ignore[arg-type]
+    assert layer.is_attached is True
+    layer.detach()
+    assert layer.is_attached is False
+
+
+def test_layer_subclass_must_provide_three_abstract_methods() -> None:
+    """A subclass missing any of attach/update_to_step/detach can't instantiate."""
+
+    class MissingDetach(Layer):
+        kind = "missing"
+
+        def attach(self, scene, source):  # type: ignore[no-untyped-def]
+            pass
+
+        def update_to_step(self, step: int) -> None:
+            pass
+
+    with pytest.raises(TypeError):
+        MissingDetach()  # type: ignore[abstract]
+
+
+def test_layer_kind_is_a_class_attribute_default() -> None:
+    """``Layer.kind`` defaults to ``"layer"``; subclasses override."""
+    assert Layer.kind == "layer"
+    assert RecordingLayer.kind == "recording"

--- a/tests/viewer/core/test_protocols.py
+++ b/tests/viewer/core/test_protocols.py
@@ -1,0 +1,57 @@
+"""Tests for the :class:`Backend` and :class:`DataSource` protocols.
+
+Both are ``runtime_checkable`` Protocols, so an unrelated class that
+implements the right methods satisfies ``isinstance(stub, Protocol)``.
+The conftest stubs (``StubBackend``, ``StubDataSource``) are the proof
+of concept that the protocol surfaces are non-trivially satisfiable.
+"""
+from __future__ import annotations
+
+from STKO_to_python.viewer.core import Backend, DataSource
+
+
+def test_stub_backend_satisfies_backend_protocol(stub_backend) -> None:  # type: ignore[no-untyped-def]
+    assert isinstance(stub_backend, Backend)
+
+
+def test_stub_source_satisfies_datasource_protocol(stub_source) -> None:  # type: ignore[no-untyped-def]
+    assert isinstance(stub_source, DataSource)
+
+
+def test_unrelated_class_does_not_satisfy_backend_protocol() -> None:
+    class NotABackend:
+        name = "fake"
+    assert not isinstance(NotABackend(), Backend)
+
+
+def test_unrelated_class_does_not_satisfy_datasource_protocol() -> None:
+    class NotASource:
+        @property
+        def dataset(self):
+            return None
+    # Missing required methods (node_coords, etc.) — Protocol rejects.
+    assert not isinstance(NotASource(), DataSource)
+
+
+def test_backend_protocol_methods_are_declared() -> None:
+    """Pin the protocol surface so accidental removals fail loudly."""
+    expected_methods = {
+        "make_scene", "set_bounds", "set_camera", "set_style",
+        "add_segments", "add_points", "add_polygons", "add_arrows",
+        "update_scalars", "update_points", "set_visible", "remove",
+        "show", "save", "snapshot",
+    }
+    declared = set(dir(Backend))
+    missing = expected_methods - declared
+    assert not missing, f"Backend protocol missing methods: {sorted(missing)}"
+
+
+def test_datasource_protocol_methods_are_declared() -> None:
+    expected_methods = {
+        "node_coords", "element_centroids", "model_bbox",
+        "n_steps", "time",
+        "resolve_node_ids", "resolve_element_ids",
+    }
+    declared = set(dir(DataSource))
+    missing = expected_methods - declared
+    assert not missing, f"DataSource protocol missing methods: {sorted(missing)}"

--- a/tests/viewer/core/test_scene.py
+++ b/tests/viewer/core/test_scene.py
@@ -1,0 +1,201 @@
+"""Tests for the :class:`Scene` orchestrator."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from STKO_to_python.viewer.core import BBox, Scene, SceneStyle
+
+from .conftest import RecordingLayer, StubBackend, StubDataSource
+
+
+# --------------------------------------------------------------------- #
+# Construction + handle creation                                        #
+# --------------------------------------------------------------------- #
+
+
+def test_scene_constructs_without_calling_backend(
+    stub_backend, stub_source,
+) -> None:
+    """The backend isn't touched until something asks for the handle."""
+    Scene(stub_backend, stub_source)
+    assert stub_backend.make_scene_calls == 0
+
+
+def test_scene_handle_is_lazy(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    assert stub_backend.make_scene_calls == 0
+    _ = scene.handle
+    assert stub_backend.make_scene_calls == 1
+    _ = scene.handle  # cached
+    assert stub_backend.make_scene_calls == 1
+
+
+def test_scene_handle_set_style_runs_once(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source, style=SceneStyle(background="black"))
+    _ = scene.handle
+    assert len(stub_backend.set_style_calls) == 1
+    style_passed = stub_backend.set_style_calls[0][1]
+    assert style_passed.background == "black"
+
+
+def test_scene_default_style_is_empty_scene_style(
+    stub_backend, stub_source,
+) -> None:
+    scene = Scene(stub_backend, stub_source)
+    assert scene.style == SceneStyle()
+
+
+# --------------------------------------------------------------------- #
+# Layer management                                                      #
+# --------------------------------------------------------------------- #
+
+
+def test_scene_add_attaches_layer_and_appends(
+    stub_backend, stub_source,
+) -> None:
+    scene = Scene(stub_backend, stub_source)
+    layer = RecordingLayer(name="A")
+    returned = scene.add(layer)
+    assert returned is layer
+    assert layer in scene
+    assert len(scene) == 1
+    assert layer.is_attached
+    assert len(layer.attach_calls) == 1
+
+
+def test_scene_add_forces_handle_before_layer_attach(
+    stub_backend, stub_source,
+) -> None:
+    """Layers expect ``scene.handle`` to exist when ``attach`` runs."""
+    scene = Scene(stub_backend, stub_source)
+    layer = RecordingLayer()
+    scene.add(layer)
+    # The scene handle was created (so layer.attach could use backend).
+    assert stub_backend.make_scene_calls == 1
+
+
+def test_scene_add_after_set_step_advances_new_layer(
+    stub_backend, stub_source,
+) -> None:
+    """A layer added after the cursor has moved is fast-forwarded."""
+    scene = Scene(stub_backend, stub_source)
+    scene.set_step(7)
+    layer = RecordingLayer()
+    scene.add(layer)
+    assert layer.update_calls == [7]
+
+
+def test_scene_remove_detaches_layer(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    layer = RecordingLayer()
+    scene.add(layer)
+    scene.remove(layer)
+    assert layer not in scene
+    assert layer.detach_calls == 1
+    assert layer.is_attached is False
+
+
+def test_scene_remove_unknown_layer_raises(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    orphan = RecordingLayer(name="orphan")
+    with pytest.raises(ValueError, match="not in this scene"):
+        scene.remove(orphan)
+
+
+# --------------------------------------------------------------------- #
+# Step / stage cursor                                                   #
+# --------------------------------------------------------------------- #
+
+
+def test_scene_set_step_propagates_to_every_layer(
+    stub_backend, stub_source,
+) -> None:
+    scene = Scene(stub_backend, stub_source)
+    a = RecordingLayer(name="A")
+    b = RecordingLayer(name="B")
+    scene.add(a)
+    scene.add(b)
+    scene.set_step(3)
+    assert a.update_calls == [3]
+    assert b.update_calls == [3]
+    assert scene.current_step == 3
+
+
+def test_scene_set_step_fires_invisible_layers_too(
+    stub_backend, stub_source,
+) -> None:
+    """Per the perf contract, invisible layers still get fresh data."""
+    scene = Scene(stub_backend, stub_source)
+    layer = RecordingLayer(visible=False)
+    scene.add(layer)
+    scene.set_step(5)
+    assert layer.update_calls == [5]
+
+
+def test_scene_set_stage_stores_stage(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    scene.set_stage("STAGE_1")
+    assert scene.current_stage == "STAGE_1"
+
+
+# --------------------------------------------------------------------- #
+# Bounds + output                                                       #
+# --------------------------------------------------------------------- #
+
+
+def test_scene_fit_bounds_pulls_bbox_from_source(
+    stub_backend, stub_source,
+) -> None:
+    scene = Scene(stub_backend, stub_source)
+    scene.fit_bounds()
+    assert len(stub_backend.set_bounds_calls) == 1
+    _, bbox_passed = stub_backend.set_bounds_calls[0]
+    assert bbox_passed == BBox(-1, -2, -3, 4, 5, 6)
+
+
+def test_scene_show_delegates_to_backend(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    scene.show()
+    assert stub_backend.show_calls == 1
+
+
+def test_scene_save_passes_dpi(stub_backend, stub_source, tmp_path) -> None:
+    scene = Scene(stub_backend, stub_source)
+    out = tmp_path / "frame.png"
+    scene.save(out, dpi=150)
+    assert len(stub_backend.save_calls) == 1
+    scene_arg, path_arg, dpi_arg = stub_backend.save_calls[0]
+    assert path_arg == out
+    assert dpi_arg == 150
+
+
+def test_scene_snapshot_returns_backend_array(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    arr = scene.snapshot()
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == np.uint8
+    assert arr.shape[-1] == 3
+
+
+# --------------------------------------------------------------------- #
+# Container protocol                                                    #
+# --------------------------------------------------------------------- #
+
+
+def test_scene_iteration_preserves_insertion_order(
+    stub_backend, stub_source,
+) -> None:
+    scene = Scene(stub_backend, stub_source)
+    a = RecordingLayer(name="A")
+    b = RecordingLayer(name="B")
+    c = RecordingLayer(name="C")
+    scene.add(a); scene.add(b); scene.add(c)
+    assert list(scene) == [a, b, c]
+
+
+def test_scene_len_matches_layer_count(stub_backend, stub_source) -> None:
+    scene = Scene(stub_backend, stub_source)
+    assert len(scene) == 0
+    scene.add(RecordingLayer())
+    assert len(scene) == 1

--- a/tests/viewer/core/test_selection.py
+++ b/tests/viewer/core/test_selection.py
@@ -1,0 +1,53 @@
+"""Tests for :class:`SelectionSpec`."""
+from __future__ import annotations
+
+import pytest
+
+from STKO_to_python.viewer.core import SelectionSpec
+
+
+def test_selection_spec_empty_classmethod() -> None:
+    spec = SelectionSpec.empty()
+    assert spec.is_empty()
+    assert spec == SelectionSpec()
+
+
+def test_selection_spec_default_construction_is_empty() -> None:
+    spec = SelectionSpec()
+    assert spec.is_empty()
+
+
+def test_selection_spec_is_not_empty_when_any_field_set() -> None:
+    assert not SelectionSpec(selection_set_name="slab").is_empty()
+    assert not SelectionSpec(node_ids=(1, 2, 3)).is_empty()
+    assert not SelectionSpec(element_type="203-ASDShellQ4").is_empty()
+
+
+def test_selection_spec_is_frozen() -> None:
+    spec = SelectionSpec(node_ids=(1, 2))
+    with pytest.raises(Exception):
+        spec.node_ids = (3,)  # type: ignore[misc]
+
+
+def test_selection_spec_is_hashable() -> None:
+    a = SelectionSpec(node_ids=(1, 2, 3))
+    b = SelectionSpec(node_ids=(1, 2, 3))
+    c = SelectionSpec(node_ids=(1, 2, 4))
+    assert hash(a) == hash(b)
+    assert hash(a) != hash(c)
+    # Suitable as a dict / set key — used downstream as cache key.
+    assert {a, b, c} == {a, c}
+
+
+def test_selection_spec_combines_multiple_fields_via_and() -> None:
+    """Multiple non-None fields are AND-combined at resolution time.
+
+    This test pins the documented semantics — actual resolution happens
+    in the adapter layer; here we just confirm both fields persist.
+    """
+    spec = SelectionSpec(
+        selection_set_name="slab",
+        element_type="203-ASDShellQ4",
+    )
+    assert spec.selection_set_name == "slab"
+    assert spec.element_type == "203-ASDShellQ4"

--- a/tests/viewer/core/test_style.py
+++ b/tests/viewer/core/test_style.py
@@ -1,0 +1,77 @@
+"""Tests for :class:`LayerStyle` and :class:`SceneStyle`."""
+from __future__ import annotations
+
+import pytest
+
+from STKO_to_python.viewer.core import LayerStyle, SceneStyle
+
+
+def test_layer_style_defaults_are_none() -> None:
+    style = LayerStyle()
+    assert style.color is None
+    assert style.linewidth is None
+    assert style.alpha is None
+
+
+def test_layer_style_is_frozen() -> None:
+    style = LayerStyle(color="red")
+    with pytest.raises(Exception):
+        style.color = "blue"  # type: ignore[misc]
+
+
+def test_layer_style_merge_layer_wins_when_set() -> None:
+    base = LayerStyle(color="blue", linewidth=1.0)
+    override = LayerStyle(color="red")
+    merged = override.merge(base)
+    assert merged.color == "red"       # override wins
+    assert merged.linewidth == 1.0     # inherited from base
+
+
+def test_layer_style_merge_inherits_all_when_override_is_empty() -> None:
+    base = LayerStyle(color="blue", linewidth=2.5, alpha=0.5)
+    merged = LayerStyle().merge(base)
+    assert merged.color == "blue"
+    assert merged.linewidth == 2.5
+    assert merged.alpha == 0.5
+
+
+def test_layer_style_merge_does_not_mutate_inputs() -> None:
+    base = LayerStyle(color="blue")
+    override = LayerStyle(color="red")
+    merged = override.merge(base)
+    assert base.color == "blue"
+    assert override.color == "red"
+    assert merged.color == "red"
+
+
+def test_scene_style_get_defaults_for_missing_kind_returns_empty() -> None:
+    scene = SceneStyle()
+    empty = scene.get_defaults_for("nonexistent_layer_kind")
+    assert isinstance(empty, LayerStyle)
+    assert empty == LayerStyle()
+
+
+def test_scene_style_get_defaults_for_known_kind() -> None:
+    scene = SceneStyle(
+        layer_defaults={"mesh": LayerStyle(color="lightgray", linewidth=0.5)},
+    )
+    default = scene.get_defaults_for("mesh")
+    assert default.color == "lightgray"
+    assert default.linewidth == 0.5
+
+
+def test_scene_style_with_layer_default_returns_new_instance() -> None:
+    original = SceneStyle()
+    updated = original.with_layer_default("mesh", LayerStyle(color="red"))
+    # Original unchanged.
+    assert original.layer_defaults == {}
+    # New scene has the new default.
+    assert updated.get_defaults_for("mesh").color == "red"
+
+
+def test_scene_style_with_layer_default_overrides_existing() -> None:
+    scene = SceneStyle(
+        layer_defaults={"mesh": LayerStyle(color="blue")},
+    )
+    updated = scene.with_layer_default("mesh", LayerStyle(color="red"))
+    assert updated.get_defaults_for("mesh").color == "red"

--- a/tests/viewer/core/test_types_and_errors.py
+++ b/tests/viewer/core/test_types_and_errors.py
@@ -1,0 +1,92 @@
+"""Tests for the small value types and exception classes."""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from STKO_to_python.viewer.core import (
+    BBox,
+    BackendCapabilityError,
+    CameraSpec,
+    LayerAttachError,
+)
+
+
+# --------------------------------------------------------------------- #
+# BBox                                                                  #
+# --------------------------------------------------------------------- #
+
+
+def test_bbox_size_center_diagonal() -> None:
+    bbox = BBox(-1.0, -2.0, -3.0, 4.0, 6.0, 9.0)
+    assert bbox.size == (5.0, 8.0, 12.0)
+    assert bbox.center == (1.5, 2.0, 3.0)
+    assert math.isclose(bbox.diagonal, math.sqrt(25 + 64 + 144))
+
+
+def test_bbox_zero_diagonal_is_zero() -> None:
+    """A degenerate box (single point) has zero diagonal."""
+    bbox = BBox(1.0, 2.0, 3.0, 1.0, 2.0, 3.0)
+    assert bbox.diagonal == 0.0
+
+
+def test_bbox_is_frozen() -> None:
+    bbox = BBox(0, 0, 0, 1, 1, 1)
+    with pytest.raises(Exception):
+        bbox.x_min = 5  # type: ignore[misc]
+
+
+def test_bbox_is_hashable() -> None:
+    bbox_a = BBox(0, 0, 0, 1, 1, 1)
+    bbox_b = BBox(0, 0, 0, 1, 1, 1)
+    bbox_c = BBox(0, 0, 0, 1, 1, 2)
+    assert hash(bbox_a) == hash(bbox_b)
+    assert hash(bbox_a) != hash(bbox_c)
+    # Hashable means it can live in a set / dict key.
+    assert {bbox_a, bbox_b, bbox_c} == {bbox_a, bbox_c}
+
+
+# --------------------------------------------------------------------- #
+# CameraSpec                                                            #
+# --------------------------------------------------------------------- #
+
+
+def test_camera_spec_holds_fields() -> None:
+    cam = CameraSpec(
+        position=(0.0, 0.0, 5.0),
+        focal_point=(0.0, 0.0, 0.0),
+        view_up=(0.0, 1.0, 0.0),
+    )
+    assert cam.position == (0.0, 0.0, 5.0)
+    assert cam.focal_point == (0.0, 0.0, 0.0)
+    assert cam.view_up == (0.0, 1.0, 0.0)
+    assert cam.parallel_projection is False
+
+
+def test_camera_spec_parallel_projection_overrides() -> None:
+    cam = CameraSpec(
+        position=(0, 0, 5),
+        focal_point=(0, 0, 0),
+        view_up=(0, 1, 0),
+        parallel_projection=True,
+    )
+    assert cam.parallel_projection is True
+
+
+# --------------------------------------------------------------------- #
+# Exceptions                                                            #
+# --------------------------------------------------------------------- #
+
+
+def test_backend_capability_error_is_not_implemented_error() -> None:
+    """Catching ``NotImplementedError`` also catches ``BackendCapabilityError``."""
+    assert issubclass(BackendCapabilityError, NotImplementedError)
+    with pytest.raises(NotImplementedError):
+        raise BackendCapabilityError("test")
+
+
+def test_layer_attach_error_is_runtime_error() -> None:
+    assert issubclass(LayerAttachError, RuntimeError)
+    with pytest.raises(RuntimeError):
+        raise LayerAttachError("test")


### PR DESCRIPTION
First module of Phase 2 per docs/viewer/00-roadmap.md. Lands the backend-neutral contracts every renderer implementation will satisfy. No rendering happens here; concrete backends and layer types ride on top in subsequent steps.

New subpackage: STKO_to_python.viewer.core
- backend.py     — Backend runtime-checkable Protocol
- datasource.py  — DataSource runtime-checkable Protocol
- layer.py       — Layer ABC (attach / update_to_step / detach)
- scene.py       — Scene concrete orchestrator (lazy handle, layer
                   stack, step cursor, fit_bounds, snapshot)
- style.py       — LayerStyle + SceneStyle frozen dataclasses with
                   merge() inheritance and per-kind defaults
- selection.py   — SelectionSpec frozen + hashable filter
- types.py       — BBox, CameraSpec, SceneHandle/ActorRef aliases
- errors.py      — BackendCapabilityError, LayerAttachError

The core subpackage is pure-Python and has no runtime dependency on pyvista, vtk, PySide6, or any optional extra. The viewer smoke test keeps that contract honest.

59 new unit tests in tests/viewer/core/. Coverage:
- BBox properties + hashability + frozen invariant
- LayerStyle.merge() inheritance + immutability
- SceneStyle.with_layer_default()
- SelectionSpec hashable / empty() / is_empty()
- Backend protocol satisfied by a stub class via runtime_checkable
- DataSource protocol same
- Protocol method-set pinned so accidental removals fail loudly
- Layer ABC cannot be instantiated; subclass requirements enforced
- Scene composition: lazy handle, add propagates current_step, remove detaches, set_step fires every layer (including invisible), iteration preserves insertion order

Stacked on guppi/viewer-shell-frame (PR #84). When that merges this branch's base auto-retargets to main.