### PR TITLE
Add NodeLayer + VectorLayer — viewer (Phase 2.6)

### DIFF
--- a/src/STKO_to_python/viewer/layers/__init__.py
+++ b/src/STKO_to_python/viewer/layers/__init__.py
@@ -1,7 +1,7 @@
 """Concrete :class:`Layer` implementations.
 
-Layers are renderable units in a :class:`Scene`. As of v1.11 the
-package ships two:
+Layers are renderable units in a :class:`Scene`. As of v1.12 the
+package ships four:
 
 * :class:`MeshLayer` — static element-edge wireframe; powers the
   Phase 2.4 rewire of ``ds.plot.mesh`` and ``ds.plot.undeformed_shape``.
@@ -9,18 +9,25 @@ package ships two:
   ``original + scale * displacement``; powers the Phase 2.5 rewire
   of ``ds.plot.deformed_shape`` and supports in-place
   :meth:`~DeformedMeshLayer.update_to_step` for animation.
+* :class:`NodeLayer` — point cloud at node positions, optionally
+  scalar-coloured by a nodal result (Phase 2.6).
+* :class:`VectorLayer` — arrow glyphs at node positions driven by a
+  nodal vector result, with per-step updates (Phase 2.6).
 
-The remaining catalog (node/vector, contour, gauss, diagram, fiber,
-…) lands in Phases 2.6–3.X.
+The remaining catalog (contour, gauss, diagram, fiber, layer stack,
+zerolength, clipping) lands in Phase 3 alongside the PyVista backend.
 
 The Phase 2 contract is the **byte-identical refactor under the
 existing API**: ``ds.plot.*`` keeps every signature and visual
 output; only the implementation now flows through
-Scene + Layer + MplBackend.
+Scene + Layer + MplBackend. Greenfield layers (no v1.x counterpart)
+like NodeLayer and VectorLayer ship with matplotlib coverage so the
+contracts are exercised in unit tests ahead of the 3-D work.
 """
 from __future__ import annotations
 
 from .deformed_mesh import DeformedMeshLayer
 from .mesh import MeshLayer
+from .node import NodeLayer, VectorLayer
 
-__all__ = ["DeformedMeshLayer", "MeshLayer"]
+__all__ = ["DeformedMeshLayer", "MeshLayer", "NodeLayer", "VectorLayer"]

--- a/src/STKO_to_python/viewer/layers/node.py
+++ b/src/STKO_to_python/viewer/layers/node.py
@@ -1,0 +1,553 @@
+"""``NodeLayer`` + ``VectorLayer`` — point cloud and arrow glyphs at node positions.
+
+These are the **first greenfield layers** — neither has a v1.x
+``ds.plot.*`` counterpart to rewire, so they introduce new capability
+rather than re-routing existing code. The first user-facing entry
+points are expected to land in Phase 3 (PyVista backend) alongside
+the 3-D scene catalog; Phase 2.6 ships the layers themselves with
+matplotlib coverage so the contract can be exercised in unit tests
+ahead of the 3-D work.
+
+Both layers fetch nodal results through ``source.dataset.nodes``
+(the same path :func:`~STKO_to_python.plotting.deformed_shape._displacement_at_step`
+uses). That coupling is the same temporary
+``viewer → plotting``-style coupling
+:class:`~STKO_to_python.viewer.layers.DeformedMeshLayer` carries —
+it relocates to the DataSource protocol (``nodal_values`` /
+``nodal_vectors``) in a later phase when more layers need it.
+
+Class split (per
+``docs/viewer/01-architecture.md`` §8 and the directive's §5.4):
+
+* :class:`NodeLayer` — point cloud at node positions. Optional scalar
+  coloring (``result_name`` + ``component``). Time-varying only when
+  a scalar is bound; otherwise :meth:`Layer.update_to_step` is a
+  no-op.
+* :class:`VectorLayer` — arrow glyphs at node positions. The vector
+  field is REQUIRED — the layer carries a ``(result_name,
+  model_stage, step)`` binding and a scale multiplier.
+
+Phase 2.6 perf note: :class:`VectorLayer`'s ``update_to_step``
+removes and re-adds the arrow actor — matplotlib's ``Quiver`` has no
+general in-place vector setter (especially in 3-D), and the
+``Backend.update_arrows`` primitive has not landed yet. The animation
+cost is O(N_arrows) per step until Phase 3 lands the primitive. For
+the 2-D notebook case this is acceptable; the perf contract matters
+for the Phase 4 GUI scrubber where every animation frame is on a
+budget.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+
+from ..core.errors import LayerAttachError
+from ..core.layer import Layer
+from ..core.selection import SelectionSpec
+
+if TYPE_CHECKING:
+    from ..core.datasource import DataSource
+    from ..core.scene import Scene
+
+
+# ---------------------------------------------------------------------- #
+# Shared internals
+# ---------------------------------------------------------------------- #
+def _fetch_nodal_snapshot(
+    dataset: Any,
+    *,
+    result_name: str,
+    model_stage: str,
+    step: int,
+    node_ids: np.ndarray,
+) -> pd.DataFrame:
+    """Pull a single ``(stage, step)`` snapshot of a nodal result.
+
+    Returns a DataFrame whose index is ``node_id`` (matching the
+    caller's order) and whose columns are component keys (typically
+    ``"1"``, ``"2"``, ``"3"`` for a vector result). Wraps the same
+    path :func:`STKO_to_python.plotting.deformed_shape._displacement_at_step`
+    uses so the query-engine cache is shared.
+    """
+    nr = dataset.nodes.get_nodal_results(
+        results_name=result_name,
+        model_stage=model_stage,
+        node_ids=[int(nid) for nid in node_ids],
+    )
+    df = nr.df
+    try:
+        snap = df.xs(int(step), level="step")
+    except KeyError as exc:
+        raise ValueError(
+            f"step={step} not present in {result_name} for stage "
+            f"{model_stage!r}."
+        ) from exc
+
+    cols = snap.columns
+    if isinstance(cols, pd.MultiIndex):
+        comp_cols = [c for c in cols if str(c[0]) == result_name]
+        if not comp_cols:
+            raise ValueError(
+                f"Result {result_name!r} not present in fetched results."
+            )
+        snap = snap.loc[:, comp_cols]
+        snap.columns = [c[1] for c in snap.columns]
+
+    # Reindex to caller's node order so the returned array aligns with
+    # the layer's pre-allocated geometry.
+    snap = snap.reindex([int(nid) for nid in node_ids])
+    return snap
+
+
+def _component_to_scalar(snap: pd.DataFrame, component: Any) -> np.ndarray:
+    """Reduce a nodal-result snapshot to a ``(N,)`` scalar array.
+
+    ``component`` may be:
+
+    * The literal string ``"magnitude"`` — compute
+      ``sqrt(sum_i c_i^2)`` across every available component.
+    * An integer or numeric string (``1``, ``"1"``, ``2``, …) —
+      select the matching column.
+    """
+    if component == "magnitude":
+        arr = snap.to_numpy(dtype=np.float64)
+        return np.linalg.norm(arr, axis=1)
+    col_key = str(component)
+    for c in snap.columns:
+        if str(c) == col_key:
+            return snap[c].to_numpy(dtype=np.float64)
+    raise ValueError(
+        f"Component {component!r} not in available columns "
+        f"{[str(c) for c in snap.columns]}."
+    )
+
+
+def _snap_to_vector(snap: pd.DataFrame, n_components: int) -> np.ndarray:
+    """Reduce a nodal-result snapshot to a ``(N, n_components)`` vector array.
+
+    Components are sorted numerically when possible (``1``, ``2``,
+    ``3``) so ``v[:, 0]`` is always the first component. Missing
+    components are zero-padded; extra components are truncated.
+    """
+    sorted_cols = sorted(
+        snap.columns,
+        key=lambda c: (int(c) if str(c).isdigit() else 1_000_000, str(c)),
+    )
+    snap = snap.loc[:, sorted_cols]
+    arr = snap.to_numpy(dtype=np.float64)
+    n_have = arr.shape[1] if arr.ndim == 2 else 0
+    if n_have < n_components:
+        pad = np.zeros(
+            (arr.shape[0], n_components - n_have), dtype=np.float64,
+        )
+        arr = np.hstack([arr, pad]) if n_have else pad
+    elif n_have > n_components:
+        arr = arr[:, :n_components]
+    return arr
+
+
+# ---------------------------------------------------------------------- #
+# NodeLayer
+# ---------------------------------------------------------------------- #
+class NodeLayer(Layer):
+    """Point cloud at node positions, optional scalar coloring.
+
+    Modes (selected at construction):
+
+    * **Position-only** — ``result_name=None``. Static point cloud at
+      the original node coordinates with uniform ``color``.
+      :meth:`update_to_step` is a no-op.
+    * **Scalar-bound** — ``result_name`` and ``component`` provided.
+      Points are coloured by a per-node scalar derived from a nodal
+      result at ``(model_stage, step)``. :meth:`update_to_step`
+      re-fetches scalars at the new step and calls
+      ``backend.update_scalars`` in place.
+
+    Parameters
+    ----------
+    result_name, component, model_stage, step:
+        Scalar binding. All four are required together if any are
+        provided. ``component`` may be an integer / numeric string
+        (selecting one column from a vector result) or the literal
+        ``"magnitude"`` (compute ``sqrt(sum c_i^2)`` across every
+        available component).
+    color:
+        Uniform colour for the position-only mode. Ignored when
+        ``scalars`` are bound.
+    size:
+        Marker size (matplotlib ``s=`` units).
+    cmap, vmin, vmax:
+        Colormap controls. Used only in scalar-bound mode.
+    name, selection, visible, z_order:
+        Forwarded to :class:`Layer`.
+    mpl_zorder:
+        Matplotlib z-order applied post-hoc via ``actor.set_zorder``.
+        Default ``2.5`` sits above MeshLayer (``1.0``) and at the
+        same level as a typical mesh overlay.
+    """
+
+    kind: str = "node"
+
+    def __init__(
+        self,
+        *,
+        result_name: str | None = None,
+        component: Any = None,
+        model_stage: str | None = None,
+        step: int | None = None,
+        color: Any = "C0",
+        size: float = 20.0,
+        cmap: str | None = "viridis",
+        vmin: float | None = None,
+        vmax: float | None = None,
+        name: str | None = None,
+        selection: "SelectionSpec | None" = None,
+        visible: bool = True,
+        z_order: int = 0,
+        mpl_zorder: float = 2.5,
+    ) -> None:
+        super().__init__(
+            name=name, selection=selection, visible=visible, z_order=z_order,
+        )
+        # Scalar binding is all-or-nothing.
+        bound_any = any(
+            v is not None for v in (result_name, component, model_stage, step)
+        )
+        bound_all = all(
+            v is not None for v in (result_name, component, model_stage)
+        )
+        if bound_any and not bound_all:
+            raise ValueError(
+                "Scalar-bound NodeLayer requires result_name, component, "
+                "AND model_stage (and step at construction); got "
+                f"result_name={result_name!r}, component={component!r}, "
+                f"model_stage={model_stage!r}, step={step!r}."
+            )
+
+        self.result_name = result_name
+        self.component = component
+        self.model_stage = model_stage
+        self._initial_step = step
+        self._current_step: int | None = None
+
+        self.color = color
+        self.size = float(size)
+        self.cmap = cmap
+        self.vmin = vmin
+        self.vmax = vmax
+        self.mpl_zorder = mpl_zorder
+
+        # Populated at attach.
+        self._actor: Any = None
+        self._node_ids: np.ndarray = np.zeros(0, dtype=np.int64)
+        self._coords: np.ndarray = np.zeros((0, 3), dtype=np.float64)
+        self._scalars: np.ndarray | None = None
+
+    # ------------------------------------------------------------------ #
+    # Read-only summary surface
+    # ------------------------------------------------------------------ #
+    @property
+    def is_scalar_bound(self) -> bool:
+        return self.result_name is not None
+
+    @property
+    def current_step(self) -> int | None:
+        return self._current_step
+
+    @property
+    def node_ids(self) -> np.ndarray:
+        return self._node_ids.copy()
+
+    @property
+    def coords(self) -> np.ndarray:
+        return self._coords.copy()
+
+    @property
+    def scalars(self) -> np.ndarray | None:
+        return None if self._scalars is None else self._scalars.copy()
+
+    @property
+    def actor(self) -> Any:
+        return self._actor
+
+    # ------------------------------------------------------------------ #
+    # Layer lifecycle
+    # ------------------------------------------------------------------ #
+    def attach(self, scene: "Scene", source: "DataSource") -> None:
+        if self.is_attached:
+            raise LayerAttachError(f"Layer {self.name!r} is already attached.")
+        self._scene = scene
+        self._source = source
+
+        ids = source.resolve_node_ids(self.selection)
+        if ids.size == 0:
+            raise LayerAttachError(
+                f"No nodes remain after filtering for {self.selection!r}."
+            )
+        self._node_ids = ids
+        self._coords = source.node_coords(ids)
+
+        scalars: np.ndarray | None = None
+        if self.is_scalar_bound:
+            scalars = self._fetch_scalars(self._initial_step)
+            self._scalars = scalars
+
+        actor = scene.backend.add_points(
+            scene.handle,
+            self._coords,
+            color=self.color if scalars is None else None,
+            size=self.size,
+            scalars=scalars,
+            cmap=self.cmap if scalars is not None else None,
+        )
+        self._actor = actor
+
+        if hasattr(actor, "set_zorder"):
+            actor.set_zorder(self.mpl_zorder)
+        if scalars is not None and (
+            self.vmin is not None or self.vmax is not None
+        ):
+            if hasattr(actor, "set_clim"):
+                actor.set_clim(self.vmin, self.vmax)
+
+        if not self.visible:
+            scene.backend.set_visible(actor, False)
+
+        self._current_step = self._initial_step
+
+    def update_to_step(self, step: int) -> None:
+        """Re-fetch scalars at ``step`` (no-op in position-only mode)."""
+        if not self.is_attached:
+            return
+        if not self.is_scalar_bound:
+            return
+        if step == self._current_step:
+            return
+        scalars = self._fetch_scalars(step)
+        self._scalars = scalars
+        self._scene.backend.update_scalars(self._actor, scalars)  # type: ignore[union-attr]
+        self._current_step = step
+
+    def detach(self) -> None:
+        scene = self._scene
+        if scene is not None and self._actor is not None:
+            scene.backend.remove(scene.handle, self._actor)
+        self._actor = None
+        self._node_ids = np.zeros(0, dtype=np.int64)
+        self._coords = np.zeros((0, 3), dtype=np.float64)
+        self._scalars = None
+        self._current_step = None
+        self._scene = None
+        self._source = None
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    def _fetch_scalars(self, step: int | None) -> np.ndarray:
+        if step is None:
+            raise LayerAttachError(
+                "Scalar-bound NodeLayer requires step= at construction "
+                "(or via update_to_step)."
+            )
+        snap = _fetch_nodal_snapshot(
+            self._source.dataset,  # type: ignore[union-attr]
+            result_name=self.result_name,  # type: ignore[arg-type]
+            model_stage=self.model_stage,  # type: ignore[arg-type]
+            step=int(step),
+            node_ids=self._node_ids,
+        )
+        return _component_to_scalar(snap, self.component)
+
+
+# ---------------------------------------------------------------------- #
+# VectorLayer
+# ---------------------------------------------------------------------- #
+class VectorLayer(Layer):
+    """Arrow glyphs at node positions, vector from a nodal result.
+
+    Origins are the **original** node coordinates (Phase 2.6). A
+    deformed-origin variant — origins follow a
+    :class:`~STKO_to_python.viewer.layers.DeformedMeshLayer` — lands in
+    Phase 3 alongside the PyVista backend.
+
+    Vectors are pulled from ``(model_stage, step)`` of ``result_name``;
+    missing components are zero-padded, extras truncated. Plot through
+    ``backend.add_arrows`` with the configured ``scale``.
+
+    Phase 2.6 perf gap: :meth:`update_to_step` **removes and re-adds**
+    the arrow actor. matplotlib's ``Quiver`` lacks a generic in-place
+    vector setter (especially in 3-D), and the
+    ``Backend.update_arrows`` primitive has not landed yet. Per-step
+    cost is O(N_arrows). The Phase 3 PyVista backend adds the
+    primitive and this layer switches to in-place updates.
+
+    Parameters
+    ----------
+    result_name, model_stage, step:
+        Vector result binding. ``step`` is the initial step;
+        :meth:`update_to_step` advances it.
+    scale:
+        Multiplier applied to the raw vector before plotting.
+    n_components:
+        How many components to extract per node. Default ``3``;
+        missing components are zero-padded, extras truncated.
+    color, cmap:
+        Forwarded to ``backend.add_arrows``.
+    name, selection, visible, z_order:
+        Forwarded to :class:`Layer`.
+    """
+
+    kind: str = "vector"
+
+    def __init__(
+        self,
+        *,
+        result_name: str,
+        model_stage: str,
+        step: int,
+        scale: float = 1.0,
+        n_components: int = 3,
+        color: Any = "C1",
+        cmap: str | None = None,
+        name: str | None = None,
+        selection: "SelectionSpec | None" = None,
+        visible: bool = True,
+        z_order: int = 0,
+    ) -> None:
+        super().__init__(
+            name=name, selection=selection, visible=visible, z_order=z_order,
+        )
+        if not result_name or not model_stage:
+            raise ValueError(
+                "VectorLayer requires result_name and model_stage; got "
+                f"result_name={result_name!r}, model_stage={model_stage!r}."
+            )
+        if n_components < 1:
+            raise ValueError(f"n_components must be ≥ 1; got {n_components}.")
+
+        self.result_name = result_name
+        self.model_stage = model_stage
+        self.scale = float(scale)
+        self.n_components = int(n_components)
+        self.color = color
+        self.cmap = cmap
+
+        self._initial_step = int(step) if step is not None else None
+        self._current_step: int | None = None
+        self._actor: Any = None
+        self._node_ids: np.ndarray = np.zeros(0, dtype=np.int64)
+        self._origins: np.ndarray = np.zeros((0, 3), dtype=np.float64)
+        self._vectors: np.ndarray = np.zeros((0, 3), dtype=np.float64)
+
+    # ------------------------------------------------------------------ #
+    # Read-only summary
+    # ------------------------------------------------------------------ #
+    @property
+    def current_step(self) -> int | None:
+        return self._current_step
+
+    @property
+    def node_ids(self) -> np.ndarray:
+        return self._node_ids.copy()
+
+    @property
+    def origins(self) -> np.ndarray:
+        return self._origins.copy()
+
+    @property
+    def vectors(self) -> np.ndarray:
+        return self._vectors.copy()
+
+    @property
+    def actor(self) -> Any:
+        return self._actor
+
+    # ------------------------------------------------------------------ #
+    # Layer lifecycle
+    # ------------------------------------------------------------------ #
+    def attach(self, scene: "Scene", source: "DataSource") -> None:
+        if self.is_attached:
+            raise LayerAttachError(f"Layer {self.name!r} is already attached.")
+        self._scene = scene
+        self._source = source
+
+        ids = source.resolve_node_ids(self.selection)
+        if ids.size == 0:
+            raise LayerAttachError(
+                f"No nodes remain after filtering for {self.selection!r}."
+            )
+        self._node_ids = ids
+        self._origins = source.node_coords(ids)
+        self._vectors = self._fetch_vectors(self._initial_step)
+
+        self._actor = scene.backend.add_arrows(
+            scene.handle,
+            self._origins,
+            self._vectors,
+            scale=self.scale,
+            color=self.color,
+            cmap=self.cmap,
+        )
+        if not self.visible:
+            scene.backend.set_visible(self._actor, False)
+        self._current_step = self._initial_step
+
+    def update_to_step(self, step: int) -> None:
+        """Advance to ``step`` by removing + re-adding the arrow actor.
+
+        See class docstring for the Phase 2.6 perf gap rationale.
+        """
+        if not self.is_attached:
+            return
+        if step == self._current_step:
+            return
+        scene = self._scene  # type: ignore[assignment]
+        # Remove the existing actor before re-adding.
+        scene.backend.remove(scene.handle, self._actor)
+        self._vectors = self._fetch_vectors(step)
+        self._actor = scene.backend.add_arrows(
+            scene.handle,
+            self._origins,
+            self._vectors,
+            scale=self.scale,
+            color=self.color,
+            cmap=self.cmap,
+        )
+        if not self.visible:
+            scene.backend.set_visible(self._actor, False)
+        self._current_step = step
+
+    def detach(self) -> None:
+        scene = self._scene
+        if scene is not None and self._actor is not None:
+            scene.backend.remove(scene.handle, self._actor)
+        self._actor = None
+        self._node_ids = np.zeros(0, dtype=np.int64)
+        self._origins = np.zeros((0, 3), dtype=np.float64)
+        self._vectors = np.zeros((0, 3), dtype=np.float64)
+        self._current_step = None
+        self._scene = None
+        self._source = None
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    def _fetch_vectors(self, step: int | None) -> np.ndarray:
+        if step is None:
+            raise LayerAttachError(
+                "VectorLayer requires step= at construction "
+                "(or via update_to_step)."
+            )
+        snap = _fetch_nodal_snapshot(
+            self._source.dataset,  # type: ignore[union-attr]
+            result_name=self.result_name,
+            model_stage=self.model_stage,
+            step=int(step),
+            node_ids=self._node_ids,
+        )
+        return _snap_to_vector(snap, self.n_components)
+
+
+__all__ = ["NodeLayer", "VectorLayer"]

--- a/tests/viewer/layers/test_node_layer.py
+++ b/tests/viewer/layers/test_node_layer.py
@@ -1,0 +1,426 @@
+"""Tests for :class:`NodeLayer`.
+
+Coverage:
+
+1. Construction validation — scalar binding is all-or-nothing.
+2. Position-only mode — static layer, ``update_to_step`` is a no-op.
+3. Scalar-bound mode — initial scalars at attach, in-place updates
+   via ``backend.update_scalars`` on step changes; magnitude and
+   single-component selectors both work.
+4. Selection subsetting (matches the same SelectionSpec contract the
+   other layers use).
+5. Detach cleanup.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import PathCollection
+
+from STKO_to_python.viewer.backends.mpl.backend import MplBackend
+from STKO_to_python.viewer.core import (
+    MPCODataSourceAdapter,
+    Scene,
+    SelectionSpec,
+)
+from STKO_to_python.viewer.core.errors import LayerAttachError
+from STKO_to_python.viewer.layers import NodeLayer
+
+
+# --------------------------------------------------------------------- #
+# Fake-dataset helpers
+# --------------------------------------------------------------------- #
+
+
+class _FakeNodalResults:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+
+
+def _make_disp_df(
+    node_ids,
+    *,
+    n_steps: int = 5,
+    vectors: dict[int, np.ndarray] | None = None,
+) -> pd.DataFrame:
+    """Build a ``(node_id, step) -> (DISPLACEMENT, 1/2/3)`` DataFrame.
+
+    ``vectors``: optional ``{node_id: ndarray(n_steps, 3)}`` — when a
+    node is missing it gets zeros.
+    """
+    rows = []
+    for nid in node_ids:
+        per_node = (
+            vectors[int(nid)]
+            if vectors and int(nid) in vectors
+            else np.zeros((n_steps, 3), dtype=np.float64)
+        )
+        for step in range(n_steps):
+            rows.append(
+                {
+                    "node_id": int(nid),
+                    "step": int(step),
+                    "c1": float(per_node[step, 0]),
+                    "c2": float(per_node[step, 1]),
+                    "c3": float(per_node[step, 2]),
+                }
+            )
+    df = pd.DataFrame(rows).set_index(["node_id", "step"])
+    df.columns = pd.MultiIndex.from_tuples(
+        [("DISPLACEMENT", "1"), ("DISPLACEMENT", "2"), ("DISPLACEMENT", "3")],
+        names=["result", "component"],
+    )
+    return df
+
+
+def _make_fake_dataset(*, displacement_df: pd.DataFrame | None = None):
+    node_rows = [
+        (1, 0.0, 0.0, 0.0),
+        (2, 1.0, 0.0, 0.0),
+        (3, 1.0, 1.0, 0.0),
+        (4, 0.0, 1.0, 0.0),
+    ]
+    elem_rows = [
+        (10, "5-ElasticBeam3d", 2, (1, 2)),
+        (11, "203-ASDShellQ4", 4, (1, 2, 3, 4)),
+    ]
+    nodes_df = pd.DataFrame(node_rows, columns=["node_id", "x", "y", "z"])
+    elements_df = pd.DataFrame(
+        elem_rows,
+        columns=["element_id", "element_type", "num_nodes", "node_list"],
+    )
+
+    if displacement_df is None:
+        displacement_df = _make_disp_df([1, 2, 3, 4])
+
+    def _fake_get_nodal_results(*, results_name, model_stage, node_ids):
+        return _FakeNodalResults(displacement_df)
+
+    nodes_obj = SimpleNamespace(get_nodal_results=_fake_get_nodal_results)
+
+    fake = SimpleNamespace(
+        nodes=nodes_obj,
+        nodes_info={"dataframe": nodes_df},
+        elements_info={"dataframe": elements_df},
+        model_stages=["STAGE_0"],
+        number_of_steps={"STAGE_0": 5},
+        time=pd.DataFrame(
+            [{"MODEL_STAGE": "STAGE_0", "STEP": i, "TIME": float(i) * 0.1}
+             for i in range(5)]
+        ).set_index(["MODEL_STAGE", "STEP"]),
+    )
+    fake._selection_resolver = None
+    return fake
+
+
+def _make_scene(fake_dataset, *, is_3d=False):
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d)
+    source = MPCODataSourceAdapter(fake_dataset)
+    return Scene(backend, source, is_3d=is_3d, handle=handle)
+
+
+# --------------------------------------------------------------------- #
+# Construction
+# --------------------------------------------------------------------- #
+
+
+def test_kind_is_node() -> None:
+    assert NodeLayer.kind == "node"
+
+
+def test_default_construction_is_position_only() -> None:
+    layer = NodeLayer()
+    assert layer.is_scalar_bound is False
+    assert layer.result_name is None
+    assert layer.size == 20.0
+    assert layer.mpl_zorder == 2.5
+
+
+def test_partial_scalar_binding_raises() -> None:
+    """Scalar binding is all-or-nothing — partial binding is rejected."""
+    with pytest.raises(ValueError, match="all-or-nothing|requires result_name"):
+        NodeLayer(result_name="DISPLACEMENT")
+    with pytest.raises(ValueError, match="requires result_name"):
+        NodeLayer(result_name="DISPLACEMENT", component="1")
+    with pytest.raises(ValueError, match="requires result_name"):
+        NodeLayer(component="magnitude", model_stage="STAGE_0", step=0)
+
+
+def test_full_scalar_binding_is_accepted() -> None:
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="1",
+        model_stage="STAGE_0",
+        step=0,
+    )
+    assert layer.is_scalar_bound is True
+
+
+# --------------------------------------------------------------------- #
+# Position-only mode
+# --------------------------------------------------------------------- #
+
+
+def test_position_only_attach_places_one_point_per_node() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer()
+    try:
+        scene.add(layer)
+        assert isinstance(layer.actor, PathCollection)
+        assert layer.node_ids.tolist() == [1, 2, 3, 4]
+        assert layer.coords.shape == (4, 3)
+        assert layer.scalars is None
+    finally:
+        plt.close("all")
+
+
+def test_position_only_update_to_step_is_no_op() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer()
+    try:
+        scene.add(layer)
+        actor_before = layer.actor
+        layer.update_to_step(3)
+        assert layer.actor is actor_before
+        assert layer.current_step is None  # never set in position-only mode
+    finally:
+        plt.close("all")
+
+
+def test_position_only_attach_applies_mpl_zorder() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer(mpl_zorder=4.0)
+    try:
+        scene.add(layer)
+        assert layer.actor.get_zorder() == pytest.approx(4.0)
+    finally:
+        plt.close("all")
+
+
+def test_position_only_attach_respects_visible_false() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer(visible=False)
+    try:
+        scene.add(layer)
+        assert layer.actor.get_visible() is False
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Scalar-bound mode
+# --------------------------------------------------------------------- #
+
+
+def test_scalar_bound_attach_fetches_initial_scalars() -> None:
+    # Make node 2 at step 3 have displacement (1, 0, 0).
+    vectors = {2: np.zeros((5, 3))}
+    vectors[2][3] = np.array([1.0, 0.0, 0.0])
+    df = _make_disp_df([1, 2, 3, 4], vectors=vectors)
+    fake = _make_fake_dataset(displacement_df=df)
+
+    scene = _make_scene(fake)
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="1",
+        model_stage="STAGE_0",
+        step=3,
+    )
+    try:
+        scene.add(layer)
+        scalars = layer.scalars
+        assert scalars is not None
+        # node 2 (row 1 in [1,2,3,4]) has component 1 = 1.0
+        assert scalars[1] == pytest.approx(1.0)
+        # others are zero
+        assert scalars[0] == pytest.approx(0.0)
+        assert scalars[2] == pytest.approx(0.0)
+        assert scalars[3] == pytest.approx(0.0)
+        assert layer.current_step == 3
+    finally:
+        plt.close("all")
+
+
+def test_scalar_bound_magnitude_computes_norm() -> None:
+    vectors = {3: np.zeros((5, 3))}
+    vectors[3][0] = np.array([3.0, 4.0, 0.0])  # magnitude = 5
+    df = _make_disp_df([1, 2, 3, 4], vectors=vectors)
+    fake = _make_fake_dataset(displacement_df=df)
+
+    scene = _make_scene(fake)
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="magnitude",
+        model_stage="STAGE_0",
+        step=0,
+    )
+    try:
+        scene.add(layer)
+        scalars = layer.scalars
+        # node 3 is index 2 in [1,2,3,4]
+        assert scalars[2] == pytest.approx(5.0)
+        assert scalars[0] == pytest.approx(0.0)
+    finally:
+        plt.close("all")
+
+
+def test_scalar_bound_unknown_component_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="bogus",
+        model_stage="STAGE_0",
+        step=0,
+    )
+    try:
+        with pytest.raises(ValueError, match="bogus"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_scalar_bound_update_to_step_replaces_scalars_in_place() -> None:
+    """update_to_step must call backend.update_scalars on the SAME
+    actor — no recreation."""
+    vectors = {
+        1: np.zeros((5, 3)),
+        2: np.zeros((5, 3)),
+    }
+    vectors[1][2] = np.array([10.0, 0.0, 0.0])
+    vectors[2][4] = np.array([20.0, 0.0, 0.0])
+    df = _make_disp_df([1, 2, 3, 4], vectors=vectors)
+    fake = _make_fake_dataset(displacement_df=df)
+
+    scene = _make_scene(fake)
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="1",
+        model_stage="STAGE_0",
+        step=2,
+    )
+    try:
+        scene.add(layer)
+        actor_at_step2 = layer.actor
+        assert layer.scalars[0] == pytest.approx(10.0)
+
+        layer.update_to_step(4)
+        # Same actor object — no recreation.
+        assert layer.actor is actor_at_step2
+        assert layer.current_step == 4
+        # Scalars reflect step 4.
+        assert layer.scalars[1] == pytest.approx(20.0)
+        assert layer.scalars[0] == pytest.approx(0.0)
+    finally:
+        plt.close("all")
+
+
+def test_scalar_bound_update_to_step_unchanged_is_no_op() -> None:
+    call_log = {"n": 0}
+
+    def _counting(*, results_name, model_stage, node_ids):
+        call_log["n"] += 1
+        return _FakeNodalResults(_make_disp_df([1, 2, 3, 4]))
+
+    fake = _make_fake_dataset()
+    fake.nodes = SimpleNamespace(get_nodal_results=_counting)
+    scene = _make_scene(fake)
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="1",
+        model_stage="STAGE_0",
+        step=2,
+    )
+    try:
+        scene.add(layer)
+        n_attach = call_log["n"]
+        layer.update_to_step(2)
+        assert call_log["n"] == n_attach
+    finally:
+        plt.close("all")
+
+
+def test_pre_attach_update_to_step_is_silent() -> None:
+    layer = NodeLayer(
+        result_name="DISPLACEMENT",
+        component="1",
+        model_stage="STAGE_0",
+        step=0,
+    )
+    layer.update_to_step(5)
+    assert layer.current_step is None
+
+
+# --------------------------------------------------------------------- #
+# Selection subsetting
+# --------------------------------------------------------------------- #
+
+
+def test_selection_by_node_ids_subsets_layer() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer(selection=SelectionSpec(node_ids=(2, 4)))
+    try:
+        scene.add(layer)
+        assert layer.node_ids.tolist() == [2, 4]
+        assert layer.coords.shape == (2, 3)
+    finally:
+        plt.close("all")
+
+
+def test_empty_selection_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer(selection=SelectionSpec(node_ids=(9999,)))
+    try:
+        with pytest.raises(LayerAttachError, match="No nodes remain"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Detach
+# --------------------------------------------------------------------- #
+
+
+def test_detach_clears_state() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer()
+    try:
+        scene.add(layer)
+        assert layer.is_attached
+        assert layer.node_ids.size == 4
+        scene.remove(layer)
+        assert not layer.is_attached
+        assert layer.node_ids.size == 0
+        assert layer.coords.size == 0
+        assert layer.scalars is None
+        assert layer.actor is None
+    finally:
+        plt.close("all")
+
+
+def test_attach_twice_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = NodeLayer()
+    try:
+        scene.add(layer)
+        with pytest.raises(LayerAttachError, match="already attached"):
+            layer.attach(scene, scene.source)
+    finally:
+        plt.close("all")

--- a/tests/viewer/layers/test_vector_layer.py
+++ b/tests/viewer/layers/test_vector_layer.py
@@ -1,0 +1,371 @@
+"""Tests for :class:`VectorLayer`.
+
+Coverage:
+
+1. Construction validation — ``result_name`` and ``model_stage``
+   are required; ``n_components`` must be ≥ 1.
+2. Attach — origins from node coords, vectors fetched from the
+   result, padded/truncated to ``n_components``.
+3. ``update_to_step`` — remove + re-add (Phase 2.6 perf gap;
+   documented in the layer's class docstring). Pin the contract:
+   actor instance changes across step updates so callers can detect
+   the remove-re-add lifecycle.
+4. Selection subsetting.
+5. Detach cleanup.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.viewer.backends.mpl.backend import MplBackend
+from STKO_to_python.viewer.core import (
+    MPCODataSourceAdapter,
+    Scene,
+    SelectionSpec,
+)
+from STKO_to_python.viewer.core.errors import LayerAttachError
+from STKO_to_python.viewer.layers import VectorLayer
+
+
+# --------------------------------------------------------------------- #
+# Fake-dataset helpers (same shape as test_node_layer.py)
+# --------------------------------------------------------------------- #
+
+
+class _FakeNodalResults:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+
+
+def _make_disp_df(
+    node_ids,
+    *,
+    n_steps: int = 5,
+    vectors: dict[int, np.ndarray] | None = None,
+    n_components: int = 3,
+) -> pd.DataFrame:
+    rows = []
+    for nid in node_ids:
+        per_node = (
+            vectors[int(nid)]
+            if vectors and int(nid) in vectors
+            else np.zeros((n_steps, n_components), dtype=np.float64)
+        )
+        for step in range(n_steps):
+            row = {"node_id": int(nid), "step": int(step)}
+            for c in range(n_components):
+                row[f"c{c + 1}"] = float(per_node[step, c])
+            rows.append(row)
+    df = pd.DataFrame(rows).set_index(["node_id", "step"])
+    df.columns = pd.MultiIndex.from_tuples(
+        [("DISPLACEMENT", str(c + 1)) for c in range(n_components)],
+        names=["result", "component"],
+    )
+    return df
+
+
+def _make_fake_dataset(*, displacement_df: pd.DataFrame | None = None):
+    node_rows = [
+        (1, 0.0, 0.0, 0.0),
+        (2, 1.0, 0.0, 0.0),
+        (3, 1.0, 1.0, 0.0),
+        (4, 0.0, 1.0, 0.0),
+    ]
+    elem_rows = [
+        (10, "5-ElasticBeam3d", 2, (1, 2)),
+    ]
+    nodes_df = pd.DataFrame(node_rows, columns=["node_id", "x", "y", "z"])
+    elements_df = pd.DataFrame(
+        elem_rows,
+        columns=["element_id", "element_type", "num_nodes", "node_list"],
+    )
+
+    if displacement_df is None:
+        displacement_df = _make_disp_df([1, 2, 3, 4])
+
+    def _fake(*, results_name, model_stage, node_ids):
+        return _FakeNodalResults(displacement_df)
+
+    fake = SimpleNamespace(
+        nodes=SimpleNamespace(get_nodal_results=_fake),
+        nodes_info={"dataframe": nodes_df},
+        elements_info={"dataframe": elements_df},
+        model_stages=["STAGE_0"],
+        number_of_steps={"STAGE_0": 5},
+        time=pd.DataFrame(
+            [{"MODEL_STAGE": "STAGE_0", "STEP": i, "TIME": float(i) * 0.1}
+             for i in range(5)]
+        ).set_index(["MODEL_STAGE", "STEP"]),
+    )
+    fake._selection_resolver = None
+    return fake
+
+
+def _make_scene(fake_dataset, *, is_3d=False):
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d)
+    source = MPCODataSourceAdapter(fake_dataset)
+    return Scene(backend, source, is_3d=is_3d, handle=handle)
+
+
+# --------------------------------------------------------------------- #
+# Construction
+# --------------------------------------------------------------------- #
+
+
+def test_kind_is_vector() -> None:
+    assert VectorLayer.kind == "vector"
+
+
+def test_construction_requires_result_name() -> None:
+    with pytest.raises(ValueError, match="requires result_name"):
+        VectorLayer(result_name="", model_stage="STAGE_0", step=0)
+
+
+def test_construction_requires_model_stage() -> None:
+    with pytest.raises(ValueError, match="requires result_name"):
+        VectorLayer(result_name="DISPLACEMENT", model_stage="", step=0)
+
+
+def test_construction_rejects_zero_n_components() -> None:
+    with pytest.raises(ValueError, match="n_components"):
+        VectorLayer(
+            result_name="DISPLACEMENT", model_stage="STAGE_0",
+            step=0, n_components=0,
+        )
+
+
+def test_construction_preserves_config() -> None:
+    layer = VectorLayer(
+        result_name="DISPLACEMENT",
+        model_stage="MODEL_STAGE[1]",
+        step=7,
+        scale=50.0,
+        n_components=2,
+        color="red",
+    )
+    assert layer.result_name == "DISPLACEMENT"
+    assert layer.model_stage == "MODEL_STAGE[1]"
+    assert layer.scale == 50.0
+    assert layer.n_components == 2
+    assert layer.color == "red"
+
+
+# --------------------------------------------------------------------- #
+# Attach
+# --------------------------------------------------------------------- #
+
+
+def test_attach_places_arrow_origins_at_node_coords() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+    )
+    try:
+        scene.add(layer)
+        assert layer.node_ids.tolist() == [1, 2, 3, 4]
+        np.testing.assert_allclose(layer.origins[0], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(layer.origins[1], [1.0, 0.0, 0.0])
+        assert layer.actor is not None
+        assert layer.current_step == 0
+    finally:
+        plt.close("all")
+
+
+def test_attach_extracts_vectors_at_initial_step() -> None:
+    vectors = {2: np.zeros((5, 3))}
+    vectors[2][3] = np.array([0.5, 1.5, -0.25])
+    df = _make_disp_df([1, 2, 3, 4], vectors=vectors)
+    fake = _make_fake_dataset(displacement_df=df)
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=3,
+    )
+    try:
+        scene.add(layer)
+        # node 2 is row 1.
+        np.testing.assert_allclose(layer.vectors[1], [0.5, 1.5, -0.25])
+        # others are zero.
+        np.testing.assert_allclose(layer.vectors[0], [0.0, 0.0, 0.0])
+    finally:
+        plt.close("all")
+
+
+def test_attach_pads_short_results_to_n_components() -> None:
+    """A 2-component result must be zero-padded to length 3 by default."""
+    df = _make_disp_df([1, 2, 3, 4], n_components=2)
+    fake = _make_fake_dataset(displacement_df=df)
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+    )
+    try:
+        scene.add(layer)
+        assert layer.vectors.shape == (4, 3)
+        np.testing.assert_allclose(layer.vectors[:, 2], 0.0)
+    finally:
+        plt.close("all")
+
+
+def test_attach_truncates_long_results_to_n_components() -> None:
+    df = _make_disp_df([1, 2, 3, 4], n_components=5)
+    fake = _make_fake_dataset(displacement_df=df)
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+        n_components=3,
+    )
+    try:
+        scene.add(layer)
+        assert layer.vectors.shape == (4, 3)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# update_to_step — perf gap (remove + re-add)
+# --------------------------------------------------------------------- #
+
+
+def test_update_to_step_swaps_actor_and_advances_step() -> None:
+    """Phase 2.6 perf gap: update_to_step removes + re-adds the
+    arrow actor. Test pins this contract — the actor *instance*
+    changes, but vectors track the new step."""
+    vectors = {2: np.zeros((5, 3))}
+    vectors[2][1] = np.array([1.0, 0.0, 0.0])
+    vectors[2][4] = np.array([0.0, 2.0, 0.0])
+    df = _make_disp_df([1, 2, 3, 4], vectors=vectors)
+    fake = _make_fake_dataset(displacement_df=df)
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=1,
+    )
+    try:
+        scene.add(layer)
+        actor_at_step1 = layer.actor
+        np.testing.assert_allclose(layer.vectors[1], [1.0, 0.0, 0.0])
+
+        layer.update_to_step(4)
+        # Different actor instance — see class docstring.
+        assert layer.actor is not actor_at_step1
+        assert layer.current_step == 4
+        np.testing.assert_allclose(layer.vectors[1], [0.0, 2.0, 0.0])
+    finally:
+        plt.close("all")
+
+
+def test_update_to_step_no_op_on_unchanged_step() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=2,
+    )
+    try:
+        scene.add(layer)
+        actor_before = layer.actor
+        layer.update_to_step(2)
+        assert layer.actor is actor_before
+    finally:
+        plt.close("all")
+
+
+def test_pre_attach_update_to_step_is_silent() -> None:
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+    )
+    layer.update_to_step(3)
+    assert layer.current_step is None
+
+
+# --------------------------------------------------------------------- #
+# Selection + detach
+# --------------------------------------------------------------------- #
+
+
+def test_selection_subsets_arrows() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+        selection=SelectionSpec(node_ids=(1, 3)),
+    )
+    try:
+        scene.add(layer)
+        assert layer.node_ids.tolist() == [1, 3]
+        assert layer.origins.shape == (2, 3)
+        assert layer.vectors.shape == (2, 3)
+    finally:
+        plt.close("all")
+
+
+def test_empty_selection_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+        selection=SelectionSpec(node_ids=(9999,)),
+    )
+    try:
+        with pytest.raises(LayerAttachError, match="No nodes remain"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_detach_clears_state_and_removes_actor() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+    )
+    try:
+        scene.add(layer)
+        assert layer.is_attached
+        scene.remove(layer)
+        assert not layer.is_attached
+        assert layer.actor is None
+        assert layer.node_ids.size == 0
+        assert layer.origins.size == 0
+        assert layer.vectors.size == 0
+        assert layer.current_step is None
+    finally:
+        plt.close("all")
+
+
+def test_attach_twice_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+    )
+    try:
+        scene.add(layer)
+        with pytest.raises(LayerAttachError, match="already attached"):
+            layer.attach(scene, scene.source)
+    finally:
+        plt.close("all")
+
+
+def test_invisible_on_attach_hides_actor() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = VectorLayer(
+        result_name="DISPLACEMENT", model_stage="STAGE_0", step=0,
+        visible=False,
+    )
+    try:
+        scene.add(layer)
+        # Quiver inherits the matplotlib Artist API (set_visible /
+        # get_visible).
+        assert layer.actor.get_visible() is False
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary

- **First greenfield layers** — neither has a v1.x `ds.plot.*` counterpart to rewire. Phase 2.6 ships them with matplotlib coverage so the contracts are exercised in unit tests ahead of Phase 3 (PyVista backend) where they get their user-facing entry points.
- **`NodeLayer`** — point cloud at node positions, optionally scalar-coloured by a nodal result (component selector supports both single-column and `"magnitude"`). Scalar binding is validated all-or-nothing at construction. `update_to_step` mutates the scatter's scalar array via `backend.update_scalars` — **same actor instance across steps** (apeGmsh perf contract).
- **`VectorLayer`** — arrow glyphs at original node positions, driven by a nodal vector result with configurable `n_components` (defaults to 3; missing components are zero-padded, extras truncated). `update_to_step` **removes + re-adds** the arrow actor — Phase 2.6 perf gap, documented in the class docstring (matplotlib's Quiver lacks a generic in-place vector setter, especially in 3-D; the `Backend.update_arrows` primitive lands in Phase 3).

## Design notes

- Both layers share `_fetch_nodal_snapshot` (calls `dataset.nodes.get_nodal_results` — same path `_displacement_at_step` uses, so the query-engine cache is hit) plus two reduction helpers: `_component_to_scalar` (magnitude / single component) and `_snap_to_vector` (numeric component sort + pad/truncate).
- The temporary `viewer → dataset` coupling matches the one `DeformedMeshLayer` already carries; both relocate to the `DataSource` protocol (`nodal_values` / `nodal_vectors`) in a later phase when more layers need them.
- `NodeLayer.mpl_zorder=2.5` sits above `MeshLayer` (1.0); `VectorLayer` uses matplotlib's default Quiver zorder.

## Test plan

- [x] **35 new tests** across [`tests/viewer/layers/test_node_layer.py`](tests/viewer/layers/test_node_layer.py) (18) and [`test_vector_layer.py`](tests/viewer/layers/test_vector_layer.py) (17): construction validation, position-only mode, scalar binding (magnitude / single component), **in-place update for NodeLayer** (same actor across steps), **remove+re-add for VectorLayer** (different actor across steps, contract is pinned), selection subsetting, detach cleanup, attach-twice guards, visibility-on-attach.
- [x] Full suite: **1529 passed, 49 skipped** (fixture-availability skips only). All prior MeshLayer / DeformedMeshLayer / plot regression tests stay green.

## What's next

Phase 3.0 — `PyVistaBackend` + `ContourLayer` (five-path dispatch ported from apeGmsh: nodal / GP-cell / GP-cell-averaged / GP-node-extrapolated / GP-node-discrete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)