### PR TITLE
Add DeformedMeshLayer + rewire ds.plot.deformed_shape (Phase 2.5)

### DIFF
--- a/src/STKO_to_python/plotting/deformed_shape.py
+++ b/src/STKO_to_python/plotting/deformed_shape.py
@@ -13,13 +13,26 @@ Anything else with a known node count falls back to a "convex polygon"
 edge loop (n edges connecting consecutive nodes); higher-order solids
 that don't fit one of the cases above are skipped with a warning.
 
+**Phase 2.5 internals.** As of v1.11, both :func:`plot_deformed_shape`
+and :func:`plot_undeformed_shape` flow their rendering through the
+viewer's ``Scene + Layer + Backend`` machinery
+(:class:`~STKO_to_python.viewer.layers.DeformedMeshLayer` /
+:class:`~STKO_to_python.viewer.layers.MeshLayer` over
+:class:`~STKO_to_python.viewer.backends.mpl.backend.MplBackend`).
+Public signatures, returns, and visual output are unchanged. The
+private helpers (:func:`_build_segments`, :func:`_decide_3d`,
+:func:`_autoscale_axes`, :func:`_displacement_at_step`) stay here for
+now because both the layer code and the v1.x companions
+(:func:`plot_beam_solids_deformed`) import them; they relocate to
+:mod:`viewer.math` in a later phase. See ``docs/viewer/00-roadmap.md``
+Phase 2.5.
+
 The public entry points sit on :class:`STKO_to_python.plotting.plot.Plot`
 (``ds.plot.deformed_shape`` / ``ds.plot.undeformed_shape``); this module
 is the implementation, not the user-facing API.
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -313,94 +326,63 @@ def plot_deformed_shape(
         * ``is_3d`` — whether the axes are 3D
         * ``scale``, ``step``, ``model_stage``
     """
+    from ..viewer.backends.mpl.backend import MplBackend
+    from ..viewer.core import MPCODataSourceAdapter, Scene
+    from ..viewer.layers import DeformedMeshLayer, MeshLayer
+
     df_nodes = dataset.nodes_info["dataframe"]
     df_elements = dataset.elements_info["dataframe"]
     if df_nodes.empty or df_elements.empty:
         raise ValueError("Dataset has no nodes or no elements to draw.")
 
-    original = {
-        int(row.node_id): np.array([row.x, row.y, row.z], dtype=np.float64)
-        for row in df_nodes.itertuples(index=False)
-    }
-
-    if scale == 0.0 or step is None:
-        deformed = {nid: xyz.copy() for nid, xyz in original.items()}
-    else:
-        disp = _displacement_at_step(
-            dataset, model_stage=model_stage, step=int(step)
-        )
-        deformed = {}
-        for nid, xyz in original.items():
-            d = disp.get(nid)
-            if d is None:
-                deformed[nid] = xyz.copy()
-            else:
-                deformed[nid] = xyz + float(scale) * d
-
     is_3d = _decide_3d(df_elements, df_nodes)
 
-    # ------------------------------------------------------------------ #
-    # axes
-    # ------------------------------------------------------------------ #
-    if ax is None:
-        import matplotlib.pyplot as plt
-
-        if is_3d:
-            fig = plt.figure()
-            ax = fig.add_subplot(111, projection="3d")
-        else:
-            fig, ax = plt.subplots()
-
-    # ------------------------------------------------------------------ #
-    # build segments
-    # ------------------------------------------------------------------ #
-    deformed_segs, edges_per_class, skipped = _build_segments(
-        df_elements=df_elements, coord_lookup=deformed
-    )
+    # Phase 2.5 rewire — undeformed overlay rides on MeshLayer, the
+    # deformed mesh on DeformedMeshLayer. The handle is pre-allocated
+    # so the caller-supplied ``ax`` is honoured and the default
+    # SceneStyle is **not** applied (would mutate plt.rcParams as a
+    # side effect; the v1.x renderer never did that).
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d, ax=ax)
+    source = MPCODataSourceAdapter(dataset)
+    scene = Scene(backend, source, is_3d=is_3d, handle=handle)
 
     if show_undeformed:
-        und_segs, _, _ = _build_segments(
-            df_elements=df_elements, coord_lookup=original
+        undeformed_layer = MeshLayer(
+            edge_color=undeformed_color,
+            linewidth=undeformed_linewidth,
+            alpha=undeformed_alpha,
+            mpl_zorder=1.0,
         )
-        for label, segs in und_segs.items():
-            _draw_segments(
-                ax,
-                segs,
-                is_3d=is_3d,
-                color=undeformed_color,
-                linewidth=undeformed_linewidth,
-                alpha=undeformed_alpha,
-                zorder=1.0,
-            )
+        scene.add(undeformed_layer)
 
-    seg_count = 0
-    for label, segs in deformed_segs.items():
-        _draw_segments(
-            ax,
-            segs,
-            is_3d=is_3d,
-            color=color,
-            linewidth=linewidth,
-            alpha=alpha,
-            zorder=2.0,
-        )
-        seg_count += int(segs.shape[0])
-
-    if skipped:
-        warnings.warn(
-            "[deformed_shape] Skipped element classes with unsupported "
-            f"topology: {skipped}",
-            RuntimeWarning,
-        )
-
-    # ------------------------------------------------------------------ #
-    # framing
-    # ------------------------------------------------------------------ #
-    coord_stack = np.vstack(
-        [np.stack(list(deformed.values())), np.stack(list(original.values()))]
-        if show_undeformed
-        else [np.stack(list(deformed.values()))]
+    deformed_layer = DeformedMeshLayer(
+        model_stage=model_stage,
+        step=int(step) if step is not None else None,
+        scale=float(scale),
+        edge_color=color,
+        linewidth=linewidth,
+        alpha=alpha,
+        mpl_zorder=2.0,
     )
+    scene.add(deformed_layer)
+
+    # Framing — keep the v1.x behaviour of including BOTH the deformed
+    # and original coords when ``show_undeformed`` is on, so the bbox
+    # accommodates the entire motion path.
+    deformed = deformed_layer.deformed_coords
+    original = deformed_layer.original_coords
+    if show_undeformed:
+        coord_stack = np.vstack(
+            [
+                np.stack(list(deformed.values())),
+                np.stack(list(original.values())),
+            ]
+        )
+    else:
+        coord_stack = np.stack(list(deformed.values()))
+
+    ax = handle.ax
     _autoscale_axes(ax, coord_stack, is_3d=is_3d)
 
     if not is_3d:
@@ -417,9 +399,9 @@ def plot_deformed_shape(
     meta: Dict[str, Any] = {
         "deformed_coords": deformed,
         "original_coords": original,
-        "edges_per_class": edges_per_class,
-        "segment_count": seg_count,
-        "skipped_classes": skipped,
+        "edges_per_class": deformed_layer.edges_per_class,
+        "segment_count": deformed_layer.segment_count,
+        "skipped_classes": deformed_layer.skipped_classes,
         "is_3d": is_3d,
         "scale": float(scale),
         "step": int(step) if step is not None else None,
@@ -442,49 +424,41 @@ def plot_undeformed_shape(
     Equivalent to :func:`plot_deformed_shape` with ``scale=0`` and
     ``show_undeformed=False``, but without fetching DISPLACEMENT.
     """
+    from ..viewer.backends.mpl.backend import MplBackend
+    from ..viewer.core import MPCODataSourceAdapter, Scene
+    from ..viewer.layers import MeshLayer
+
     df_nodes = dataset.nodes_info["dataframe"]
     df_elements = dataset.elements_info["dataframe"]
     if df_nodes.empty or df_elements.empty:
         raise ValueError("Dataset has no nodes or no elements to draw.")
 
+    is_3d = _decide_3d(df_elements, df_nodes)
+
+    # Phase 2.5 rewire — undeformed mesh through MeshLayer. The legacy
+    # _draw_segments default zorder is 2.0, so we override MeshLayer's
+    # default (1.0) to preserve the v1.x z-stack.
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d, ax=ax)
+    source = MPCODataSourceAdapter(dataset)
+    scene = Scene(backend, source, is_3d=is_3d, handle=handle)
+
+    layer = MeshLayer(
+        edge_color=color,
+        linewidth=linewidth,
+        alpha=alpha,
+        mpl_zorder=2.0,
+    )
+    scene.add(layer)
+
+    # Build the ``original_coords`` dict the meta surface promises.
     original = {
         int(row.node_id): np.array([row.x, row.y, row.z], dtype=np.float64)
         for row in df_nodes.itertuples(index=False)
     }
-    is_3d = _decide_3d(df_elements, df_nodes)
-
-    if ax is None:
-        import matplotlib.pyplot as plt
-
-        if is_3d:
-            fig = plt.figure()
-            ax = fig.add_subplot(111, projection="3d")
-        else:
-            fig, ax = plt.subplots()
-
-    segs_per_class, edges_per_class, skipped = _build_segments(
-        df_elements=df_elements, coord_lookup=original
-    )
-    seg_count = 0
-    for label, segs in segs_per_class.items():
-        _draw_segments(
-            ax,
-            segs,
-            is_3d=is_3d,
-            color=color,
-            linewidth=linewidth,
-            alpha=alpha,
-        )
-        seg_count += int(segs.shape[0])
-
-    if skipped:
-        warnings.warn(
-            "[undeformed_shape] Skipped element classes with unsupported "
-            f"topology: {skipped}",
-            RuntimeWarning,
-        )
-
     coord_stack = np.stack(list(original.values()))
+
+    ax = handle.ax
     _autoscale_axes(ax, coord_stack, is_3d=is_3d)
 
     if not is_3d:
@@ -499,9 +473,9 @@ def plot_undeformed_shape(
 
     meta: Dict[str, Any] = {
         "original_coords": original,
-        "edges_per_class": edges_per_class,
-        "segment_count": seg_count,
-        "skipped_classes": skipped,
+        "edges_per_class": layer.edges_per_class,
+        "segment_count": layer.n_edges,
+        "skipped_classes": layer.skipped_classes,
         "is_3d": is_3d,
     }
     return ax, meta

--- a/src/STKO_to_python/viewer/backends/mpl/backend.py
+++ b/src/STKO_to_python/viewer/backends/mpl/backend.py
@@ -292,7 +292,10 @@ class MplBackend:
         Handles three common cases:
 
         * ``LineCollection`` / ``Line3DCollection`` — replaces the
-          segment array via ``set_segments``.
+          segment array via ``set_segments``. 3-D segments (shape
+          ``(N, 2, 3)``) passed to a 2-D ``LineCollection`` are
+          z-dropped to ``(N, 2, 2)`` — same convention as
+          :meth:`add_segments` so layers can stay shape-agnostic.
         * ``PathCollection`` (scatter) — replaces the offsets via
           ``set_offsets`` (2-D) or ``set_offsets`` + ``set_3d_properties``
           (3-D).
@@ -300,7 +303,12 @@ class MplBackend:
           caller learns rather than silently dropping the update.
         """
         pts = np.asarray(points, dtype=np.float64)
-        if isinstance(actor, (LineCollection, Line3DCollection)):
+        if isinstance(actor, Line3DCollection):
+            actor.set_segments(pts)
+            return
+        if isinstance(actor, LineCollection):
+            if pts.ndim == 3 and pts.shape[-1] == 3:
+                pts = pts[:, :, :2]
             actor.set_segments(pts)
             return
         if isinstance(actor, PathCollection):

--- a/src/STKO_to_python/viewer/layers/__init__.py
+++ b/src/STKO_to_python/viewer/layers/__init__.py
@@ -1,19 +1,26 @@
 """Concrete :class:`Layer` implementations.
 
-Layers are renderable units in a :class:`Scene`. Phase 2.4 ships the
-first one — :class:`MeshLayer`, which wraps the v1.x ``ds.plot.mesh``
-edge-rendering through the Scene/Backend/DataSource machinery. The
-remaining layer types from the directive's catalog (deformed mesh,
-node/vector, contour, gauss, diagram, fiber, …) land in Phases
-2.5–3.X.
+Layers are renderable units in a :class:`Scene`. As of v1.11 the
+package ships two:
 
-The Phase 2.4 contract is the **byte-identical refactor under the
-existing API**: ``ds.plot.mesh()`` keeps its signature and visual
-output; only the implementation now flows through Scene + MeshLayer +
-MplBackend.
+* :class:`MeshLayer` — static element-edge wireframe; powers the
+  Phase 2.4 rewire of ``ds.plot.mesh`` and ``ds.plot.undeformed_shape``.
+* :class:`DeformedMeshLayer` — time-varying edge wireframe at
+  ``original + scale * displacement``; powers the Phase 2.5 rewire
+  of ``ds.plot.deformed_shape`` and supports in-place
+  :meth:`~DeformedMeshLayer.update_to_step` for animation.
+
+The remaining catalog (node/vector, contour, gauss, diagram, fiber,
+…) lands in Phases 2.6–3.X.
+
+The Phase 2 contract is the **byte-identical refactor under the
+existing API**: ``ds.plot.*`` keeps every signature and visual
+output; only the implementation now flows through
+Scene + Layer + MplBackend.
 """
 from __future__ import annotations
 
+from .deformed_mesh import DeformedMeshLayer
 from .mesh import MeshLayer
 
-__all__ = ["MeshLayer"]
+__all__ = ["DeformedMeshLayer", "MeshLayer"]

--- a/src/STKO_to_python/viewer/layers/deformed_mesh.py
+++ b/src/STKO_to_python/viewer/layers/deformed_mesh.py
@@ -1,0 +1,302 @@
+"""``DeformedMeshLayer`` — element edges at a deformed step.
+
+Time-varying counterpart to :class:`MeshLayer`. Fetches the nodal
+displacement field at a given ``(model_stage, step)``, builds the
+deformed coordinates as ``original + scale * displacement``, then
+draws element edges through the scene's backend.
+
+Per the perf contract in ``docs/viewer/01-architecture.md`` §4 and
+``docs/viewer/02-porting-from-apegmsh.md`` §6, :meth:`update_to_step`
+mutates pre-allocated actor data via ``backend.update_points`` rather
+than recreating actors. That keeps the per-step cost dominated by the
+displacement fetch (which the query engine caches) plus an
+O(n_segments) coord scatter — not by VTK/matplotlib actor allocation.
+
+Like :class:`MeshLayer`, this layer borrows
+:func:`_build_segments` from
+:mod:`STKO_to_python.plotting.deformed_shape` and the displacement
+fetch from the same module. Those helpers move into
+:mod:`viewer.math` in a later phase.
+"""
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+# Temporary imports from plotting/ — see module docstring.
+from ...plotting.deformed_shape import _build_segments, _displacement_at_step
+from ..core.errors import LayerAttachError
+from ..core.layer import Layer
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from ..core.datasource import DataSource
+    from ..core.scene import Scene
+    from ..core.selection import SelectionSpec
+
+
+class DeformedMeshLayer(Layer):
+    """Element-edge wireframe at ``original + scale * displacement(step)``.
+
+    The layer fixes ``model_stage`` and ``scale`` at construction;
+    ``step`` is the initial step and may be advanced via
+    :meth:`update_to_step` (drives time scrubbers and animation
+    export). Each step change re-fetches displacements through the
+    dataset's cached :class:`~STKO_to_python.nodes.node_manager.NodeManager`
+    and updates segment endpoints in place — no actor recreation.
+
+    Parameters
+    ----------
+    model_stage:
+        Stage name (e.g. ``"MODEL_STAGE[1]"``).
+    step:
+        Initial step inside the stage. May be advanced later via
+        :meth:`update_to_step`.
+    scale:
+        Displacement amplification. ``1.0`` is true-to-life; ``0.0``
+        collapses to the undeformed configuration (no DISPLACEMENT
+        fetch happens in that case — same shortcut as the v1.x
+        renderer).
+    name, selection, visible, z_order:
+        Forwarded to :class:`Layer`.
+    edge_color, linewidth, alpha:
+        Edge styling. Defaults match the v1.x
+        ``ds.plot.deformed_shape`` API (``"C0"``, ``1.2``, ``1.0``).
+    mpl_zorder:
+        Matplotlib z-order for the segment collections. Default
+        ``2.0`` sits **above** the undeformed overlay (which the
+        v1.x renderer draws at ``zorder=1.0``).
+    """
+
+    kind: str = "deformed_mesh"
+
+    def __init__(
+        self,
+        *,
+        model_stage: str,
+        step: int,
+        scale: float = 1.0,
+        name: str | None = None,
+        selection: "SelectionSpec | None" = None,
+        visible: bool = True,
+        z_order: int = 0,
+        edge_color: Any = "C0",
+        linewidth: float = 1.2,
+        alpha: float = 1.0,
+        mpl_zorder: float = 2.0,
+    ) -> None:
+        super().__init__(
+            name=name, selection=selection, visible=visible, z_order=z_order,
+        )
+        self.model_stage = str(model_stage)
+        self.scale = float(scale)
+        self.edge_color = edge_color
+        self.linewidth = linewidth
+        self.alpha = alpha
+        self.mpl_zorder = mpl_zorder
+
+        self._initial_step: int | None = (
+            int(step) if step is not None else None
+        )
+        self._current_step: int | None = None
+
+        # Populated at attach.
+        self._df_filtered: "pd.DataFrame | None" = None
+        self._original_coords: dict[int, np.ndarray] = {}
+        self._deformed_coords: dict[int, np.ndarray] = {}
+        self._actors_per_class: dict[str, Any] = {}
+        self._edges_per_class: dict[str, int] = {}
+        self._skipped_classes: list[str] = []
+        self._segment_count: int = 0
+
+    # ------------------------------------------------------------------ #
+    # Read-only summary surface
+    # ------------------------------------------------------------------ #
+    @property
+    def current_step(self) -> int | None:
+        """The step the layer is currently rendering, or ``None`` before attach."""
+        return self._current_step
+
+    @property
+    def segment_count(self) -> int:
+        """Total number of deformed segments across all element classes."""
+        return self._segment_count
+
+    @property
+    def edges_per_class(self) -> dict[str, int]:
+        """``{class_label: edges_per_element}`` for every drawn class."""
+        return dict(self._edges_per_class)
+
+    @property
+    def skipped_classes(self) -> list[str]:
+        """Class labels skipped because their topology isn't supported."""
+        return list(self._skipped_classes)
+
+    @property
+    def original_coords(self) -> dict[int, np.ndarray]:
+        """Original node coordinates, ``{node_id: ndarray(3)}``."""
+        return {nid: xyz.copy() for nid, xyz in self._original_coords.items()}
+
+    @property
+    def deformed_coords(self) -> dict[int, np.ndarray]:
+        """Current deformed coordinates, ``{node_id: ndarray(3)}``."""
+        return {nid: xyz.copy() for nid, xyz in self._deformed_coords.items()}
+
+    @property
+    def actors(self) -> dict[str, Any]:
+        """``{class_label: backend actor}`` mapping. For inspection only."""
+        return dict(self._actors_per_class)
+
+    # ------------------------------------------------------------------ #
+    # Layer lifecycle
+    # ------------------------------------------------------------------ #
+    def attach(self, scene: "Scene", source: "DataSource") -> None:
+        if self.is_attached:
+            raise LayerAttachError(f"Layer {self.name!r} is already attached.")
+        self._scene = scene
+        self._source = source
+
+        ds = source.dataset
+        df_nodes = ds.nodes_info["dataframe"]
+        df_elements = ds.elements_info["dataframe"]
+        if df_nodes.empty or df_elements.empty:
+            raise LayerAttachError(
+                "Dataset has no nodes or no elements to draw."
+            )
+
+        if self.selection.is_empty():
+            df_filtered = df_elements
+        else:
+            kept = source.resolve_element_ids(self.selection)
+            if kept.size == 0:
+                raise LayerAttachError(
+                    f"No elements remain after filtering for {self.selection!r}."
+                )
+            kept_set = {int(i) for i in kept}
+            df_filtered = df_elements[df_elements["element_id"].isin(kept_set)]
+            if df_filtered.empty:
+                raise LayerAttachError(
+                    f"No elements remain after filtering for {self.selection!r}."
+                )
+
+        self._df_filtered = df_filtered
+        self._original_coords = {
+            int(r.node_id): np.array([r.x, r.y, r.z], dtype=np.float64)
+            for r in df_nodes.itertuples(index=False)
+        }
+
+        # Compute the initial step's deformed coordinates and build
+        # segments + actors. Subsequent set_step calls only call
+        # update_points on these actors — no actor recreation.
+        self._compute_deformed_for_step(self._initial_step)
+        segs_per_class, edges_per_class, skipped = _build_segments(
+            df_elements=self._df_filtered, coord_lookup=self._deformed_coords,
+        )
+        self._edges_per_class = dict(edges_per_class)
+        self._skipped_classes = list(skipped)
+
+        backend = scene.backend
+        handle = scene.handle
+        seg_count = 0
+        for label, segs in segs_per_class.items():
+            actor = backend.add_segments(
+                handle, segs,
+                color=self.edge_color,
+                width=self.linewidth,
+                alpha=self.alpha,
+            )
+            if hasattr(actor, "set_zorder"):
+                actor.set_zorder(self.mpl_zorder)
+            self._actors_per_class[label] = actor
+            seg_count += int(segs.shape[0])
+        self._segment_count = seg_count
+
+        if skipped:
+            warnings.warn(
+                "[deformed_mesh] Skipped element classes with unsupported "
+                f"topology: {skipped}",
+                RuntimeWarning,
+            )
+
+        if not self.visible:
+            for actor in self._actors_per_class.values():
+                backend.set_visible(actor, False)
+
+        self._current_step = self._initial_step
+
+    def update_to_step(self, step: int) -> None:
+        """Advance to ``step`` via in-place segment mutation.
+
+        No-op when the layer is unattached or already at ``step``.
+        """
+        if not self.is_attached:
+            return
+        if step == self._current_step:
+            return
+
+        self._compute_deformed_for_step(step)
+        segs_per_class, _, _ = _build_segments(
+            df_elements=self._df_filtered, coord_lookup=self._deformed_coords,
+        )
+        backend = self._scene.backend  # type: ignore[union-attr]
+        seg_count = 0
+        for label, segs in segs_per_class.items():
+            actor = self._actors_per_class.get(label)
+            if actor is None:
+                # New class showed up at this step (e.g. element-by-element
+                # activation). Allocating a new actor would violate the
+                # no-recreation contract, so we skip — animations should
+                # be defined on a fixed topology.
+                continue
+            backend.update_points(actor, segs)
+            seg_count += int(segs.shape[0])
+        self._segment_count = seg_count
+        self._current_step = step
+
+    def detach(self) -> None:
+        scene = self._scene
+        if scene is not None:
+            for actor in self._actors_per_class.values():
+                scene.backend.remove(scene.handle, actor)
+        self._actors_per_class.clear()
+        self._original_coords = {}
+        self._deformed_coords = {}
+        self._edges_per_class = {}
+        self._skipped_classes = []
+        self._segment_count = 0
+        self._df_filtered = None
+        self._current_step = None
+        self._scene = None
+        self._source = None
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    def _compute_deformed_for_step(self, step: int | None) -> None:
+        if self.scale == 0.0 or step is None:
+            self._deformed_coords = {
+                nid: xyz.copy() for nid, xyz in self._original_coords.items()
+            }
+            return
+        if self._source is None:
+            raise LayerAttachError(
+                "Cannot compute deformed coordinates: layer is not attached."
+            )
+        disp = _displacement_at_step(
+            self._source.dataset, model_stage=self.model_stage, step=int(step),
+        )
+        deformed: dict[int, np.ndarray] = {}
+        scale = float(self.scale)
+        for nid, xyz in self._original_coords.items():
+            d = disp.get(nid)
+            if d is None:
+                deformed[nid] = xyz.copy()
+            else:
+                deformed[nid] = xyz + scale * d
+        self._deformed_coords = deformed
+
+
+__all__ = ["DeformedMeshLayer"]

--- a/tests/viewer/layers/test_deformed_mesh_layer.py
+++ b/tests/viewer/layers/test_deformed_mesh_layer.py
@@ -1,0 +1,581 @@
+"""Tests for :class:`DeformedMeshLayer`.
+
+Three flavours of coverage:
+
+1. **Unit tests** against a fake :class:`MPCODataSet` with a
+   monkey-patched ``_displacement_at_step`` so the layer can be
+   exercised without an HDF5 fixture.
+2. **Backend-integration tests** that drive the real :class:`Scene`
+   and :class:`MplBackend` to confirm actor types, zorder, in-place
+   ``update_to_step`` semantics, and detach cleanup.
+3. **Real-fixture parity** against ``elastic_frame_dir`` — proves the
+   Phase 2.5 rewire of ``ds.plot.deformed_shape`` keeps the legacy
+   meta contract intact and that animation via
+   :meth:`DeformedMeshLayer.update_to_step` produces the same
+   geometry the legacy ``ds.plot.deformed_shape(step=N)`` produces.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import LineCollection
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+
+from STKO_to_python.viewer.backends.mpl.backend import MplBackend
+from STKO_to_python.viewer.core import (
+    MPCODataSourceAdapter,
+    Scene,
+    SelectionSpec,
+)
+from STKO_to_python.viewer.core.errors import LayerAttachError
+from STKO_to_python.viewer.layers import DeformedMeshLayer
+from STKO_to_python.viewer.layers import deformed_mesh as deformed_mesh_module
+
+
+# --------------------------------------------------------------------- #
+# Fake-dataset helpers
+# --------------------------------------------------------------------- #
+
+
+def _make_fake_dataset(
+    *,
+    node_rows=None,
+    elem_rows=None,
+):
+    """Tiny stand-in for :class:`MPCODataSet`."""
+    if node_rows is None:
+        node_rows = [
+            (1, 0.0, 0.0, 0.0),
+            (2, 1.0, 0.0, 0.0),
+            (3, 1.0, 1.0, 0.0),
+            (4, 0.0, 1.0, 0.0),
+        ]
+    if elem_rows is None:
+        elem_rows = [
+            (10, "5-ElasticBeam3d", 2, (1, 2)),
+            (11, "203-ASDShellQ4", 4, (1, 2, 3, 4)),
+        ]
+    nodes_df = pd.DataFrame(node_rows, columns=["node_id", "x", "y", "z"])
+    elements_df = pd.DataFrame(
+        elem_rows,
+        columns=["element_id", "element_type", "num_nodes", "node_list"],
+    )
+    fake = SimpleNamespace(
+        nodes_info={"dataframe": nodes_df},
+        elements_info={"dataframe": elements_df},
+        model_stages=["STAGE_0"],
+        number_of_steps={"STAGE_0": 1},
+        time=pd.DataFrame(
+            [{"MODEL_STAGE": "STAGE_0", "STEP": 0, "TIME": 0.0}]
+        ).set_index(["MODEL_STAGE", "STEP"]),
+    )
+    fake._selection_resolver = None
+    return fake
+
+
+def _make_scene(fake_dataset, *, is_3d=False, ax=None):
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d, ax=ax)
+    source = MPCODataSourceAdapter(fake_dataset)
+    return Scene(backend, source, is_3d=is_3d, handle=handle)
+
+
+def _disp_factory(disp_per_step):
+    """Build a ``_displacement_at_step`` stand-in keyed on ``step``.
+
+    ``disp_per_step``: ``{step: {node_id: ndarray(3)}}``.
+    """
+
+    def _stub(dataset, *, model_stage, step):
+        if step not in disp_per_step:
+            raise ValueError(
+                f"step={step} not present in DISPLACEMENT for stage "
+                f"{model_stage!r}."
+            )
+        return {nid: np.asarray(v, dtype=np.float64)
+                for nid, v in disp_per_step[step].items()}
+
+    return _stub
+
+
+# --------------------------------------------------------------------- #
+# Construction / contract
+# --------------------------------------------------------------------- #
+
+
+def test_kind_is_deformed_mesh() -> None:
+    assert DeformedMeshLayer.kind == "deformed_mesh"
+
+
+def test_default_styling_matches_legacy_plot_deformed_shape() -> None:
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0)
+    assert layer.edge_color == "C0"
+    assert layer.linewidth == 1.2
+    assert layer.alpha == 1.0
+    assert layer.mpl_zorder == 2.0
+
+
+def test_summary_is_empty_before_attach() -> None:
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=5, scale=10.0)
+    assert layer.current_step is None
+    assert layer.segment_count == 0
+    assert layer.edges_per_class == {}
+    assert layer.skipped_classes == []
+    assert layer.actors == {}
+    assert layer.original_coords == {}
+    assert layer.deformed_coords == {}
+
+
+def test_init_preserves_model_stage_scale_step() -> None:
+    layer = DeformedMeshLayer(
+        model_stage="MODEL_STAGE[1]", step=7, scale=50.0,
+    )
+    assert layer.model_stage == "MODEL_STAGE[1]"
+    assert layer.scale == 50.0
+    # _initial_step is internal; current_step is exposed.
+    assert layer.current_step is None  # not yet attached
+
+
+# --------------------------------------------------------------------- #
+# Attach lifecycle — coords + segments
+# --------------------------------------------------------------------- #
+
+
+def test_attach_with_scale_zero_collapses_to_original(monkeypatch) -> None:
+    """``scale=0`` must skip the DISPLACEMENT fetch entirely."""
+
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("displacement fetch must not run when scale=0")
+
+    monkeypatch.setattr(
+        deformed_mesh_module, "_displacement_at_step", _should_not_be_called,
+    )
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=5, scale=0.0)
+    try:
+        scene.add(layer)
+        for nid, orig in layer.original_coords.items():
+            np.testing.assert_array_equal(layer.deformed_coords[nid], orig)
+        assert layer.current_step == 5
+    finally:
+        plt.close("all")
+
+
+def test_attach_with_none_step_collapses_to_original(monkeypatch) -> None:
+    """``step=None`` is the same shortcut — useful for the
+    ``show_undeformed`` overlay case in plot_deformed_shape."""
+
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("displacement fetch must not run when step=None")
+
+    monkeypatch.setattr(
+        deformed_mesh_module, "_displacement_at_step", _should_not_be_called,
+    )
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=None, scale=1.0)
+    try:
+        scene.add(layer)
+        for nid, orig in layer.original_coords.items():
+            np.testing.assert_array_equal(layer.deformed_coords[nid], orig)
+    finally:
+        plt.close("all")
+
+
+def test_attach_applies_displacement_at_initial_step(monkeypatch) -> None:
+    """deformed_coords[nid] == original_coords[nid] + scale * disp."""
+    disp_per_step = {
+        5: {
+            1: np.array([0.1, 0.0, 0.0]),
+            2: np.array([0.2, 0.0, 0.0]),
+            3: np.array([0.3, 0.0, 0.0]),
+            4: np.array([0.4, 0.0, 0.0]),
+        }
+    }
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory(disp_per_step),
+    )
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=5, scale=10.0)
+    try:
+        scene.add(layer)
+        np.testing.assert_allclose(
+            layer.deformed_coords[2],
+            np.array([1.0 + 10.0 * 0.2, 0.0, 0.0]),
+        )
+        np.testing.assert_allclose(
+            layer.deformed_coords[3],
+            np.array([1.0 + 10.0 * 0.3, 1.0, 0.0]),
+        )
+        assert layer.current_step == 5
+    finally:
+        plt.close("all")
+
+
+def test_attach_skips_nodes_without_displacement(monkeypatch) -> None:
+    """Missing nodes use their original coordinates — same shortcut
+    as the legacy renderer."""
+    disp_per_step = {
+        5: {1: np.array([0.5, 0.0, 0.0])}  # only node 1 has disp
+    }
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory(disp_per_step),
+    )
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=5, scale=1.0)
+    try:
+        scene.add(layer)
+        np.testing.assert_allclose(layer.deformed_coords[1], [0.5, 0.0, 0.0])
+        np.testing.assert_allclose(layer.deformed_coords[2], [1.0, 0.0, 0.0])  # unchanged
+    finally:
+        plt.close("all")
+
+
+def test_attach_populates_actor_per_element_class(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({5: {1: [0, 0, 0], 2: [0, 0, 0], 3: [0, 0, 0], 4: [0, 0, 0]}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=5, scale=1.0)
+    try:
+        scene.add(layer)
+        assert set(layer.actors.keys()) == {
+            "5-ElasticBeam3d(2n)",
+            "203-ASDShellQ4(4n)",
+        }
+        # 1 beam edge + 4 quad edges = 5 segments.
+        assert layer.segment_count == 5
+    finally:
+        plt.close("all")
+
+
+def test_attach_raises_when_dataset_is_empty() -> None:
+    fake = _make_fake_dataset(node_rows=[], elem_rows=[])
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=0.0)
+    try:
+        with pytest.raises(LayerAttachError, match="no nodes or no elements"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_attach_twice_raises(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({0: {nid: [0, 0, 0] for nid in (1, 2, 3, 4)}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    try:
+        scene.add(layer)
+        with pytest.raises(LayerAttachError, match="already attached"):
+            layer.attach(scene, scene.source)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Backend interaction
+# --------------------------------------------------------------------- #
+
+
+def test_2d_attach_emits_line_collection_per_class(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({0: {nid: [0, 0, 0] for nid in (1, 2, 3, 4)}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake, is_3d=False)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert isinstance(actor, LineCollection)
+            assert not isinstance(actor, Line3DCollection)
+    finally:
+        plt.close("all")
+
+
+def test_3d_attach_emits_line3dcollection_per_class(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({0: {nid: [0, 0, 0] for nid in (1, 2, 3, 4)}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake, is_3d=True)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert isinstance(actor, Line3DCollection)
+    finally:
+        plt.close("all")
+
+
+def test_default_mpl_zorder_sits_above_undeformed_overlay(monkeypatch) -> None:
+    """zorder=2.0 keeps the deformed wireframe in front of the
+    undeformed overlay (which sits at 1.0)."""
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({0: {nid: [0, 0, 0] for nid in (1, 2, 3, 4)}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert actor.get_zorder() == pytest.approx(2.0)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# update_to_step — the apeGmsh perf contract
+# --------------------------------------------------------------------- #
+
+
+def test_update_to_step_mutates_segments_without_recreating_actors(
+    monkeypatch,
+) -> None:
+    """The perf contract: a step change must update existing actors,
+    not recreate them. We verify by holding the actor instance across
+    a step change and re-checking ``id()``."""
+    disp = {
+        0: {nid: np.zeros(3) for nid in (1, 2, 3, 4)},
+        5: {
+            1: np.array([0.1, 0.0, 0.0]),
+            2: np.array([0.2, 0.0, 0.0]),
+            3: np.array([0.3, 0.0, 0.0]),
+            4: np.array([0.4, 0.0, 0.0]),
+        },
+    }
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory(disp),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=10.0)
+    try:
+        scene.add(layer)
+        beam_actor_before = layer.actors["5-ElasticBeam3d(2n)"]
+        # Snapshot the beam's segment ([node 1, node 2]).
+        before = np.asarray(beam_actor_before.get_segments())
+        layer.update_to_step(5)
+        beam_actor_after = layer.actors["5-ElasticBeam3d(2n)"]
+        # Same Python object — actor was not recreated.
+        assert beam_actor_after is beam_actor_before
+        # Segments moved with the displacement.
+        after = np.asarray(beam_actor_after.get_segments())
+        assert not np.allclose(before, after)
+        assert layer.current_step == 5
+        # And the deformed_coords dict tracks the new step.
+        np.testing.assert_allclose(
+            layer.deformed_coords[2], np.array([1.0 + 10.0 * 0.2, 0.0, 0.0]),
+        )
+    finally:
+        plt.close("all")
+
+
+def test_update_to_step_is_no_op_when_step_unchanged(monkeypatch) -> None:
+    call_count = {"n": 0}
+    real_factory = _disp_factory({0: {nid: np.zeros(3) for nid in (1, 2, 3, 4)}})
+
+    def _counting_fetch(*args, **kwargs):
+        call_count["n"] += 1
+        return real_factory(*args, **kwargs)
+
+    monkeypatch.setattr(
+        deformed_mesh_module, "_displacement_at_step", _counting_fetch,
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    try:
+        scene.add(layer)
+        n_attach = call_count["n"]
+        layer.update_to_step(0)  # same step
+        assert call_count["n"] == n_attach  # no extra fetch
+    finally:
+        plt.close("all")
+
+
+def test_update_to_step_no_op_before_attach() -> None:
+    """A pre-attach update_to_step must be silent, not crash."""
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    layer.update_to_step(5)  # nothing happens — not attached
+    assert layer.current_step is None
+
+
+# --------------------------------------------------------------------- #
+# detach
+# --------------------------------------------------------------------- #
+
+
+def test_detach_clears_actors_and_state(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({0: {nid: np.zeros(3) for nid in (1, 2, 3, 4)}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(model_stage="STAGE_0", step=0, scale=1.0)
+    try:
+        scene.add(layer)
+        assert layer.segment_count > 0
+        scene.remove(layer)
+        assert not layer.is_attached
+        assert layer.actors == {}
+        assert layer.segment_count == 0
+        assert layer.edges_per_class == {}
+        assert layer.original_coords == {}
+        assert layer.deformed_coords == {}
+        assert layer.current_step is None
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Selection-driven subset rendering
+# --------------------------------------------------------------------- #
+
+
+def test_selection_by_element_ids_subsets_the_layer(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deformed_mesh_module,
+        "_displacement_at_step",
+        _disp_factory({0: {nid: np.zeros(3) for nid in (1, 2, 3, 4)}}),
+    )
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = DeformedMeshLayer(
+        model_stage="STAGE_0", step=0, scale=1.0,
+        selection=SelectionSpec(element_ids=(10,)),
+    )
+    try:
+        scene.add(layer)
+        assert set(layer.edges_per_class.keys()) == {"5-ElasticBeam3d(2n)"}
+        assert layer.segment_count == 1
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Real-fixture parity — proves the Phase 2.5 rewire is byte-identical
+# --------------------------------------------------------------------- #
+
+
+def test_plot_deformed_shape_rewire_returns_legacy_meta(
+    elastic_frame_dir: Path,
+) -> None:
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    try:
+        ax, meta = ds.plot.deformed_shape(
+            model_stage="MODEL_STAGE[1]", step=5, scale=10.0,
+        )
+        # Legacy meta surface.
+        assert set(meta.keys()) >= {
+            "deformed_coords",
+            "original_coords",
+            "edges_per_class",
+            "segment_count",
+            "skipped_classes",
+            "is_3d",
+            "scale",
+            "step",
+            "model_stage",
+        }
+        assert meta["edges_per_class"] == {"5-ElasticBeam3d(2n)": 1}
+        assert meta["segment_count"] == 3
+        assert meta["skipped_classes"] == []
+        assert meta["is_3d"] is True
+        assert meta["scale"] == 10.0
+        assert meta["step"] == 5
+        assert meta["model_stage"] == "MODEL_STAGE[1]"
+        # The undeformed overlay sits below the deformed mesh.
+        line3d_collections = [
+            c for c in ax.collections if isinstance(c, Line3DCollection)
+        ]
+        zorders = sorted(c.get_zorder() for c in line3d_collections)
+        assert zorders == [pytest.approx(1.0), pytest.approx(2.0)]
+    finally:
+        plt.close("all")
+
+
+def test_animation_step_change_matches_one_shot_renders(
+    elastic_frame_dir: Path,
+) -> None:
+    """update_to_step on a live layer must produce the same geometry
+    as a fresh ``ds.plot.deformed_shape(step=N)`` would. This is the
+    animation contract."""
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(elastic_frame_dir), "results", verbose=False)
+    backend = MplBackend()
+    fig = plt.figure()
+    user_ax = fig.add_subplot(111, projection="3d")
+    handle = backend.make_scene(is_3d=True, ax=user_ax)
+    source = MPCODataSourceAdapter(ds)
+    scene = Scene(backend, source, is_3d=True, handle=handle)
+
+    try:
+        layer = DeformedMeshLayer(
+            model_stage="MODEL_STAGE[1]", step=2, scale=10.0,
+        )
+        scene.add(layer)
+        coords_step2 = layer.deformed_coords
+        # Advance to step 7 — same actor mutated in place.
+        layer.update_to_step(7)
+        coords_step7 = layer.deformed_coords
+        assert layer.current_step == 7
+
+        # Independent one-shot render at step 7 — must match the
+        # animated layer's coords.
+        _, meta_step7_one_shot = ds.plot.deformed_shape(
+            model_stage="MODEL_STAGE[1]", step=7, scale=10.0,
+            show_undeformed=False,
+        )
+        for nid, xyz in meta_step7_one_shot["deformed_coords"].items():
+            np.testing.assert_allclose(
+                coords_step7[int(nid)], xyz, atol=1e-12,
+            )
+        # The two animation snapshots were independent dicts — the
+        # ``deformed_coords`` property returns a defensive copy, so
+        # update_to_step must not have aliased into the earlier
+        # snapshot.
+        assert coords_step2 is not coords_step7
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary

- First **time-varying** `Layer`: tracks `model_stage` + `scale`, advances the step via `update_to_step`, honours the apeGmsh perf contract (in-place actor updates, no recreation).
- **Byte-identical rewire** of `ds.plot.deformed_shape` and `ds.plot.undeformed_shape` through `Scene / Layer / MplBackend`. Public signatures, `(ax, meta)` returns, and visual output unchanged.
- Small `MplBackend.update_points` fix: symmetric z-dropping for 2-D `LineCollection` so a layer can hand `(N, 2, 3)` segments to either projection. Without this, in-place updates on 2-D scenes raised a matplotlib `Path` shape error.

## Design notes

- `DeformedMeshLayer.update_to_step(step)` re-fetches `DISPLACEMENT` (cache-hit through the query engine), recomputes segments for the **same** topology, and calls `backend.update_points` on the existing actors. Same-step calls are no-ops; pre-attach calls are silent.
- `scale=0` or `step=None` skip the DISPLACEMENT fetch entirely — same shortcut the v1.x renderer uses for the `show_undeformed` overlay.
- `mpl_zorder=2.0` by default so the deformed wireframe sits **above** the undeformed overlay, which rides on `MeshLayer` at `mpl_zorder=1.0`. `plot_undeformed_shape` instead uses `MeshLayer(mpl_zorder=2.0)` to preserve the legacy `_draw_segments` default that the v1.x function inherited (it did NOT override zorder the way `plot_mesh` did).
- Defaults preserved verbatim from the v1.x `ds.plot.deformed_shape` API: `edge_color=\"C0\"`, `linewidth=1.2`, `alpha=1.0`.
- Meta dict (`deformed_coords`, `original_coords`, `segment_count`, `edges_per_class`, `skipped_classes`, `is_3d`, `scale`, `step`, `model_stage`) reads directly off the `DeformedMeshLayer` properties.

## Test plan

- [x] **21 new tests** in [`tests/viewer/layers/test_deformed_mesh_layer.py`](tests/viewer/layers/test_deformed_mesh_layer.py): construction defaults, `scale=0` / `step=None` shortcuts, displacement application, missing-node graceful fallback, attach lifecycle, 2-D / 3-D actor types, zorder, **`update_to_step` in-place semantics** (same actor instance across steps), no-op on unchanged step, pre-attach silent, detach cleanup, selection subsetting, and real-fixture animation parity against `elastic_frame_dir`.
- [x] **All 8** `tests/integration/test_deformed_shape.py` regression tests pass on the rewired path.
- [x] Full suite: **1494 passed, 49 skipped** (fixture-availability skips only).

## What's next

Phase 2.6 — `NodeLayer` + `VectorLayer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)