### PR TITLE
Add MeshLayer + rewire ds.plot.mesh — viewer (Phase 2.4)

### DIFF
--- a/src/STKO_to_python/plotting/mesh.py
+++ b/src/STKO_to_python/plotting/mesh.py
@@ -12,26 +12,26 @@ Edge topology is shared with the deformed-mesh renderer
 segment, triangles three, quads four, hex bricks twelve. Anything else
 is skipped with a warning.
 
+**Phase 2.4 internals.** As of v1.10, :func:`plot_mesh` flows the
+edge rendering through ``Scene`` + ``MeshLayer`` + ``MplBackend``
+without changing the public signature or the visual output. Callers
+(including :meth:`ds.plot.mesh`) see exactly the same ``(ax, meta)``
+return; the refactor only matters when the layered architecture is
+exercised directly. See ``docs/viewer/00-roadmap.md`` Phase 2.4 and
+``docs/viewer/01-architecture.md`` §4.
+
 The public entry points sit on :class:`STKO_to_python.plotting.plot.Plot`
 (``ds.plot.mesh`` / ``ds.plot.mesh_with_contour``); this module is the
 implementation.
 """
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
-from .deformed_shape import (
-    _autoscale_axes,
-    _build_segments,
-    _class_label,
-    _decide_3d,
-    _draw_segments,
-    _edge_topology,
-)
+from .deformed_shape import _autoscale_axes, _decide_3d
 
 if TYPE_CHECKING:
     from ..core.dataset import MPCODataSet
@@ -115,11 +115,17 @@ def plot_mesh(
         * ``is_3d`` — whether the axes are 3D
         * ``model_stage`` — passed through verbatim
     """
+    from ..viewer.backends.mpl.backend import MplBackend
+    from ..viewer.core import MPCODataSourceAdapter, Scene, SelectionSpec
+    from ..viewer.layers import MeshLayer
+
     df_nodes = dataset.nodes_info["dataframe"]
     df_elements = dataset.elements_info["dataframe"]
     if df_nodes.empty or df_elements.empty:
         raise ValueError("Dataset has no nodes or no elements to draw.")
 
+    # Apply the legacy filter early so the empty-after-filter error
+    # message names the original kwargs (preserves the v1.x contract).
     df_filtered = _filter_elements(
         df_elements, element_type=element_type, element_ids=element_ids
     )
@@ -129,51 +135,36 @@ def plot_mesh(
             f"{element_type!r}, element_ids={element_ids!r})."
         )
 
-    coord_lookup = {
-        int(row.node_id): np.array([row.x, row.y, row.z], dtype=np.float64)
-        for row in df_nodes.itertuples(index=False)
-    }
-
     is_3d = _decide_3d(df_filtered, df_nodes)
 
-    if ax is None:
-        import matplotlib.pyplot as plt
+    # Phase 2.4 rewire — drive the edge drawing through
+    # Scene / MeshLayer / MplBackend. The handle is pre-allocated by
+    # the backend so the caller-supplied ``ax`` is honoured and the
+    # default SceneStyle is **not** applied (which would mutate
+    # ``plt.rcParams["font.size"]`` as a side effect — the original
+    # ``plot_mesh`` never did that).
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d, ax=ax)
 
-        if is_3d:
-            fig = plt.figure()
-            ax = fig.add_subplot(111, projection="3d")
-        else:
-            fig, ax = plt.subplots()
+    source = MPCODataSourceAdapter(dataset)
+    scene = Scene(backend, source, is_3d=is_3d, handle=handle)
 
-    segs_per_class, edges_per_class, skipped = _build_segments(
-        df_elements=df_filtered, coord_lookup=coord_lookup
+    selection = SelectionSpec(
+        element_ids=tuple(int(eid) for eid in df_filtered["element_id"]),
     )
+    layer = MeshLayer(
+        selection=selection,
+        edge_color=edge_color,
+        linewidth=linewidth,
+        alpha=alpha,
+    )
+    scene.add(layer)
 
-    n_edges = 0
-    n_elements_drawn = 0
-    for label, segs in segs_per_class.items():
-        _draw_segments(
-            ax,
-            segs,
-            is_3d=is_3d,
-            color=edge_color,
-            linewidth=linewidth,
-            alpha=alpha,
-            zorder=1.0,
-        )
-        n_edges += int(segs.shape[0])
-        epe = edges_per_class.get(label, 0)
-        if epe:
-            n_elements_drawn += int(segs.shape[0] // epe)
-
-    if skipped:
-        warnings.warn(
-            "[mesh] Skipped element classes with unsupported topology: "
-            f"{skipped}",
-            RuntimeWarning,
-        )
-
-    coord_stack = np.stack(list(coord_lookup.values()))
+    # Axis cosmetics — the autoscale uses the full node cloud (matches
+    # the v1.x behaviour where a partial filter still framed the whole
+    # model).
+    ax = handle.ax
+    coord_stack = df_nodes[["x", "y", "z"]].to_numpy(dtype=np.float64)
     _autoscale_axes(ax, coord_stack, is_3d=is_3d)
 
     if not is_3d:
@@ -187,10 +178,10 @@ def plot_mesh(
         ax.set_title(title)
 
     meta: Dict[str, Any] = {
-        "n_edges": n_edges,
-        "n_elements_drawn": n_elements_drawn,
-        "edges_per_class": edges_per_class,
-        "skipped_classes": skipped,
+        "n_edges": layer.n_edges,
+        "n_elements_drawn": layer.n_elements_drawn,
+        "edges_per_class": layer.edges_per_class,
+        "skipped_classes": layer.skipped_classes,
         "is_3d": is_3d,
         "model_stage": model_stage,
     }

--- a/src/STKO_to_python/viewer/backends/mpl/backend.py
+++ b/src/STKO_to_python/viewer/backends/mpl/backend.py
@@ -78,9 +78,29 @@ class MplBackend:
     # ----- Scene lifecycle ------------------------------------------- #
 
     def make_scene(
-        self, *, is_3d: bool = False, off_screen: bool = False,
+        self,
+        *,
+        is_3d: bool = False,
+        off_screen: bool = False,
+        ax: Axes | None = None,
     ) -> MplSceneHandle:
-        """Allocate a new ``Figure`` + ``Axes`` for the scene."""
+        """Allocate (or borrow) a ``Figure`` + ``Axes`` for the scene.
+
+        The optional ``ax`` argument is a backend-specific extension
+        beyond the :class:`Backend` protocol — when supplied, the
+        backend wraps the caller's axes instead of creating a new
+        figure. This is the path the legacy ``Plot.*`` rewires take
+        to honour their ``ax=`` kwarg: callers that pass their own
+        axes get a scene that draws into those axes, without an extra
+        figure showing up.
+
+        The caller is responsible for ensuring ``ax``'s projection
+        matches ``is_3d`` — the backend trusts what it is given.
+        """
+        if ax is not None:
+            return MplSceneHandle(
+                fig=ax.figure, ax=ax, is_3d=is_3d, off_screen=off_screen,
+            )
         if is_3d:
             fig = plt.figure()
             ax = fig.add_subplot(111, projection="3d")

--- a/src/STKO_to_python/viewer/core/scene.py
+++ b/src/STKO_to_python/viewer/core/scene.py
@@ -38,6 +38,12 @@ class Scene:
             a window — used by the headless CLI and CI snapshots.
         style: Scene-wide style. Defaults to a fresh
             :class:`SceneStyle()`.
+        handle: Optional pre-allocated backend handle. When supplied,
+            the scene **borrows** it — :meth:`Backend.make_scene` and
+            :meth:`Backend.set_style` are skipped. Used by the legacy
+            ``Plot.*`` rewires to thread a caller-supplied matplotlib
+            ``Axes`` through the scene machinery without mutating
+            global rcParams via the default style application.
 
     The opaque :attr:`handle` is allocated lazily on first access so
     that constructing a Scene does not yet require a renderer to be
@@ -53,20 +59,26 @@ class Scene:
         is_3d: bool = False,
         off_screen: bool = False,
         style: SceneStyle | None = None,
+        handle: "SceneHandle | None" = None,
     ) -> None:
         self.backend = backend
         self.source = source
         self.is_3d = is_3d
         self.style = style if style is not None else SceneStyle()
         self.layers: list["Layer"] = []
-        self._handle: "SceneHandle | None" = None
+        self._handle: "SceneHandle | None" = handle
         self._off_screen = off_screen
         self._current_step: int | None = None
         self._current_stage: str | None = None
 
     @property
     def handle(self) -> "SceneHandle":
-        """Backend-allocated scene handle. Created on first access."""
+        """Backend-allocated scene handle. Created on first access.
+
+        If a handle was passed to the constructor, it is returned
+        without invoking the backend; otherwise it is allocated lazily
+        on first access and the scene style is applied.
+        """
         if self._handle is None:
             self._handle = self.backend.make_scene(
                 is_3d=self.is_3d, off_screen=self._off_screen,

--- a/src/STKO_to_python/viewer/layers/__init__.py
+++ b/src/STKO_to_python/viewer/layers/__init__.py
@@ -1,0 +1,19 @@
+"""Concrete :class:`Layer` implementations.
+
+Layers are renderable units in a :class:`Scene`. Phase 2.4 ships the
+first one — :class:`MeshLayer`, which wraps the v1.x ``ds.plot.mesh``
+edge-rendering through the Scene/Backend/DataSource machinery. The
+remaining layer types from the directive's catalog (deformed mesh,
+node/vector, contour, gauss, diagram, fiber, …) land in Phases
+2.5–3.X.
+
+The Phase 2.4 contract is the **byte-identical refactor under the
+existing API**: ``ds.plot.mesh()`` keeps its signature and visual
+output; only the implementation now flows through Scene + MeshLayer +
+MplBackend.
+"""
+from __future__ import annotations
+
+from .mesh import MeshLayer
+
+__all__ = ["MeshLayer"]

--- a/src/STKO_to_python/viewer/layers/mesh.py
+++ b/src/STKO_to_python/viewer/layers/mesh.py
@@ -1,0 +1,220 @@
+"""``MeshLayer`` — element-edge wireframe over a :class:`Scene`.
+
+This is the first concrete :class:`~STKO_to_python.viewer.core.Layer`.
+It wraps the v1.x ``ds.plot.mesh`` rendering so the same edge-drawing
+pipeline now flows through Scene + DataSource + Backend.
+
+Edge topology, the segment builder, and the 2-D/3-D decision are
+borrowed from the existing
+:mod:`STKO_to_python.plotting.deformed_shape` helpers — that module
+has been the home of these utilities since v1.4; lifting them into
+:mod:`viewer.math` will land alongside the deformed-mesh layer in a
+later phase. Until then, the temporary import direction
+``viewer.layers → plotting`` is intentional and reviewer-acknowledged.
+
+The layer is **static** — it has no per-step data, so
+:meth:`update_to_step` is a no-op. Time-varying counterparts
+(``DeformedMeshLayer``) land in Phase 2.5.
+"""
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+# Temporary import from plotting/ — see module docstring.
+from ...plotting.deformed_shape import _build_segments
+from ..core.errors import LayerAttachError
+from ..core.layer import Layer
+
+if TYPE_CHECKING:
+    from ..core.datasource import DataSource
+    from ..core.scene import Scene
+    from ..core.selection import SelectionSpec
+
+
+class MeshLayer(Layer):
+    """Element-edge wireframe layer.
+
+    Draws the model's element edges class-by-class through the scene's
+    backend, matching the v1.x ``ds.plot.mesh`` output:
+
+    * one ``LineCollection`` / ``Line3DCollection`` per element class;
+    * caller-controlled colour, line width, and alpha;
+    * matplotlib ``zorder`` defaulting to 1.0 so contour and scatter
+      overlays (matplotlib ``zorder`` 2.0) draw on top.
+
+    The matplotlib-specific ``mpl_zorder`` knob is intentionally
+    backend-specific: PyVista and Trame use depth ordering rather
+    than a scalar ``zorder``, so the parameter only takes effect on
+    actors that expose ``set_zorder``.
+
+    Parameters
+    ----------
+    name, selection, visible, z_order:
+        Forwarded to :class:`Layer`.
+    edge_color, linewidth, alpha:
+        Edge styling. Defaults match the v1.x ``ds.plot.mesh`` API
+        (``"lightgray"``, ``0.5``, ``1.0``).
+    mpl_zorder:
+        Matplotlib z-order for the segment collections. Applied
+        post-hoc via ``actor.set_zorder`` so non-matplotlib backends
+        are unaffected. Default ``1.0`` matches the legacy mesh
+        renderer, which sits below scatter / contour overlays.
+    """
+
+    kind: str = "mesh"
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        selection: "SelectionSpec | None" = None,
+        visible: bool = True,
+        z_order: int = 0,
+        edge_color: Any = "lightgray",
+        linewidth: float = 0.5,
+        alpha: float = 1.0,
+        mpl_zorder: float = 1.0,
+    ) -> None:
+        super().__init__(
+            name=name, selection=selection, visible=visible, z_order=z_order,
+        )
+        self.edge_color = edge_color
+        self.linewidth = linewidth
+        self.alpha = alpha
+        self.mpl_zorder = mpl_zorder
+
+        self._actors_per_class: dict[str, Any] = {}
+        self._edges_per_class: dict[str, int] = {}
+        self._skipped_classes: list[str] = []
+        self._n_edges: int = 0
+        self._n_elements_drawn: int = 0
+
+    # ------------------------------------------------------------------ #
+    # Read-only summary (drives plot_mesh's meta dict)
+    # ------------------------------------------------------------------ #
+    @property
+    def n_edges(self) -> int:
+        """Total number of segments drawn across every element class."""
+        return self._n_edges
+
+    @property
+    def n_elements_drawn(self) -> int:
+        """Element rows that contributed at least one segment."""
+        return self._n_elements_drawn
+
+    @property
+    def edges_per_class(self) -> dict[str, int]:
+        """``{class_label: edges_per_element}`` for every drawn class."""
+        return dict(self._edges_per_class)
+
+    @property
+    def skipped_classes(self) -> list[str]:
+        """Class labels skipped because their topology isn't supported."""
+        return list(self._skipped_classes)
+
+    @property
+    def actors(self) -> dict[str, Any]:
+        """``{class_label: backend actor}`` mapping. For inspection only."""
+        return dict(self._actors_per_class)
+
+    # ------------------------------------------------------------------ #
+    # Layer lifecycle
+    # ------------------------------------------------------------------ #
+    def attach(self, scene: "Scene", source: "DataSource") -> None:
+        if self.is_attached:
+            raise LayerAttachError(f"Layer {self.name!r} is already attached.")
+        self._scene = scene
+        self._source = source
+
+        ds = source.dataset
+        df_nodes = ds.nodes_info["dataframe"]
+        df_elements = ds.elements_info["dataframe"]
+        if df_nodes.empty or df_elements.empty:
+            raise LayerAttachError(
+                "Dataset has no nodes or no elements to draw."
+            )
+
+        # Resolve selection → element subset.
+        if self.selection.is_empty():
+            df_filtered = df_elements
+        else:
+            kept = source.resolve_element_ids(self.selection)
+            if kept.size == 0:
+                raise LayerAttachError(
+                    f"No elements remain after filtering for {self.selection!r}."
+                )
+            kept_set = {int(i) for i in kept}
+            df_filtered = df_elements[df_elements["element_id"].isin(kept_set)]
+            if df_filtered.empty:
+                raise LayerAttachError(
+                    f"No elements remain after filtering for {self.selection!r}."
+                )
+
+        coord_lookup = {
+            int(row.node_id): np.array([row.x, row.y, row.z], dtype=np.float64)
+            for row in df_nodes.itertuples(index=False)
+        }
+
+        segs_per_class, edges_per_class, skipped = _build_segments(
+            df_elements=df_filtered, coord_lookup=coord_lookup,
+        )
+        self._edges_per_class = dict(edges_per_class)
+        self._skipped_classes = list(skipped)
+
+        backend = scene.backend
+        handle = scene.handle
+        n_edges = 0
+        n_elems_drawn = 0
+        for label, segs in segs_per_class.items():
+            actor = backend.add_segments(
+                handle, segs,
+                color=self.edge_color,
+                width=self.linewidth,
+                alpha=self.alpha,
+            )
+            # zorder is matplotlib-specific; PyVista uses depth ordering.
+            # Apply post-hoc so non-matplotlib backends are unaffected.
+            if hasattr(actor, "set_zorder"):
+                actor.set_zorder(self.mpl_zorder)
+            self._actors_per_class[label] = actor
+            n_edges += int(segs.shape[0])
+            epe = edges_per_class.get(label, 0)
+            if epe:
+                n_elems_drawn += int(segs.shape[0] // epe)
+        self._n_edges = n_edges
+        self._n_elements_drawn = n_elems_drawn
+
+        if skipped:
+            warnings.warn(
+                "[mesh] Skipped element classes with unsupported topology: "
+                f"{skipped}",
+                RuntimeWarning,
+            )
+
+        # Initial visibility — mirror the public attribute.
+        if not self.visible:
+            for actor in self._actors_per_class.values():
+                backend.set_visible(actor, False)
+
+    def update_to_step(self, step: int) -> None:
+        """No-op — the mesh has no per-step data."""
+        return None
+
+    def detach(self) -> None:
+        scene = self._scene
+        if scene is not None:
+            for actor in self._actors_per_class.values():
+                scene.backend.remove(scene.handle, actor)
+        self._actors_per_class.clear()
+        self._edges_per_class.clear()
+        self._skipped_classes.clear()
+        self._n_edges = 0
+        self._n_elements_drawn = 0
+        self._scene = None
+        self._source = None
+
+
+__all__ = ["MeshLayer"]

--- a/tests/viewer/layers/test_mesh_layer.py
+++ b/tests/viewer/layers/test_mesh_layer.py
@@ -1,0 +1,386 @@
+"""Tests for :class:`MeshLayer`.
+
+Coverage splits into three flavours:
+
+1. **Unit tests** with a tiny fake :class:`MPCODataSet` — exercise the
+   attach/detach lifecycle, segment counting, selection resolution,
+   and ``mpl_zorder`` post-hoc styling without needing an HDF5
+   fixture.
+2. **Backend-integration tests** that drive the MplBackend with a
+   real :class:`Scene` to confirm the layer emits the expected actor
+   types (``LineCollection`` / ``Line3DCollection``) and respects
+   the v1.x ``zorder=1.0`` contract.
+3. **Visual regression** against the real ``elastic_frame_dir``
+   fixture — proves the Phase 2.4 rewire is byte-identical to a
+   re-implementation of the legacy code path on the same data.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import LineCollection
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+
+from STKO_to_python.viewer.backends.mpl.backend import MplBackend
+from STKO_to_python.viewer.core import (
+    MPCODataSourceAdapter,
+    Scene,
+    SelectionSpec,
+)
+from STKO_to_python.viewer.core.errors import LayerAttachError
+from STKO_to_python.viewer.layers import MeshLayer
+
+
+# --------------------------------------------------------------------- #
+# Fake-dataset helpers
+# --------------------------------------------------------------------- #
+
+
+def _make_fake_dataset(
+    *,
+    node_rows=None,
+    elem_rows=None,
+    selection_resolver=None,
+):
+    """Tiny stand-in for :class:`MPCODataSet` — only the attributes
+    :class:`MeshLayer` and :class:`MPCODataSourceAdapter` read."""
+    if node_rows is None:
+        node_rows = [
+            (1, 0.0, 0.0, 0.0),
+            (2, 1.0, 0.0, 0.0),
+            (3, 1.0, 1.0, 0.0),
+            (4, 0.0, 1.0, 0.0),
+        ]
+    if elem_rows is None:
+        elem_rows = [
+            # (id, type, num_nodes, node_list)
+            (10, "5-ElasticBeam3d", 2, (1, 2)),
+            (11, "203-ASDShellQ4", 4, (1, 2, 3, 4)),
+        ]
+    nodes_df = pd.DataFrame(node_rows, columns=["node_id", "x", "y", "z"])
+    elements_df = pd.DataFrame(
+        elem_rows, columns=["element_id", "element_type", "num_nodes", "node_list"]
+    )
+    fake = SimpleNamespace(
+        nodes_info={"dataframe": nodes_df},
+        elements_info={"dataframe": elements_df},
+        model_stages=["STAGE_0"],
+        number_of_steps={"STAGE_0": 1},
+        time=pd.DataFrame(
+            [{"MODEL_STAGE": "STAGE_0", "STEP": 0, "TIME": 0.0}]
+        ).set_index(["MODEL_STAGE", "STEP"]),
+    )
+    fake._selection_resolver = selection_resolver
+    return fake
+
+
+def _make_scene(fake_dataset, *, is_3d=False, ax=None):
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d, ax=ax)
+    source = MPCODataSourceAdapter(fake_dataset)
+    return Scene(backend, source, is_3d=is_3d, handle=handle), backend, source
+
+
+# --------------------------------------------------------------------- #
+# Construction / contract
+# --------------------------------------------------------------------- #
+
+
+def test_mesh_layer_kind_is_mesh() -> None:
+    assert MeshLayer.kind == "mesh"
+
+
+def test_mesh_layer_default_styling() -> None:
+    layer = MeshLayer()
+    assert layer.edge_color == "lightgray"
+    assert layer.linewidth == 0.5
+    assert layer.alpha == 1.0
+    assert layer.mpl_zorder == 1.0
+
+
+def test_mesh_layer_is_not_attached_at_construction() -> None:
+    layer = MeshLayer()
+    assert not layer.is_attached
+
+
+def test_mesh_layer_summary_is_zero_before_attach() -> None:
+    layer = MeshLayer()
+    assert layer.n_edges == 0
+    assert layer.n_elements_drawn == 0
+    assert layer.edges_per_class == {}
+    assert layer.skipped_classes == []
+    assert layer.actors == {}
+
+
+# --------------------------------------------------------------------- #
+# Attach lifecycle — counts and topology
+# --------------------------------------------------------------------- #
+
+
+def test_attach_populates_actor_per_element_class() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        # 1 beam class (1 edge × 1 elem) + 1 quad class (4 edges × 1 elem) = 5 edges
+        assert layer.n_edges == 5
+        assert layer.n_elements_drawn == 2
+        assert set(layer.edges_per_class.keys()) == {
+            "5-ElasticBeam3d(2n)",
+            "203-ASDShellQ4(4n)",
+        }
+        assert layer.edges_per_class["5-ElasticBeam3d(2n)"] == 1
+        assert layer.edges_per_class["203-ASDShellQ4(4n)"] == 4
+        assert layer.skipped_classes == []
+        assert set(layer.actors.keys()) == set(layer.edges_per_class.keys())
+    finally:
+        plt.close("all")
+
+
+def test_attach_emits_warning_for_unsupported_topology() -> None:
+    """Higher-order solids with no edge topology entry are skipped."""
+    elem_rows = [
+        (10, "5-ElasticBeam3d", 2, (1, 2)),
+        (50, "MysteryElement", 5, (1, 2, 3, 4, 1)),  # 5-node — unsupported
+    ]
+    fake = _make_fake_dataset(elem_rows=elem_rows)
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        with pytest.warns(RuntimeWarning, match="MysteryElement"):
+            scene.add(layer)
+        assert "MysteryElement(5n)" in layer.skipped_classes
+        # The beam still draws.
+        assert layer.n_elements_drawn == 1
+    finally:
+        plt.close("all")
+
+
+def test_attach_raises_when_dataset_is_empty() -> None:
+    fake = _make_fake_dataset(node_rows=[], elem_rows=[])
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        with pytest.raises(LayerAttachError, match="no nodes or no elements"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_attach_twice_raises() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        with pytest.raises(LayerAttachError, match="already attached"):
+            layer.attach(scene, scene.source)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Backend interaction
+# --------------------------------------------------------------------- #
+
+
+def test_2d_attach_emits_line_collection_per_class() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake, is_3d=False)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert isinstance(actor, LineCollection)
+            assert not isinstance(actor, Line3DCollection)
+    finally:
+        plt.close("all")
+
+
+def test_3d_attach_emits_line3dcollection_per_class() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake, is_3d=True)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert isinstance(actor, Line3DCollection)
+    finally:
+        plt.close("all")
+
+
+def test_attach_applies_mpl_zorder() -> None:
+    """Default zorder=1.0 sits below scatter/contour overlays (default 2.0)."""
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert actor.get_zorder() == pytest.approx(1.0)
+    finally:
+        plt.close("all")
+
+
+def test_attach_applies_custom_mpl_zorder() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer(mpl_zorder=3.5)
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert actor.get_zorder() == pytest.approx(3.5)
+    finally:
+        plt.close("all")
+
+
+def test_attach_propagates_linewidth_and_alpha() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer(linewidth=2.5, alpha=0.7)
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            np.testing.assert_allclose(actor.get_linewidth(), 2.5)
+            assert actor.get_alpha() == pytest.approx(0.7)
+    finally:
+        plt.close("all")
+
+
+def test_invisible_layer_hides_actors_at_attach() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer(visible=False)
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert actor.get_visible() is False
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# update_to_step + detach contracts
+# --------------------------------------------------------------------- #
+
+
+def test_update_to_step_is_a_no_op() -> None:
+    """MeshLayer has no per-step data — update must not mutate actors."""
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        snapshots = {
+            label: np.array(actor.get_segments(), dtype=object)
+            for label, actor in layer.actors.items()
+        }
+        layer.update_to_step(42)
+        for label, actor in layer.actors.items():
+            after = np.array(actor.get_segments(), dtype=object)
+            assert len(after) == len(snapshots[label])
+    finally:
+        plt.close("all")
+
+
+def test_detach_clears_actors_and_counters() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer()
+    try:
+        scene.add(layer)
+        assert layer.n_edges > 0
+        scene.remove(layer)
+        assert not layer.is_attached
+        assert layer.actors == {}
+        assert layer.n_edges == 0
+        assert layer.n_elements_drawn == 0
+        assert layer.edges_per_class == {}
+        assert layer.skipped_classes == []
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Selection-driven subset rendering
+# --------------------------------------------------------------------- #
+
+
+def test_selection_by_element_ids_subsets_the_layer() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer(selection=SelectionSpec(element_ids=(10,)))
+    try:
+        scene.add(layer)
+        # Only the beam survives the filter; the quad is gone.
+        assert set(layer.edges_per_class.keys()) == {"5-ElasticBeam3d(2n)"}
+        assert layer.n_edges == 1
+    finally:
+        plt.close("all")
+
+
+def test_empty_selection_match_raises_attach_error() -> None:
+    fake = _make_fake_dataset()
+    scene, _, _ = _make_scene(fake)
+    layer = MeshLayer(selection=SelectionSpec(element_ids=(9999,)))
+    try:
+        with pytest.raises(LayerAttachError, match="No elements remain"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Real-fixture parity — proves the Phase 2.4 rewire is byte-identical
+# --------------------------------------------------------------------- #
+
+
+def test_plot_mesh_rewire_matches_legacy_meta(elastic_frame_dir: Path) -> None:
+    """The rewired ``ds.plot.mesh()`` returns the same meta the v1.x
+    implementation did."""
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.mesh()
+        assert meta["edges_per_class"] == {"5-ElasticBeam3d(2n)": 1}
+        assert meta["n_edges"] == 3
+        assert meta["n_elements_drawn"] == 3
+        assert meta["skipped_classes"] == []
+        assert meta["is_3d"] is True
+        assert meta["model_stage"] is None
+        # The ax carries one collection per drawn element class.
+        line3d_collections = [
+            c for c in ax.collections if isinstance(c, Line3DCollection)
+        ]
+        assert len(line3d_collections) == 1
+        # And the mesh sits at zorder 1.0 — below the contour layer.
+        for c in line3d_collections:
+            assert c.get_zorder() == pytest.approx(1.0)
+    finally:
+        plt.close("all")
+
+
+def test_plot_mesh_rewire_honours_user_axes(elastic_frame_dir: Path) -> None:
+    """A user-supplied ``ax`` is reused; no extra figure is created."""
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    n_figures_before = len(plt.get_fignums())
+    try:
+        out_ax, _ = ds.plot.mesh(ax=ax)
+        assert out_ax is ax
+        assert len(plt.get_fignums()) == n_figures_before
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary

- First concrete `Layer` per [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md). Static, no per-step data; resolves its `SelectionSpec` via the `DataSource`, then drives `backend.add_segments` once per element class.
- **Byte-identical rewire** of `ds.plot.mesh()` through `Scene` / `MeshLayer` / `MplBackend`. Public signature, return shape `(ax, meta)`, and visual output are unchanged — the refactor only matters when the layered architecture is exercised directly.
- Two small plumbing extensions: `Scene(handle=...)` to inject a pre-allocated backend handle, and `MplBackend.make_scene(ax=...)` to wrap a caller-supplied matplotlib axes. Together they thread the legacy `ax=` kwarg through the new machinery **without** applying the default `SceneStyle` (which would mutate `plt.rcParams[\"font.size\"]` — a side effect the v1.x renderer never had).

## Design notes

- `MeshLayer.mpl_zorder=1.0` is applied post-hoc via `actor.set_zorder` so non-matplotlib backends are unaffected. Matches the v1.x convention: mesh sits below scatter/contour overlays (default `zorder=2.0`).
- `MeshLayer` reuses `_build_segments` from `plotting/deformed_shape.py` — an intentional, temporary `viewer → plotting` import direction documented in the module header. Lifts into `viewer/math/` in a later phase.
- `plot_mesh` filter check + error message (`\"(element_type=..., element_ids=...)\"`) preserved verbatim before scene construction so the v1.x error contract is intact.
- `MeshLayer` carries the legacy `meta` surface as read-only properties (`n_edges`, `n_elements_drawn`, `edges_per_class`, `skipped_classes`) — `plot_mesh` just reads them off.

## Test plan

- [x] 20 new tests in [`tests/viewer/layers/test_mesh_layer.py`](tests/viewer/layers/test_mesh_layer.py): lifecycle, counts, topology, backend interaction (LineCollection / Line3DCollection per class), zorder, visibility, selection subsetting, `update_to_step` no-op, `detach` cleanup, and a real-fixture parity check against `elastic_frame_dir`.
- [x] Full suite: **1473 passed, 49 skipped** (only fixture-availability skips). Includes every `tests/integration/test_mesh_plot.py` integration test passing on the rewired path.

## What's next

Phase 2.5 — `DeformedMeshLayer` and rewire `ds.plot.deformed_shape()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)