### PR TITLE
Rename viewer CLI: stko-viewer -> mpco-viewer (docs)

### DIFF
--- a/docs/viewer/00-roadmap.md
+++ b/docs/viewer/00-roadmap.md
@@ -59,7 +59,7 @@ actually break something.
 | Phase 1 — Algorithm tier | `v1.10.0` | New pure-numpy modules; matplotlib renderers may opt to use them. |
 | Phase 2 — Backend + 2D layers | `v1.11.0` | Scene/Layer machinery under existing `Plot.*` methods. Convenience API unchanged. |
 | Phase 3 — PyVista backend + 3D layers | `v1.12.0` | New `[viewer-3d]` extra. Qt not yet required. |
-| Phase 4 — Qt desktop | `v1.13.0` | New `[viewer]` extra. Adds CLI entry point `stko-viewer`. |
+| Phase 4 — Qt desktop | `v1.13.0` | New `[viewer]` extra. Adds CLI entry point `mpco-viewer`. |
 | Phase 5 — Headless CLI | `v1.14.0` | New `[viewer-headless]` extra; animation/screenshot CLI. |
 | Phase 6 — Trame web | `v2.0.0` *(optional)* | Only bumps MAJOR if it forces a refactor of the public viewer API. Otherwise stays MINOR. |
 
@@ -217,7 +217,7 @@ because the algorithms are mostly already done by Phase 1.
 
 ## Phase 4 — Qt desktop UI
 
-**Goal:** the "full experience." Ship the `stko-viewer` GUI: dock layout,
+**Goal:** the "full experience." Ship the `mpco-viewer` GUI: dock layout,
 time scrubber, diagram tree, picking, settings tabs, animation export.
 
 **Deliverables:**
@@ -237,8 +237,8 @@ time scrubber, diagram tree, picking, settings tabs, animation export.
       `step_changed` callbacks.
     - `picking.py` — port of apeGmsh's vectorized box-pick math.
     - `session.py` — save/restore window layout + layer specs to disk.
-- `pyproject.toml` — add `[project.scripts]` entry: `stko-viewer = STKO_to_python.viewer.qt.cli:main`
-- `stko-viewer <file.mpco>` — open the file in the GUI.
+- `pyproject.toml` — add `[project.scripts]` entry: `mpco-viewer = STKO_to_python.viewer.qt.cli:main`
+- `mpco-viewer <file.mpco>` — open the file in the GUI.
 - `MPCODataSet.viewer()` — open the current dataset in the GUI (blocks).
 
 **Definition of done:**
@@ -263,9 +263,9 @@ as the GUI, no Qt loop.
 
 **Deliverables:**
 
-- `stko-viewer animate run.mpco --config view.toml --out anim.mp4`
-- `stko-viewer screenshot run.mpco --step 250 --out frame.png`
-- `stko-viewer batch run.mpco --config batch.toml --out frames/`
+- `mpco-viewer animate run.mpco --config view.toml --out anim.mp4`
+- `mpco-viewer screenshot run.mpco --step 250 --out frame.png`
+- `mpco-viewer batch run.mpco --config batch.toml --out frames/`
 - `view.toml` schema — declarative spec for layers + camera + step range.
   Matches the in-memory `Scene` layout 1:1 so the GUI can save → run on
   cluster → reload result.
@@ -275,7 +275,7 @@ as the GUI, no Qt loop.
 **Definition of done:**
 
 - Animation runs on a headless Linux box with no `$DISPLAY` set.
-- `stko-viewer screenshot` produces the same PNG (within tolerance) as
+- `mpco-viewer screenshot` produces the same PNG (within tolerance) as
   the GUI's "Save snapshot" button does on the same step.
 
 **Estimate:** ~1.5 weeks. **Risk:** low. Most of the work is CLI wiring;

--- a/docs/viewer/01-architecture.md
+++ b/docs/viewer/01-architecture.md
@@ -38,7 +38,7 @@ Five layers, top to bottom. Data flows down on initialization, up on render.
    +----------------------------------+
    |  Layer 5: User-facing API        |   MPCODataSet.viewer(),
    |                                  |   ds.scene(), Scene(), MultiScene(),
-   |                                  |   stko-viewer CLI
+   |                                  |   mpco-viewer CLI
    +----------------------------------+
                    |
                    v
@@ -297,7 +297,7 @@ event loop is the master clock.
 ### 7.2 Headless / batch
 
 ```
-stko-viewer animate run.mpco --config view.toml --out anim.mp4
+mpco-viewer animate run.mpco --config view.toml --out anim.mp4
         │
         └── load view.toml -> SceneSpec
             scene = Scene.from_spec(spec, ds)
@@ -399,7 +399,7 @@ src/STKO_to_python/viewer/
 ├── qt/                      # Phase 4
 │   ├── app.py
 │   ├── main_window.py
-│   ├── cli.py               # stko-viewer entry point
+│   ├── cli.py               # mpco-viewer entry point
 │   ├── widgets/
 │   │   ├── outline_tree.py
 │   │   ├── viewport.py
@@ -413,7 +413,7 @@ src/STKO_to_python/viewer/
 │   └── theme.py
 │
 ├── headless/                # Phase 5
-│   ├── cli.py               # stko-viewer animate/screenshot/batch
+│   ├── cli.py               # mpco-viewer animate/screenshot/batch
 │   └── runner.py
 │
 └── web/                     # Phase 6 (deferred)

--- a/docs/viewer/03-deployment-targets.md
+++ b/docs/viewer/03-deployment-targets.md
@@ -37,7 +37,7 @@ This adds: `pyvista>=0.43`, `vtk>=9.2`, `PySide6>=6.5`,
 **Launch:**
 
 ```bash
-stko-viewer path/to/results.mpco
+mpco-viewer path/to/results.mpco
 ```
 
 or from Python:
@@ -114,7 +114,7 @@ the answer lives next to the install docs:
 
 ```bash
 ssh -X user@cluster
-stko-viewer ...
+mpco-viewer ...
 ```
 
 What happens:
@@ -150,7 +150,7 @@ only compressed pixels — much better than X11 forwarding.
 vncviewer cluster:1
 # Inside the VNC session:
 pip install "stko_to_python[viewer]"
-stko-viewer results.mpco
+mpco-viewer results.mpco
 ```
 
 Performance: usable for inspection, less smooth than local. Animation
@@ -185,18 +185,18 @@ calls it for you on Linux when `$DISPLAY` is unset.
 
 ```bash
 # Single frame:
-stko-viewer screenshot results.mpco --step 250 --out frame.png
+mpco-viewer screenshot results.mpco --step 250 --out frame.png
 
 # Animation:
-stko-viewer animate results.mpco --config view.toml --out anim.mp4
+mpco-viewer animate results.mpco --config view.toml --out anim.mp4
 
 # Batch render every Nth step:
-stko-viewer batch results.mpco --config batch.toml --out frames/
+mpco-viewer batch results.mpco --config batch.toml --out frames/
 
 # Save a scene in the GUI, then run it on the cluster:
 # (laptop) Edit scene visually, File > Save scene to view.toml
 # (laptop) scp view.toml cluster:~/run/
-# (cluster) stko-viewer animate results.mpco --config view.toml --out anim.mp4
+# (cluster) mpco-viewer animate results.mpco --config view.toml --out anim.mp4
 # (laptop) scp cluster:~/run/anim.mp4 .
 ```
 
@@ -211,7 +211,7 @@ This is the workflow most engineers actually use for big runs.
 #SBATCH --mem=8G
 module load python/3.12
 source ~/venvs/stko/bin/activate   # has stko_to_python[viewer-headless] installed
-xvfb-run -a stko-viewer animate $RESULTS --config view.toml --out anim.mp4
+xvfb-run -a mpco-viewer animate $RESULTS --config view.toml --out anim.mp4
 ```
 
 ---
@@ -238,7 +238,7 @@ laptop browser ───── http (WebSocket) ─────► trame server 
 ssh -L 8080:localhost:8080 user@cluster
 # In another terminal:
 ssh user@cluster
-stko-viewer web results.mpco --port 8080
+mpco-viewer web results.mpco --port 8080
 # In laptop browser:
 open http://localhost:8080
 ```
@@ -269,7 +269,7 @@ enough to fit in browser memory, server-side otherwise. Configurable.
               │                    │                    │
               │                    │                    │
    [viewer] + local      What I want?              [viewer-headless]
-   stko-viewer ...           │                     stko-viewer animate ...
+   mpco-viewer ...           │                     mpco-viewer animate ...
                              ├── interactive 3D
                              │      │
                              │      ├── cluster has VNC?


### PR DESCRIPTION
## Summary

The CLI binary name was set casually in the planning docs (`docs/viewer/00-roadmap.md`, `docs/viewer/01-architecture.md`, `docs/viewer/03-deployment-targets.md`). Renaming to **`mpco-viewer`** for two reasons:

- `stko-viewer` reads as a clone of [ASDEA's STKO](https://asdeasoft.net/?stko) desktop tool, which it is not. STKO is the pre-processor + analysis controller that generates `.mpco` recorder files; this CLI is a post-processor for those files.
- `mpco-viewer` names what it actually reads — the file format — rather than the upstream brand. Less ambiguous for users who came in via OpenSees `MPCORecorder` rather than via STKO itself.

Docs-only change. No CLI has shipped yet — the binary is first declared in Phase 4 (Qt desktop), which is many PRs away. Settling the name now avoids touching code later.

22 substitutions across 3 files; the diff is mechanical.

## Test plan
- [x] `grep -r 'stko-viewer'` over the repo returns zero matches after the rename.
- [x] No code changes; no tests affected.
- [ ] CI green (mkdocs strict build will catch any broken cross-refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)