### PR TITLE
Add MPCODataSourceAdapter — viewer (Phase 2.3)

### DIFF
--- a/src/STKO_to_python/viewer/core/__init__.py
+++ b/src/STKO_to_python/viewer/core/__init__.py
@@ -23,6 +23,7 @@ smoke test (``tests/viewer/test_smoke.py``) keeps that contract honest.
 """
 from __future__ import annotations
 
+from ._mpco_adapter import MPCODataSourceAdapter
 from .backend import Backend
 from .datasource import DataSource
 from .errors import BackendCapabilityError, LayerAttachError
@@ -42,6 +43,7 @@ __all__ = [
     "Layer",
     "LayerAttachError",
     "LayerStyle",
+    "MPCODataSourceAdapter",
     "Scene",
     "SceneHandle",
     "SceneStyle",

--- a/src/STKO_to_python/viewer/core/_mpco_adapter.py
+++ b/src/STKO_to_python/viewer/core/_mpco_adapter.py
@@ -1,0 +1,370 @@
+"""Concrete :class:`DataSource` over an :class:`MPCODataSet`.
+
+This is the **one** place where viewer code touches STKO's pandas
+DataFrame world. Every other viewer module operates against the
+:class:`DataSource` protocol declared in :mod:`.datasource`, which
+keeps layers backend- and data-source-agnostic. A future non-MPCO
+source (e.g. a streaming OpenSeesPy adapter) just implements the
+protocol — the layers stay unchanged.
+
+See ``docs/viewer/01-architecture.md`` §5 and
+``docs/viewer/02-porting-from-apegmsh.md`` §8 for the rationale.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Sequence, Tuple, Union
+
+import numpy as np
+
+from .selection import SelectionSpec
+from .types import BBox
+
+if TYPE_CHECKING:
+    from ...core.dataset import MPCODataSet
+
+
+_StrOrTuple = Union[str, Sequence[str]]
+_IntOrTuple = Union[int, np.integer, Sequence[int]]
+
+
+class MPCODataSourceAdapter:
+    """:class:`DataSource` implementation wrapping a :class:`MPCODataSet`.
+
+    Translates the viewer's array-oriented protocol into DataFrame
+    queries against the dataset's existing caches. The adapter keeps a
+    reference to the dataset but never mutates it; one adapter can be
+    reused across many plotting calls.
+
+    Caches
+    ------
+    The adapter memoizes derived structures that are pure functions of
+    the dataset's geometry:
+
+    * ``node_id -> row`` and ``element_id -> row`` lookup maps, lazily
+      built on the first ``node_coords(ids=...)`` /
+      ``element_centroids(ids=...)`` call;
+    * the model bounding box;
+    * resolved id arrays keyed by ``SelectionSpec`` (which is frozen and
+      hashable) — so a layer that re-asks for the same selection across
+      steps pays the resolver cost once.
+
+    Parameters
+    ----------
+    dataset:
+        The :class:`MPCODataSet` to adapt.
+    """
+
+    __slots__ = (
+        "_dataset",
+        "_node_id_to_row",
+        "_elem_id_to_row",
+        "_bbox",
+        "_selection_cache",
+    )
+
+    def __init__(self, dataset: "MPCODataSet") -> None:
+        self._dataset = dataset
+        self._node_id_to_row: dict[int, int] | None = None
+        self._elem_id_to_row: dict[int, int] | None = None
+        self._bbox: BBox | None = None
+        self._selection_cache: dict[tuple[str, SelectionSpec], np.ndarray] = {}
+
+    @property
+    def dataset(self) -> "MPCODataSet":
+        return self._dataset
+
+    # ------------------------------------------------------------------ #
+    # Geometry
+    # ------------------------------------------------------------------ #
+    def node_coords(self, ids: np.ndarray | None = None) -> np.ndarray:
+        """``(N, 3)`` node coordinates.
+
+        Parameters
+        ----------
+        ids:
+            Optional node IDs. ``None`` returns coordinates for every
+            node in dataset order. A non-empty array returns rows in
+            the **caller's** order — so ``node_coords([3, 1, 2])`` and
+            ``node_coords([1, 2, 3])`` produce different orderings even
+            though both name the same three nodes.
+
+        Raises
+        ------
+        KeyError
+            If any element of ``ids`` is not present in the dataset.
+        """
+        df = self._dataset.nodes_info["dataframe"]
+        if df.empty:
+            return np.zeros((0, 3), dtype=np.float64)
+        coords = df[["x", "y", "z"]].to_numpy(dtype=np.float64)
+        if ids is None:
+            return coords
+        ids_arr = np.asarray(ids, dtype=np.int64).ravel()
+        if ids_arr.size == 0:
+            return np.zeros((0, 3), dtype=np.float64)
+        mapping = self._node_index_map()
+        rows = np.empty(ids_arr.size, dtype=np.int64)
+        for i, nid in enumerate(ids_arr):
+            try:
+                rows[i] = mapping[int(nid)]
+            except KeyError as exc:
+                raise KeyError(f"Node id {int(nid)} not in dataset") from exc
+        return coords[rows]
+
+    def element_centroids(self, ids: np.ndarray | None = None) -> np.ndarray:
+        """``(E, 3)`` element centroids.
+
+        Same ``ids`` semantics as :meth:`node_coords` — caller order is
+        preserved, missing IDs raise.
+        """
+        df = self._dataset.elements_info["dataframe"]
+        if df.empty:
+            return np.zeros((0, 3), dtype=np.float64)
+        coords = df[["centroid_x", "centroid_y", "centroid_z"]].to_numpy(
+            dtype=np.float64
+        )
+        if ids is None:
+            return coords
+        ids_arr = np.asarray(ids, dtype=np.int64).ravel()
+        if ids_arr.size == 0:
+            return np.zeros((0, 3), dtype=np.float64)
+        mapping = self._element_index_map()
+        rows = np.empty(ids_arr.size, dtype=np.int64)
+        for i, eid in enumerate(ids_arr):
+            try:
+                rows[i] = mapping[int(eid)]
+            except KeyError as exc:
+                raise KeyError(f"Element id {int(eid)} not in dataset") from exc
+        return coords[rows]
+
+    def model_bbox(self) -> BBox:
+        """Axis-aligned bounding box over every node in the model.
+
+        Cached after the first call. Empty datasets return an all-zero
+        :class:`BBox` (so layers can still call ``set_bounds`` without
+        special-casing the empty path).
+        """
+        if self._bbox is None:
+            df = self._dataset.nodes_info["dataframe"]
+            if df.empty:
+                self._bbox = BBox(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+            else:
+                xs = df["x"].to_numpy(dtype=np.float64)
+                ys = df["y"].to_numpy(dtype=np.float64)
+                zs = df["z"].to_numpy(dtype=np.float64)
+                self._bbox = BBox(
+                    float(xs.min()),
+                    float(ys.min()),
+                    float(zs.min()),
+                    float(xs.max()),
+                    float(ys.max()),
+                    float(zs.max()),
+                )
+        return self._bbox
+
+    # ------------------------------------------------------------------ #
+    # Time axis
+    # ------------------------------------------------------------------ #
+    def n_steps(self, stage: str | None = None) -> int:
+        """Number of analysis steps in ``stage`` (defaults to stage 0)."""
+        stage = self._resolve_stage(stage)
+        try:
+            return int(self._dataset.number_of_steps[stage])
+        except KeyError as exc:
+            raise KeyError(
+                f"Stage {stage!r} not present in dataset.number_of_steps"
+            ) from exc
+
+    def time(self, stage: str | None = None) -> np.ndarray:
+        """``(T,)`` time values for ``stage`` (defaults to stage 0).
+
+        Returns the ``TIME`` column from ``dataset.time`` restricted to
+        ``stage``, in ``STEP``-ascending order — same convention the
+        rest of the library uses for time-history queries.
+        """
+        stage = self._resolve_stage(stage)
+        df = self._dataset.time
+        try:
+            stage_df = df.loc[stage]
+        except KeyError as exc:
+            raise KeyError(f"Stage {stage!r} not present in dataset.time") from exc
+        return stage_df["TIME"].to_numpy(dtype=np.float64)
+
+    # ------------------------------------------------------------------ #
+    # Selection resolution
+    # ------------------------------------------------------------------ #
+    def resolve_node_ids(self, spec: SelectionSpec) -> np.ndarray:
+        """Return the node IDs matching ``spec`` as a sorted ``int64`` array.
+
+        Fields are AND-combined: a node is returned only when every
+        non-``None`` criterion of ``spec`` accepts it. Within a single
+        criterion (e.g. a tuple of selection-set names), members are
+        union-combined — same semantics as
+        :class:`~STKO_to_python.selection.SelectionSetResolver`.
+
+        ``spec.element_type`` and ``spec.element_ids`` are element-only
+        filters and are ignored when resolving nodes.
+        """
+        key = ("node", spec)
+        cached = self._selection_cache.get(key)
+        if cached is not None:
+            return cached.copy()
+
+        all_ids = self._all_node_ids()
+        if spec.is_empty():
+            self._selection_cache[key] = all_ids
+            return all_ids.copy()
+
+        masks: list[np.ndarray] = []
+        names, sids = _selection_set_inputs(spec)
+        if names or sids:
+            resolver = self._dataset._selection_resolver
+            from_sel = resolver.resolve_nodes(
+                names=names if names else None,
+                ids=sids if sids else None,
+            )
+            masks.append(from_sel)
+        if spec.node_ids is not None:
+            masks.append(np.asarray(spec.node_ids, dtype=np.int64).ravel())
+
+        out = _intersect_with_universe(masks, all_ids)
+        self._selection_cache[key] = out
+        return out.copy()
+
+    def resolve_element_ids(self, spec: SelectionSpec) -> np.ndarray:
+        """Return the element IDs matching ``spec`` as a sorted ``int64`` array.
+
+        ``spec.node_ids`` is a node-only filter and is ignored here.
+        ``spec.element_type`` matches on the *base* type — the prefix
+        before ``[`` — so both ``"203-ASDShellQ4"`` and
+        ``"203-ASDShellQ4[4n]"`` select the same elements (parallel to
+        ``ds.plot.mesh``'s ``element_type=`` argument).
+        """
+        key = ("element", spec)
+        cached = self._selection_cache.get(key)
+        if cached is not None:
+            return cached.copy()
+
+        all_ids = self._all_element_ids()
+        if spec.is_empty():
+            self._selection_cache[key] = all_ids
+            return all_ids.copy()
+
+        masks: list[np.ndarray] = []
+        names, sids = _selection_set_inputs(spec)
+        if names or sids:
+            resolver = self._dataset._selection_resolver
+            from_sel = resolver.resolve_elements(
+                names=names if names else None,
+                ids=sids if sids else None,
+            )
+            masks.append(from_sel)
+        if spec.element_ids is not None:
+            masks.append(np.asarray(spec.element_ids, dtype=np.int64).ravel())
+        if spec.element_type is not None:
+            masks.append(self._filter_by_element_type(spec.element_type))
+
+        out = _intersect_with_universe(masks, all_ids)
+        self._selection_cache[key] = out
+        return out.copy()
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    def _resolve_stage(self, stage: str | None) -> str:
+        if stage is not None:
+            return stage
+        stages = self._dataset.model_stages
+        if not stages:
+            raise ValueError("Dataset has no model stages")
+        return stages[0]
+
+    def _all_node_ids(self) -> np.ndarray:
+        df = self._dataset.nodes_info["dataframe"]
+        if df.empty:
+            return np.zeros(0, dtype=np.int64)
+        return df["node_id"].to_numpy(dtype=np.int64)
+
+    def _all_element_ids(self) -> np.ndarray:
+        df = self._dataset.elements_info["dataframe"]
+        if df.empty:
+            return np.zeros(0, dtype=np.int64)
+        return df["element_id"].to_numpy(dtype=np.int64)
+
+    def _node_index_map(self) -> dict[int, int]:
+        if self._node_id_to_row is None:
+            df = self._dataset.nodes_info["dataframe"]
+            self._node_id_to_row = {
+                int(nid): i for i, nid in enumerate(df["node_id"].to_numpy())
+            }
+        return self._node_id_to_row
+
+    def _element_index_map(self) -> dict[int, int]:
+        if self._elem_id_to_row is None:
+            df = self._dataset.elements_info["dataframe"]
+            self._elem_id_to_row = {
+                int(eid): i for i, eid in enumerate(df["element_id"].to_numpy())
+            }
+        return self._elem_id_to_row
+
+    def _filter_by_element_type(self, element_type: _StrOrTuple) -> np.ndarray:
+        df = self._dataset.elements_info["dataframe"]
+        types: Tuple[str, ...]
+        if isinstance(element_type, str):
+            types = (element_type,)
+        else:
+            types = tuple(str(t) for t in element_type)
+        bases = [t.split("[")[0] for t in types]
+        col = df["element_type"]
+        mask = np.zeros(len(df), dtype=bool)
+        for base in bases:
+            mask |= col.str.startswith(base).to_numpy()
+        return df.loc[mask, "element_id"].to_numpy(dtype=np.int64)
+
+
+# ---------------------------------------------------------------------- #
+# Module-private helpers
+# ---------------------------------------------------------------------- #
+def _selection_set_inputs(
+    spec: SelectionSpec,
+) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
+    """Split a spec's selection-set fields into ``(names, ids)`` tuples."""
+    raw_name = spec.selection_set_name
+    if raw_name is None:
+        names: Tuple[str, ...] = ()
+    elif isinstance(raw_name, str):
+        names = (raw_name,)
+    else:
+        names = tuple(str(n) for n in raw_name)
+
+    raw_id = spec.selection_set_id
+    if raw_id is None:
+        sids: Tuple[int, ...] = ()
+    elif isinstance(raw_id, (int, np.integer)):
+        sids = (int(raw_id),)
+    else:
+        sids = tuple(int(s) for s in raw_id)
+
+    return names, sids
+
+
+def _intersect_with_universe(
+    masks: Iterable[np.ndarray], universe: np.ndarray
+) -> np.ndarray:
+    """AND-combine ``masks`` then clip to entities the dataset knows about.
+
+    ``np.intersect1d`` deduplicates and sorts, which is the canonical
+    shape for a resolved selection — downstream layers don't rely on
+    insertion order, and a stable contract makes the cache key
+    well-defined.
+    """
+    mask_list = list(masks)
+    if not mask_list:
+        return universe.copy()
+    out = mask_list[0]
+    for m in mask_list[1:]:
+        out = np.intersect1d(out, m, assume_unique=False)
+    return np.intersect1d(out, universe, assume_unique=False)
+
+
+__all__ = ["MPCODataSourceAdapter"]

--- a/src/STKO_to_python/viewer/core/datasource.py
+++ b/src/STKO_to_python/viewer/core/datasource.py
@@ -7,8 +7,9 @@ protocol — a future viewer source (e.g. a streaming OpenSeesPy
 adapter) only has to implement the protocol; the layers don't change.
 
 The concrete :class:`MPCODataSourceAdapter` lives in
-``viewer/core/_mpco_adapter.py`` and lands in Phase 2 step 2 alongside
-the first layer that consumes it.
+``viewer/core/_mpco_adapter.py`` (added in Phase 2.3); it is the
+default implementation that the layers landing in Phase 2.4 onward
+consume.
 
 See ``docs/viewer/01-architecture.md`` §5.
 """

--- a/tests/viewer/core/test_mpco_adapter.py
+++ b/tests/viewer/core/test_mpco_adapter.py
@@ -1,0 +1,465 @@
+"""Tests for :class:`MPCODataSourceAdapter`.
+
+The adapter is the only viewer-side module that talks to STKO's
+DataFrame world, so it gets two flavors of coverage:
+
+* fake-dataset unit tests — fast, exercise every branch of the
+  adapter without depending on any HDF5 fixture;
+* a real-fixture smoke test against ``elastic_frame_dir`` to verify
+  the adapter binds to the attribute names that the real dataset
+  actually exposes (the live contract).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.viewer.core import (
+    BBox,
+    DataSource,
+    MPCODataSourceAdapter,
+    SelectionSpec,
+)
+
+
+# --------------------------------------------------------------------- #
+# Fake dataset helpers — avoid any HDF5 dependency.
+# --------------------------------------------------------------------- #
+
+
+class _FakeResolver:
+    """Mimic the small surface of :class:`SelectionSetResolver` used here."""
+
+    def __init__(
+        self,
+        node_sets: Dict[str, List[int]] | None = None,
+        elem_sets: Dict[str, List[int]] | None = None,
+    ) -> None:
+        self._node_sets = node_sets or {}
+        self._elem_sets = elem_sets or {}
+
+    def resolve_nodes(self, *, names=None, ids=None, explicit_ids=None):
+        return self._resolve(self._node_sets, names, ids, "NODES")
+
+    def resolve_elements(self, *, names=None, ids=None, explicit_ids=None):
+        return self._resolve(self._elem_sets, names, ids, "ELEMENTS")
+
+    def _resolve(self, store, names, ids, payload_key):
+        gathered: list[np.ndarray] = []
+        for n in names or ():
+            key = str(n).strip().lower()
+            if key not in store:
+                raise ValueError(f"Selection set name not found: {n!r}")
+            gathered.append(np.asarray(store[key], dtype=np.int64))
+        for sid in ids or ():
+            key = f"#{int(sid)}"
+            if key not in store:
+                raise ValueError(f"Selection set {sid} empty or missing {payload_key}")
+            gathered.append(np.asarray(store[key], dtype=np.int64))
+        if not gathered:
+            raise ValueError("Provide names, ids, and/or explicit_ids — got none.")
+        return np.unique(np.concatenate(gathered))
+
+
+def _make_fake_dataset(
+    *,
+    node_rows: list[tuple[int, float, float, float]] | None = None,
+    elem_rows: list[tuple[int, str, float, float, float]] | None = None,
+    model_stages: list[str] | None = None,
+    number_of_steps: dict[str, int] | None = None,
+    time_df: pd.DataFrame | None = None,
+    resolver: _FakeResolver | None = None,
+) -> Any:
+    """Build a duck-typed stand-in for :class:`MPCODataSet`.
+
+    Carries only the attributes :class:`MPCODataSourceAdapter` reads —
+    everything else is left out so any drift in the contract surfaces
+    as a clear ``AttributeError``.
+    """
+    if node_rows is None:
+        node_rows = [
+            (1, 0.0, 0.0, 0.0),
+            (2, 1.0, 0.0, 0.0),
+            (3, 1.0, 2.0, 0.0),
+            (4, 0.0, 2.0, 0.5),
+        ]
+    if elem_rows is None:
+        # (element_id, element_type, centroid_x, centroid_y, centroid_z)
+        elem_rows = [
+            (10, "5-ElasticBeam3d", 0.5, 0.0, 0.0),
+            (11, "203-ASDShellQ4", 0.5, 1.0, 0.25),
+            (12, "203-ASDShellQ4", 0.5, 1.5, 0.25),
+            (13, "8-Brick", 0.5, 1.5, 0.5),
+        ]
+    if model_stages is None:
+        model_stages = ["STAGE_0"]
+    if number_of_steps is None:
+        number_of_steps = {s: 3 for s in model_stages}
+    if time_df is None:
+        rows = []
+        for stage in model_stages:
+            for step in range(number_of_steps[stage]):
+                rows.append({"MODEL_STAGE": stage, "STEP": step, "TIME": float(step) * 0.1})
+        time_df = pd.DataFrame(rows).set_index(["MODEL_STAGE", "STEP"]).sort_index()
+
+    nodes_df = pd.DataFrame(node_rows, columns=["node_id", "x", "y", "z"])
+    elements_df = pd.DataFrame(
+        elem_rows,
+        columns=["element_id", "element_type", "centroid_x", "centroid_y", "centroid_z"],
+    )
+
+    fake = SimpleNamespace(
+        nodes_info={"dataframe": nodes_df},
+        elements_info={"dataframe": elements_df},
+        model_stages=list(model_stages),
+        number_of_steps=dict(number_of_steps),
+        time=time_df,
+    )
+    fake._selection_resolver = resolver if resolver is not None else _FakeResolver()
+    return fake
+
+
+# --------------------------------------------------------------------- #
+# Protocol conformance
+# --------------------------------------------------------------------- #
+
+
+def test_adapter_satisfies_datasource_protocol() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    assert isinstance(adapter, DataSource)
+
+
+def test_adapter_exposes_underlying_dataset() -> None:
+    ds = _make_fake_dataset()
+    adapter = MPCODataSourceAdapter(ds)
+    assert adapter.dataset is ds
+
+
+# --------------------------------------------------------------------- #
+# Geometry
+# --------------------------------------------------------------------- #
+
+
+def test_node_coords_full_dataset() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    coords = adapter.node_coords()
+    assert coords.shape == (4, 3)
+    np.testing.assert_allclose(coords[0], [0.0, 0.0, 0.0])
+    np.testing.assert_allclose(coords[3], [0.0, 2.0, 0.5])
+
+
+def test_node_coords_preserves_caller_order() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    coords = adapter.node_coords(np.array([3, 1, 2]))
+    np.testing.assert_allclose(coords[0], [1.0, 2.0, 0.0])  # id=3
+    np.testing.assert_allclose(coords[1], [0.0, 0.0, 0.0])  # id=1
+    np.testing.assert_allclose(coords[2], [1.0, 0.0, 0.0])  # id=2
+
+
+def test_node_coords_empty_id_array_returns_empty() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    coords = adapter.node_coords(np.array([], dtype=np.int64))
+    assert coords.shape == (0, 3)
+
+
+def test_node_coords_raises_on_unknown_id() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    with pytest.raises(KeyError, match="Node id 999"):
+        adapter.node_coords(np.array([1, 999]))
+
+
+def test_node_coords_on_empty_dataset() -> None:
+    fake = _make_fake_dataset(node_rows=[])
+    adapter = MPCODataSourceAdapter(fake)
+    coords = adapter.node_coords()
+    assert coords.shape == (0, 3)
+
+
+def test_element_centroids_full_dataset() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    cents = adapter.element_centroids()
+    assert cents.shape == (4, 3)
+
+
+def test_element_centroids_preserves_caller_order() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    cents = adapter.element_centroids(np.array([12, 10]))
+    np.testing.assert_allclose(cents[0], [0.5, 1.5, 0.25])
+    np.testing.assert_allclose(cents[1], [0.5, 0.0, 0.0])
+
+
+def test_element_centroids_raises_on_unknown_id() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    with pytest.raises(KeyError, match="Element id 999"):
+        adapter.element_centroids(np.array([10, 999]))
+
+
+def test_model_bbox_spans_every_node() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    bbox = adapter.model_bbox()
+    assert bbox == BBox(0.0, 0.0, 0.0, 1.0, 2.0, 0.5)
+
+
+def test_model_bbox_is_cached() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    bbox1 = adapter.model_bbox()
+    bbox2 = adapter.model_bbox()
+    assert bbox1 is bbox2  # cached BBox dataclass, returned by reference
+
+
+def test_model_bbox_on_empty_dataset_is_origin() -> None:
+    fake = _make_fake_dataset(node_rows=[])
+    adapter = MPCODataSourceAdapter(fake)
+    assert adapter.model_bbox() == BBox(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+
+# --------------------------------------------------------------------- #
+# Time axis
+# --------------------------------------------------------------------- #
+
+
+def test_n_steps_default_stage() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset(number_of_steps={"STAGE_0": 5}))
+    assert adapter.n_steps() == 5
+
+
+def test_n_steps_named_stage() -> None:
+    adapter = MPCODataSourceAdapter(
+        _make_fake_dataset(
+            model_stages=["A", "B"],
+            number_of_steps={"A": 2, "B": 7},
+        )
+    )
+    assert adapter.n_steps("A") == 2
+    assert adapter.n_steps("B") == 7
+
+
+def test_n_steps_unknown_stage_raises() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    with pytest.raises(KeyError, match="MISSING"):
+        adapter.n_steps("MISSING")
+
+
+def test_time_returns_step_ascending_values() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    t = adapter.time()
+    np.testing.assert_allclose(t, [0.0, 0.1, 0.2])
+
+
+def test_time_unknown_stage_raises() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    with pytest.raises(KeyError, match="MISSING"):
+        adapter.time("MISSING")
+
+
+# --------------------------------------------------------------------- #
+# Selection resolution — empty / id-only specs
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_node_ids_empty_spec_returns_all_nodes() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    out = adapter.resolve_node_ids(SelectionSpec.empty())
+    np.testing.assert_array_equal(out, [1, 2, 3, 4])
+
+
+def test_resolve_element_ids_empty_spec_returns_all_elements() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    out = adapter.resolve_element_ids(SelectionSpec.empty())
+    np.testing.assert_array_equal(out, [10, 11, 12, 13])
+
+
+def test_resolve_node_ids_by_explicit_ids() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(node_ids=(2, 4))
+    np.testing.assert_array_equal(adapter.resolve_node_ids(spec), [2, 4])
+
+
+def test_resolve_node_ids_drops_ids_not_in_dataset() -> None:
+    """Resolver is best-effort; explicit ids missing from the model drop out."""
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(node_ids=(2, 999))
+    np.testing.assert_array_equal(adapter.resolve_node_ids(spec), [2])
+
+
+def test_resolve_element_ids_by_explicit_ids() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(element_ids=(10, 12))
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [10, 12])
+
+
+# --------------------------------------------------------------------- #
+# Selection resolution — element_type filter
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_element_ids_by_element_type_base() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(element_type="203-ASDShellQ4")
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [11, 12])
+
+
+def test_resolve_element_ids_by_element_type_decorated() -> None:
+    """The decorated form ``...[4n]`` matches the base type the same way."""
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(element_type="203-ASDShellQ4[4n]")
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [11, 12])
+
+
+def test_resolve_element_ids_by_element_type_multiple() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(element_type=("203-ASDShellQ4", "5-ElasticBeam3d"))
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [10, 11, 12])
+
+
+def test_resolve_element_ids_combines_type_and_ids_via_and() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(
+        element_type="203-ASDShellQ4",
+        element_ids=(11, 13),  # 13 is a Brick — should drop out
+    )
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [11])
+
+
+# --------------------------------------------------------------------- #
+# Selection resolution — named sets
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_node_ids_via_selection_set_name() -> None:
+    resolver = _FakeResolver(node_sets={"slab": [1, 2, 3]})
+    adapter = MPCODataSourceAdapter(_make_fake_dataset(resolver=resolver))
+    spec = SelectionSpec(selection_set_name="slab")
+    np.testing.assert_array_equal(adapter.resolve_node_ids(spec), [1, 2, 3])
+
+
+def test_resolve_element_ids_via_selection_set_id() -> None:
+    resolver = _FakeResolver(elem_sets={"#7": [11, 12]})
+    adapter = MPCODataSourceAdapter(_make_fake_dataset(resolver=resolver))
+    spec = SelectionSpec(selection_set_id=7)
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [11, 12])
+
+
+def test_resolve_combines_selection_set_with_explicit_ids_via_and() -> None:
+    resolver = _FakeResolver(node_sets={"slab": [1, 2, 3]})
+    adapter = MPCODataSourceAdapter(_make_fake_dataset(resolver=resolver))
+    spec = SelectionSpec(selection_set_name="slab", node_ids=(2, 3, 4))
+    # 4 is in the dataset but not in the slab set → dropped.
+    # 1 is in the slab set but not in the explicit list → dropped.
+    np.testing.assert_array_equal(adapter.resolve_node_ids(spec), [2, 3])
+
+
+def test_node_resolution_ignores_element_only_fields() -> None:
+    """``element_type`` is element-only — passing it to a node query is a no-op."""
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(node_ids=(1, 2), element_type="203-ASDShellQ4")
+    np.testing.assert_array_equal(adapter.resolve_node_ids(spec), [1, 2])
+
+
+def test_element_resolution_ignores_node_only_fields() -> None:
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec(element_ids=(10, 11), node_ids=(1,))
+    np.testing.assert_array_equal(adapter.resolve_element_ids(spec), [10, 11])
+
+
+# --------------------------------------------------------------------- #
+# Caching behavior
+# --------------------------------------------------------------------- #
+
+
+def test_selection_results_are_cached_per_spec() -> None:
+    """A repeated selection skips the resolver — pin the cache contract.
+
+    Mutating the underlying resolver between calls would normally
+    change the answer; the cache keeps the first answer.
+    """
+    resolver = _FakeResolver(node_sets={"slab": [1, 2, 3]})
+    adapter = MPCODataSourceAdapter(_make_fake_dataset(resolver=resolver))
+    spec = SelectionSpec(selection_set_name="slab")
+    first = adapter.resolve_node_ids(spec)
+    resolver._node_sets["slab"] = [4]  # would change the answer if not cached
+    second = adapter.resolve_node_ids(spec)
+    np.testing.assert_array_equal(first, second)
+
+
+def test_selection_result_is_a_defensive_copy() -> None:
+    """Callers may mutate; the cached array must not change."""
+    adapter = MPCODataSourceAdapter(_make_fake_dataset())
+    spec = SelectionSpec.empty()
+    out1 = adapter.resolve_node_ids(spec)
+    out1[0] = -1
+    out2 = adapter.resolve_node_ids(spec)
+    np.testing.assert_array_equal(out2, [1, 2, 3, 4])
+
+
+# --------------------------------------------------------------------- #
+# Real-fixture smoke test — guards the actual MPCODataSet contract.
+# --------------------------------------------------------------------- #
+
+
+def test_adapter_against_elastic_frame_fixture(elastic_frame_dir: Path) -> None:
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    adapter = MPCODataSourceAdapter(ds)
+
+    # Protocol conformance against the live dataset.
+    assert isinstance(adapter, DataSource)
+    assert adapter.dataset is ds
+
+    # Geometry consistency with the dataset's own info dicts.
+    nodes_df = ds.nodes_info["dataframe"]
+    elements_df = ds.elements_info["dataframe"]
+    coords = adapter.node_coords()
+    assert coords.shape == (len(nodes_df), 3)
+    np.testing.assert_allclose(
+        coords, nodes_df[["x", "y", "z"]].to_numpy(dtype=np.float64)
+    )
+    centroids = adapter.element_centroids()
+    assert centroids.shape == (len(elements_df), 3)
+
+    # Subset lookup preserves caller order.
+    ids = nodes_df["node_id"].to_numpy()[:3][::-1]
+    sub = adapter.node_coords(ids)
+    np.testing.assert_allclose(
+        sub,
+        nodes_df.set_index("node_id").loc[ids, ["x", "y", "z"]].to_numpy(
+            dtype=np.float64
+        ),
+    )
+
+    # Model bbox tracks the node table.
+    bbox = adapter.model_bbox()
+    assert bbox.x_min == pytest.approx(float(nodes_df["x"].min()))
+    assert bbox.z_max == pytest.approx(float(nodes_df["z"].max()))
+
+    # Time axis matches the dataset.
+    stage0 = ds.model_stages[0]
+    assert adapter.n_steps() == int(ds.number_of_steps[stage0])
+    np.testing.assert_allclose(
+        adapter.time(), ds.time.loc[stage0]["TIME"].to_numpy(dtype=np.float64)
+    )
+
+    # Empty spec yields every entity, sorted ascending.
+    all_nodes = adapter.resolve_node_ids(SelectionSpec.empty())
+    np.testing.assert_array_equal(
+        all_nodes, np.sort(nodes_df["node_id"].to_numpy(dtype=np.int64))
+    )
+    all_elems = adapter.resolve_element_ids(SelectionSpec.empty())
+    np.testing.assert_array_equal(
+        all_elems, np.sort(elements_df["element_id"].to_numpy(dtype=np.int64))
+    )
+
+    # element_type filter matches the existing ``ds.plot.mesh`` semantics.
+    beam_ids_via_adapter = adapter.resolve_element_ids(
+        SelectionSpec(element_type="5-ElasticBeam3d")
+    )
+    beam_ids_expected = elements_df.loc[
+        elements_df["element_type"].str.startswith("5-ElasticBeam3d"), "element_id"
+    ].to_numpy(dtype=np.int64)
+    np.testing.assert_array_equal(beam_ids_via_adapter, np.sort(beam_ids_expected))


### PR DESCRIPTION
## Summary

- Concrete `DataSource` adapter wrapping `MPCODataSet` — the single boundary between viewer code and STKO's pandas DataFrame world. Phase 2.3 of the [viewer roadmap](docs/viewer/00-roadmap.md).
- Implements every method on the protocol declared in [`viewer/core/datasource.py`](src/STKO_to_python/viewer/core/datasource.py): geometry (`node_coords`, `element_centroids`, `model_bbox`), time axis (`n_steps`, `time`), and selection resolution (`resolve_node_ids`, `resolve_element_ids`).
- Selection sets, explicit IDs, and `element_type` filters are AND-combined per [`SelectionSpec`](src/STKO_to_python/viewer/core/selection.py); name/id lookups route through `ds._selection_resolver` so the `.cdata` parse fires only when a selection-set-based query actually needs it.
- Resolved selections are cached per-`(kind, SelectionSpec)` (the spec is already frozen + hashable) so a layer that re-asks across steps pays the resolver cost once. Returns are defensive copies.

## Design notes

- `node_coords(ids=...)` / `element_centroids(ids=...)` preserve the caller's order and raise `KeyError` on unknown IDs — they're strict lookups. By contrast, `resolve_node_ids` / `resolve_element_ids` are best-effort: explicit IDs missing from the model drop out via the universe intersect.
- Default stage everywhere is `ds.model_stages[0]`, matching the `stage0` convention used elsewhere in the codebase.
- `element_type` matches on the base prefix (split on `[`), parallel to `ds.plot.mesh`'s `element_type` kwarg, so both `"203-ASDShellQ4"` and `"203-ASDShellQ4[4n]"` select the same elements.

## Test plan

- [x] 35 new tests in [`tests/viewer/core/test_mpco_adapter.py`](tests/viewer/core/test_mpco_adapter.py): fake-dataset unit tests for every adapter branch (geometry, time, selection, caching, AND-combine, element_type variants) plus a real-fixture smoke test against `elastic_frame_dir` that pins the live `MPCODataSet` attribute contract.
- [x] Full viewer suite: 220 passed, 2 skipped (extras-gated).

## What's next

Phase 2.4 lands `MeshLayer` and rewires `ds.plot.mesh()` byte-identically through `Scene` / `MeshLayer` / `MplBackend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)