### PR TITLE
Add PyVistaBackend — viewer (Phase 3.0a)

### DIFF
--- a/src/STKO_to_python/viewer/backends/pyvista/__init__.py
+++ b/src/STKO_to_python/viewer/backends/pyvista/__init__.py
@@ -1,0 +1,14 @@
+"""PyVista :class:`Backend` implementation.
+
+Wraps a :class:`pyvista.Plotter` (off-screen or windowed) so the same
+``Scene`` / ``Layer`` graph that drives the matplotlib backend can
+render through VTK in 3-D. Gated behind the optional
+``[viewer-3d]`` extra; importing this subpackage when ``pyvista``
+isn't installed raises :class:`ImportError` so the lightweight
+notebook path (``pip install stko_to_python``) is unaffected.
+"""
+from __future__ import annotations
+
+from .backend import PvSceneHandle, PyVistaBackend
+
+__all__ = ["PvSceneHandle", "PyVistaBackend"]

--- a/src/STKO_to_python/viewer/backends/pyvista/backend.py
+++ b/src/STKO_to_python/viewer/backends/pyvista/backend.py
@@ -1,0 +1,494 @@
+"""PyVista :class:`Backend` implementation.
+
+Maps every primitive on the
+:class:`STKO_to_python.viewer.core.Backend` protocol onto PyVista /
+VTK's 3-D drawing surface. The scene handle wraps a
+:class:`pyvista.Plotter` (windowed or off-screen) and the per-actor
+state is a small :class:`_PvActorRef` record carrying the actor +
+the underlying ``pyvista.DataSet`` + the bound scalar field name.
+
+The dataset is held on the actor ref so :meth:`update_scalars` and
+:meth:`update_points` mutate the same arrays in place — the
+apeGmsh perf contract that keeps animation playback fast. Each
+``Modified()`` invalidation flags only the changed actor; the rest
+of the scene re-renders unchanged.
+
+The Phase 3.0 release matches the
+:class:`STKO_to_python.viewer.backends.mpl.MplBackend` API surface
+1-to-1; concrete 3-D layer types
+(``ContourLayer``, ``GaussLayer``, ``VolumeLayer``, …) ride on top
+in Phase 3.1+ and gain capabilities (``add_clipped``, ``add_slice``,
+``add_iso``) that PyVista handles natively but matplotlib cannot.
+
+This module is **only** imported when the optional ``[viewer-3d]``
+extra is installed. Layer / scene code reaches it indirectly through
+``Scene.backend`` so the import is lazy from the consumer side too.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable
+
+import numpy as np
+
+try:
+    import pyvista as pv
+except ImportError as exc:  # pragma: no cover - exercised by the smoke test
+    raise ImportError(
+        "PyVistaBackend requires the [viewer-3d] extra. Install with "
+        "'pip install \"stko_to_python[viewer-3d]\"' or "
+        "'pip install pyvista>=0.43 vtk>=9.2'."
+    ) from exc
+
+from ...core.errors import BackendCapabilityError
+from ...core.types import ActorRef, BBox, CameraSpec
+
+if TYPE_CHECKING:
+    from ...core.style import SceneStyle
+
+
+# ---------------------------------------------------------------------- #
+# Handles & actor records
+# ---------------------------------------------------------------------- #
+
+
+@dataclass
+class PvSceneHandle:
+    """Wraps a single :class:`pyvista.Plotter`.
+
+    The plotter is allocated by :meth:`PyVistaBackend.make_scene`;
+    one scene = one plotter. The ``is_3d`` flag is informational —
+    PyVista is always 3-D, but the layer code may use the flag to
+    short-circuit 2-D-only branches when the scene is intentionally
+    flat.
+
+    Attributes:
+        plotter: The :class:`pyvista.Plotter` (or
+            :class:`pyvistaqt.QtInteractor` in Phase 4).
+        is_3d: Always ``True`` for PyVista today; kept on the handle
+            so layers can introspect the projection the way they do
+            on :class:`~STKO_to_python.viewer.backends.mpl.MplSceneHandle`.
+        off_screen: When ``True``, :meth:`PyVistaBackend.show` is a
+            no-op — used by the headless CLI and CI snapshots.
+    """
+
+    plotter: Any
+    is_3d: bool
+    off_screen: bool
+
+
+@dataclass
+class _PvActorRef:
+    """Opaque actor record returned to layers.
+
+    Layers treat the ref as a cookie; the backend unwraps it on
+    :meth:`update_*` / :meth:`remove` / :meth:`set_visible` to reach
+    the actor and its underlying dataset. The dataset is held here
+    so ``point_data`` / ``cell_data`` mutation can happen on the
+    pre-allocated arrays.
+
+    ``scalar_field`` records the name of the scalar array bound at
+    actor-creation time (when the primitive received a ``scalars=``
+    argument). :meth:`PyVistaBackend.update_scalars` writes into the
+    same name.
+    """
+
+    actor: Any
+    dataset: Any  # pyvista.DataSet | None
+    scalar_field: str | None
+    kind: str  # "segments" | "points" | "polygons" | "arrows"
+
+
+# ---------------------------------------------------------------------- #
+# Backend implementation
+# ---------------------------------------------------------------------- #
+
+
+class PyVistaBackend:
+    """Backend protocol satisfied via PyVista's 3-D primitives.
+
+    Construction is free — the backend holds no scene state. Each
+    :meth:`make_scene` call allocates a fresh :class:`pyvista.Plotter`
+    wrapped in a :class:`PvSceneHandle`. Layers receive
+    :class:`_PvActorRef` records as ``ActorRef`` cookies; subsequent
+    ``update_*`` / ``set_visible`` / ``remove`` calls unwrap those
+    to reach the actor and its underlying dataset.
+
+    Off-screen rendering uses VTK's native off-screen path (no Qt,
+    no X server). On Linux, callers may need to wrap their entry
+    point in ``xvfb-run`` if no GPU + EGL stack is available — see
+    ``docs/viewer/03-deployment-targets.md`` §7.
+    """
+
+    name: str = "pyvista"
+    is_3d_capable: bool = True
+    is_interactive: bool = True
+
+    # ------------------------------------------------------------------ #
+    # Scene lifecycle
+    # ------------------------------------------------------------------ #
+    def make_scene(
+        self,
+        *,
+        is_3d: bool = True,
+        off_screen: bool = False,
+        plotter: Any = None,
+    ) -> PvSceneHandle:
+        """Allocate (or borrow) a :class:`pyvista.Plotter` for the scene.
+
+        The optional ``plotter`` argument is a backend-specific
+        extension beyond the :class:`Backend` protocol — it lets the
+        Phase 4 Qt UI thread its
+        :class:`pyvistaqt.QtInteractor` instance through the scene
+        machinery without the backend creating its own window.
+        """
+        if plotter is None:
+            plotter = pv.Plotter(off_screen=off_screen)
+        # Layers can legitimately add empty actors (e.g. a selection that
+        # filters out every element of a class, or a layer whose result
+        # field happens to be zero-length at attach). PyVista's default
+        # theme raises on empty input; relax that locally so the
+        # ``add_*`` primitives stay total over the input domain.
+        try:
+            plotter.theme.allow_empty_mesh = True
+        except AttributeError:  # pragma: no cover - older pyvista
+            pass
+        return PvSceneHandle(plotter=plotter, is_3d=is_3d, off_screen=off_screen)
+
+    def set_bounds(self, scene: PvSceneHandle, bbox: BBox) -> None:
+        """Reframe the camera to span ``bbox``.
+
+        Delegates to ``vtkRenderer.ResetCamera(bounds[6])`` — the
+        same path PyVista's own ``reset_camera`` uses, but with
+        caller-supplied bounds rather than the scene's auto-computed
+        ones. Useful when a filter / selection layer hides part of
+        the model but the camera should still frame the whole
+        geometry.
+        """
+        bounds = (
+            bbox.x_min, bbox.x_max,
+            bbox.y_min, bbox.y_max,
+            bbox.z_min, bbox.z_max,
+        )
+        scene.plotter.renderer.ResetCamera(bounds)
+
+    def set_camera(self, scene: PvSceneHandle, cam: CameraSpec) -> None:
+        """Apply a saved camera state."""
+        scene.plotter.camera_position = (
+            tuple(cam.position),
+            tuple(cam.focal_point),
+            tuple(cam.view_up),
+        )
+        if cam.parallel_projection:
+            scene.plotter.enable_parallel_projection()
+        else:
+            scene.plotter.disable_parallel_projection()
+
+    def set_style(self, scene: PvSceneHandle, style: "SceneStyle") -> None:
+        """Apply scene-wide styling (background, grid).
+
+        Font size is intentionally not propagated to a global —
+        matplotlib's ``plt.rcParams["font.size"]`` is a process-wide
+        knob, but PyVista takes font size per ``add_text`` /
+        ``show_grid`` call. Layers that add text labels in Phase 3+
+        can read ``style.font_size`` directly when they need it.
+        """
+        scene.plotter.background_color = style.background
+        if style.grid:
+            scene.plotter.show_grid()
+
+    # ------------------------------------------------------------------ #
+    # Primitives
+    # ------------------------------------------------------------------ #
+    def add_segments(
+        self,
+        scene: PvSceneHandle,
+        segments: np.ndarray,
+        *,
+        color: Any = None,
+        width: float | None = None,
+        alpha: float | None = None,
+        label: str | None = None,
+    ) -> ActorRef:
+        """Add a line-segment batch as a :class:`pyvista.PolyData`."""
+        segs = np.asarray(segments, dtype=np.float64)
+        if segs.size == 0:
+            poly = pv.PolyData()
+        else:
+            n = int(segs.shape[0])
+            points = segs.reshape(-1, 3).astype(np.float32)
+            # VTK line topology: each segment is encoded as [2, i0, i1].
+            lines = np.empty(n * 3, dtype=np.int64)
+            lines[0::3] = 2
+            lines[1::3] = np.arange(0, 2 * n, 2)
+            lines[2::3] = np.arange(1, 2 * n, 2)
+            poly = pv.PolyData(points, lines=lines)
+
+        kwargs: dict[str, Any] = {}
+        if color is not None:
+            kwargs["color"] = color
+        if width is not None:
+            kwargs["line_width"] = float(width)
+        if alpha is not None:
+            kwargs["opacity"] = float(alpha)
+        if label is not None:
+            kwargs["label"] = label
+        actor = scene.plotter.add_mesh(poly, **kwargs)
+        return _PvActorRef(
+            actor=actor, dataset=poly, scalar_field=None, kind="segments",
+        )
+
+    def add_points(
+        self,
+        scene: PvSceneHandle,
+        points: np.ndarray,
+        *,
+        color: Any = None,
+        size: float | None = None,
+        scalars: np.ndarray | None = None,
+        cmap: str | None = None,
+    ) -> ActorRef:
+        """Add a point cloud as a :class:`pyvista.PolyData`.
+
+        ``scalars`` are stored in ``point_data["scalars"]`` so
+        :meth:`update_scalars` has a known name to write into.
+        ``render_points_as_spheres=True`` matches the apeGmsh
+        recommendation for Gauss-marker clouds (avoids z-fighting
+        at glancing angles).
+        """
+        pts = np.asarray(points, dtype=np.float64).astype(np.float32)
+        if pts.size == 0:
+            poly = pv.PolyData()
+        else:
+            poly = pv.PolyData(pts)
+
+        kwargs: dict[str, Any] = {
+            "render_points_as_spheres": True,
+            "style": "points",
+        }
+        scalar_field: str | None = None
+        if scalars is not None:
+            scalar_field = "scalars"
+            poly.point_data[scalar_field] = np.asarray(scalars, dtype=np.float64)
+            kwargs["scalars"] = scalar_field
+            if cmap is not None:
+                kwargs["cmap"] = cmap
+        elif color is not None:
+            kwargs["color"] = color
+        if size is not None:
+            kwargs["point_size"] = float(size)
+        actor = scene.plotter.add_mesh(poly, **kwargs)
+        return _PvActorRef(
+            actor=actor, dataset=poly,
+            scalar_field=scalar_field, kind="points",
+        )
+
+    def add_polygons(
+        self,
+        scene: PvSceneHandle,
+        polygons: Any,
+        *,
+        values: np.ndarray | None = None,
+        cmap: str | None = None,
+        edge_color: Any = None,
+    ) -> ActorRef:
+        """Add filled polygons as a :class:`pyvista.PolyData`.
+
+        ``polygons`` is a sequence of ``(M_i, 3)`` vertex arrays —
+        one M-sided polygon per entry. Heterogeneous ``M_i`` is
+        supported via VTK's variable-length face encoding.
+        Per-cell ``values`` are stored in ``cell_data["values"]``;
+        :meth:`update_scalars` writes into the same name.
+        """
+        polys_list = list(polygons) if not isinstance(polygons, list) else polygons
+        if not polys_list:
+            poly = pv.PolyData()
+            kwargs: dict[str, Any] = {}
+            if edge_color is not None:
+                kwargs["edge_color"] = edge_color
+                kwargs["show_edges"] = True
+            actor = scene.plotter.add_mesh(poly, **kwargs)
+            return _PvActorRef(
+                actor=actor, dataset=poly,
+                scalar_field=None, kind="polygons",
+            )
+
+        all_pts: list[np.ndarray] = []
+        faces: list[int] = []
+        offset = 0
+        for p in polys_list:
+            arr = np.asarray(p, dtype=np.float64)
+            if arr.size == 0:
+                continue
+            n_v = int(arr.shape[0])
+            all_pts.append(arr)
+            faces.append(n_v)
+            faces.extend(range(offset, offset + n_v))
+            offset += n_v
+        if not all_pts:
+            poly = pv.PolyData()
+        else:
+            points = np.vstack(all_pts).astype(np.float32)
+            poly = pv.PolyData(points, faces=np.asarray(faces, dtype=np.int64))
+
+        kwargs = {}
+        if edge_color is not None:
+            kwargs["edge_color"] = edge_color
+            kwargs["show_edges"] = True
+        scalar_field: str | None = None
+        if values is not None and poly.n_cells > 0:
+            scalar_field = "values"
+            poly.cell_data[scalar_field] = np.asarray(values, dtype=np.float64)
+            kwargs["scalars"] = scalar_field
+            if cmap is not None:
+                kwargs["cmap"] = cmap
+        actor = scene.plotter.add_mesh(poly, **kwargs)
+        return _PvActorRef(
+            actor=actor, dataset=poly,
+            scalar_field=scalar_field, kind="polygons",
+        )
+
+    def add_arrows(
+        self,
+        scene: PvSceneHandle,
+        origins: np.ndarray,
+        vectors: np.ndarray,
+        *,
+        scale: float = 1.0,
+        color: Any = None,
+        cmap: str | None = None,
+    ) -> ActorRef:
+        """Add an arrow-glyph batch via :meth:`pyvista.Plotter.add_arrows`.
+
+        PyVista's ``add_arrows`` internally builds a glyph filter
+        from origins + directions; the resulting actor is **not**
+        cheaply mutable, so :meth:`update_points` raises
+        :class:`BackendCapabilityError` for arrows. Animation-driven
+        vector updates go through ``remove`` + a fresh
+        :meth:`add_arrows`. The
+        :class:`~STKO_to_python.viewer.layers.VectorLayer` already
+        carries that perf gap noted from Phase 2.6; landing an
+        in-place ``update_arrows`` primitive is a Phase 3.X
+        follow-up.
+        """
+        o = np.asarray(origins, dtype=np.float64).astype(np.float32)
+        v = (np.asarray(vectors, dtype=np.float64) * float(scale)).astype(np.float32)
+        actor = scene.plotter.add_arrows(o, v, mag=1.0)
+        if color is not None:
+            # PyVista's add_arrows ignores color in some versions —
+            # apply via actor property as a fallback.
+            try:
+                actor.prop.color = color
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return _PvActorRef(
+            actor=actor, dataset=None, scalar_field=None, kind="arrows",
+        )
+
+    # ------------------------------------------------------------------ #
+    # In-place actor updates
+    # ------------------------------------------------------------------ #
+    def update_scalars(self, actor: ActorRef, scalars: np.ndarray) -> None:
+        """Mutate an actor's scalar field in place.
+
+        Requires the actor was created with a ``scalars=`` argument
+        (which bound the field name at creation time). Arrows have
+        no scalar field — they raise :class:`BackendCapabilityError`.
+        """
+        ref = self._unwrap(actor)
+        if ref.dataset is None or ref.scalar_field is None:
+            raise BackendCapabilityError(
+                f"Actor (kind={ref.kind!r}) does not support scalar updates "
+                "— no scalar field was bound at creation."
+            )
+        ref.dataset[ref.scalar_field] = np.asarray(scalars, dtype=np.float64)
+        ref.dataset.Modified()
+
+    def update_points(self, actor: ActorRef, points: np.ndarray) -> None:
+        """Mutate an actor's vertex positions in place.
+
+        Handles segments (``(N, 2, 3)`` → flatten), points
+        (``(N, 3)``), and polygons (``(N, 3)`` — face topology
+        unchanged). Arrows raise :class:`BackendCapabilityError`
+        because PyVista's arrow glyph is built by a non-trivially
+        invertible filter; callers go through ``remove`` + a fresh
+        :meth:`add_arrows`.
+        """
+        ref = self._unwrap(actor)
+        if ref.kind == "arrows" or ref.dataset is None:
+            raise BackendCapabilityError(
+                f"Actor (kind={ref.kind!r}) does not support point updates."
+            )
+        pts = np.asarray(points, dtype=np.float64)
+        if ref.kind == "segments" and pts.ndim == 3:
+            pts = pts.reshape(-1, 3)
+        ref.dataset.points = pts.astype(np.float32)
+        ref.dataset.Modified()
+
+    def set_visible(self, actor: ActorRef, visible: bool) -> None:
+        ref = self._unwrap(actor)
+        ref.actor.SetVisibility(bool(visible))
+
+    def remove(self, scene: PvSceneHandle, actor: ActorRef) -> None:
+        """Detach ``actor`` from the scene. Idempotent if already removed."""
+        ref = self._unwrap(actor)
+        try:
+            scene.plotter.remove_actor(ref.actor)
+        except Exception:  # pragma: no cover - defensive (plotter closed, etc.)
+            pass
+
+    # ------------------------------------------------------------------ #
+    # Output
+    # ------------------------------------------------------------------ #
+    def show(self, scene: PvSceneHandle) -> None:
+        """Hand off to :meth:`pyvista.Plotter.show` unless off-screen."""
+        if scene.off_screen:
+            return
+        scene.plotter.show()
+
+    def save(self, scene: PvSceneHandle, path: Path, *, dpi: int = 300) -> None:
+        """Persist the current frame to disk.
+
+        ``dpi`` is honoured as best as PyVista allows — the plotter
+        has no direct DPI knob, so the window size is interpreted
+        relative to a notional 96-DPI canvas and ``dpi`` scales it.
+        Callers that need precise pixel counts should set
+        ``scene.plotter.window_size`` before calling.
+        """
+        if dpi != 300:
+            # Best-effort scaling from default DPI.
+            scale = max(1, int(round(dpi / 96.0)))
+            # transparent_background defaults to None which avoids forcing
+            # alpha; explicit False matches the matplotlib backend.
+            scene.plotter.screenshot(
+                str(path), transparent_background=False, scale=scale,
+            )
+        else:
+            scene.plotter.screenshot(str(path), transparent_background=False)
+
+    def snapshot(self, scene: PvSceneHandle) -> np.ndarray:
+        """Return the current frame as an ``(H, W, 3)`` ``uint8`` RGB array."""
+        img = scene.plotter.screenshot(
+            return_img=True, transparent_background=False,
+        )
+        arr = np.asarray(img)
+        if arr.ndim == 3 and arr.shape[-1] == 4:
+            arr = arr[..., :3]
+        return arr.astype(np.uint8, copy=False)
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _unwrap(actor: ActorRef) -> _PvActorRef:
+        if not isinstance(actor, _PvActorRef):
+            raise BackendCapabilityError(
+                f"Expected a PyVistaBackend actor reference, got "
+                f"{type(actor).__name__}. Layers must not pass raw VTK "
+                "actors back through the backend API."
+            )
+        return actor
+
+
+__all__ = ["PvSceneHandle", "PyVistaBackend"]

--- a/tests/viewer/backends/pyvista/test_backend.py
+++ b/tests/viewer/backends/pyvista/test_backend.py
@@ -1,0 +1,365 @@
+"""Tests for :class:`PyVistaBackend`.
+
+Like the matplotlib backend tests, each case exercises one method on
+the protocol via a fresh off-screen scene, verifies the resulting
+PyVista actor / dataset, then closes the plotter to release VTK
+resources.
+
+The entire module is gated on ``pyvista`` being importable. When the
+``[viewer-3d]`` extra isn't installed the tests are skipped — CI
+matrices that include the ``viewer-3d`` job will pick them up.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pv = pytest.importorskip("pyvista")
+
+from STKO_to_python.viewer.backends.pyvista import (
+    PvSceneHandle,
+    PyVistaBackend,
+)
+from STKO_to_python.viewer.backends.pyvista.backend import _PvActorRef
+from STKO_to_python.viewer.core import (
+    BBox,
+    Backend,
+    BackendCapabilityError,
+    CameraSpec,
+    SceneStyle,
+)
+
+
+# --------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def backend() -> PyVistaBackend:
+    return PyVistaBackend()
+
+
+@pytest.fixture
+def scene(backend: PyVistaBackend):
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    yield handle
+    try:
+        handle.plotter.close()
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------- #
+# Protocol conformance
+# --------------------------------------------------------------------- #
+
+
+def test_satisfies_backend_protocol() -> None:
+    assert isinstance(PyVistaBackend(), Backend)
+
+
+def test_backend_metadata() -> None:
+    b = PyVistaBackend()
+    assert b.name == "pyvista"
+    assert b.is_3d_capable is True
+    assert b.is_interactive is True
+
+
+# --------------------------------------------------------------------- #
+# Scene lifecycle
+# --------------------------------------------------------------------- #
+
+
+def test_make_scene_returns_handle_wrapping_plotter(backend) -> None:
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        assert isinstance(handle, PvSceneHandle)
+        assert handle.is_3d is True
+        assert handle.off_screen is True
+        assert isinstance(handle.plotter, pv.Plotter)
+    finally:
+        handle.plotter.close()
+
+
+def test_make_scene_accepts_caller_supplied_plotter(backend) -> None:
+    """The ``plotter=`` extension lets Qt thread its QtInteractor through."""
+    plotter = pv.Plotter(off_screen=True)
+    handle = backend.make_scene(plotter=plotter)
+    try:
+        assert handle.plotter is plotter
+    finally:
+        plotter.close()
+
+
+def test_set_bounds_calls_renderer_reset_camera(backend, scene) -> None:
+    """Verify the bounds reach VTK's renderer (we check the camera moves)."""
+    pos_before = scene.plotter.camera.position
+    backend.set_bounds(scene, BBox(-10, -10, -10, 10, 10, 10))
+    pos_after = scene.plotter.camera.position
+    # Reset-camera moves the camera unless it was already framing the bounds;
+    # tolerate either outcome — what we actually pin is that the call doesn't
+    # error and the camera state is consistent.
+    assert isinstance(pos_after, tuple)
+
+
+def test_set_camera_applies_orientation(backend, scene) -> None:
+    """PyVista normalizes ``camera_position`` to a renderer-driven
+    distance — what we pin is the orientation (focal point, view-up,
+    and the direction from focal to position)."""
+    cam = CameraSpec(
+        position=(5.0, 5.0, 5.0),
+        focal_point=(0.0, 0.0, 0.0),
+        view_up=(0.0, 0.0, 1.0),
+        parallel_projection=False,
+    )
+    backend.set_camera(scene, cam)
+    pos, focal, up = scene.plotter.camera_position
+    np.testing.assert_allclose(focal, [0.0, 0.0, 0.0])
+    np.testing.assert_allclose(up, [0.0, 0.0, 1.0])
+    # Direction (unit vector from focal to position) is the orientation
+    # contract; absolute distance is renderer-controlled.
+    direction = np.asarray(pos) - np.asarray(focal)
+    unit = direction / np.linalg.norm(direction)
+    expected = np.array([1.0, 1.0, 1.0]) / np.sqrt(3)
+    np.testing.assert_allclose(unit, expected, atol=1e-6)
+
+
+def test_set_camera_parallel_projection_toggle(backend, scene) -> None:
+    cam_perspective = CameraSpec(
+        position=(1.0, 0.0, 0.0),
+        focal_point=(0.0, 0.0, 0.0),
+        view_up=(0.0, 0.0, 1.0),
+        parallel_projection=False,
+    )
+    cam_parallel = CameraSpec(
+        position=(1.0, 0.0, 0.0),
+        focal_point=(0.0, 0.0, 0.0),
+        view_up=(0.0, 0.0, 1.0),
+        parallel_projection=True,
+    )
+    backend.set_camera(scene, cam_parallel)
+    assert scene.plotter.camera.parallel_projection is True
+    backend.set_camera(scene, cam_perspective)
+    assert scene.plotter.camera.parallel_projection is False
+
+
+def test_set_style_applies_background_and_grid(backend, scene) -> None:
+    style = SceneStyle(background="black", grid=False, font_size=10)
+    backend.set_style(scene, style)
+    # PyVista returns a Color object — compare component-wise.
+    bg = scene.plotter.background_color
+    assert tuple(bg.float_rgb) == pytest.approx((0.0, 0.0, 0.0))
+
+
+# --------------------------------------------------------------------- #
+# Primitives — add_segments
+# --------------------------------------------------------------------- #
+
+
+def test_add_segments_creates_polydata_with_lines(backend, scene) -> None:
+    segs = np.array(
+        [
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+        ]
+    )
+    ref = backend.add_segments(scene, segs, color="red", width=2.0, alpha=0.8)
+    assert isinstance(ref, _PvActorRef)
+    assert ref.kind == "segments"
+    assert ref.scalar_field is None
+    assert ref.dataset.n_points == 4
+    assert ref.dataset.n_lines == 2
+
+
+def test_add_segments_empty_input_creates_empty_dataset(backend, scene) -> None:
+    ref = backend.add_segments(scene, np.zeros((0, 2, 3)))
+    assert ref.kind == "segments"
+    assert ref.dataset.n_points == 0
+    assert ref.dataset.n_lines == 0
+
+
+# --------------------------------------------------------------------- #
+# Primitives — add_points
+# --------------------------------------------------------------------- #
+
+
+def test_add_points_creates_polydata(backend, scene) -> None:
+    pts = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 2.0, 2.0]])
+    ref = backend.add_points(scene, pts, color="blue", size=10.0)
+    assert ref.kind == "points"
+    assert ref.dataset.n_points == 3
+    assert ref.scalar_field is None
+
+
+def test_add_points_with_scalars_binds_scalar_field(backend, scene) -> None:
+    pts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    scalars = np.array([0.5, 1.5])
+    ref = backend.add_points(scene, pts, scalars=scalars, cmap="viridis")
+    assert ref.scalar_field == "scalars"
+    np.testing.assert_allclose(ref.dataset.point_data["scalars"], [0.5, 1.5])
+
+
+def test_add_points_empty_input(backend, scene) -> None:
+    ref = backend.add_points(scene, np.zeros((0, 3)))
+    assert ref.dataset.n_points == 0
+
+
+# --------------------------------------------------------------------- #
+# Primitives — add_polygons
+# --------------------------------------------------------------------- #
+
+
+def test_add_polygons_handles_heterogeneous_M(backend, scene) -> None:
+    """A triangle + a quad in the same call — VTK accepts heterogeneous M."""
+    tri = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0]])
+    quad = np.array(
+        [[2.0, 0.0, 0.0], [3.0, 0.0, 0.0], [3.0, 1.0, 0.0], [2.0, 1.0, 0.0]]
+    )
+    ref = backend.add_polygons(scene, [tri, quad], edge_color="black")
+    assert ref.kind == "polygons"
+    assert ref.dataset.n_points == 7
+    assert ref.dataset.n_cells == 2
+
+
+def test_add_polygons_with_per_cell_values(backend, scene) -> None:
+    tri = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0]])
+    quad = np.array(
+        [[2.0, 0.0, 0.0], [3.0, 0.0, 0.0], [3.0, 1.0, 0.0], [2.0, 1.0, 0.0]]
+    )
+    ref = backend.add_polygons(
+        scene, [tri, quad], values=np.array([1.0, 2.0]), cmap="viridis",
+    )
+    assert ref.scalar_field == "values"
+    np.testing.assert_allclose(ref.dataset.cell_data["values"], [1.0, 2.0])
+
+
+def test_add_polygons_empty_input(backend, scene) -> None:
+    ref = backend.add_polygons(scene, [])
+    assert ref.dataset.n_cells == 0
+
+
+# --------------------------------------------------------------------- #
+# Primitives — add_arrows
+# --------------------------------------------------------------------- #
+
+
+def test_add_arrows_creates_actor(backend, scene) -> None:
+    origins = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    vectors = np.array([[0.5, 0.0, 0.0], [0.0, 0.5, 0.0]])
+    ref = backend.add_arrows(scene, origins, vectors, scale=2.0, color="green")
+    assert ref.kind == "arrows"
+    assert ref.actor is not None
+    # Arrows have no scalar field and no mutable dataset reference.
+    assert ref.scalar_field is None
+    assert ref.dataset is None
+
+
+# --------------------------------------------------------------------- #
+# In-place updates
+# --------------------------------------------------------------------- #
+
+
+def test_update_scalars_mutates_point_data_in_place(backend, scene) -> None:
+    pts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    ref = backend.add_points(scene, pts, scalars=np.array([0.0, 0.0]))
+    backend.update_scalars(ref, np.array([3.0, 4.0]))
+    np.testing.assert_allclose(ref.dataset.point_data["scalars"], [3.0, 4.0])
+
+
+def test_update_scalars_raises_when_no_scalar_field_bound(backend, scene) -> None:
+    """Position-only points have no scalar field; update_scalars must error."""
+    pts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    ref = backend.add_points(scene, pts, color="red")  # no scalars=
+    with pytest.raises(BackendCapabilityError, match="scalar updates"):
+        backend.update_scalars(ref, np.array([1.0, 2.0]))
+
+
+def test_update_scalars_raises_for_arrows(backend, scene) -> None:
+    ref = backend.add_arrows(
+        scene,
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+    )
+    with pytest.raises(BackendCapabilityError):
+        backend.update_scalars(ref, np.array([1.0]))
+
+
+def test_update_points_mutates_segments_in_place(backend, scene) -> None:
+    segs = np.array([[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
+    ref = backend.add_segments(scene, segs)
+    new_segs = np.array([[[5.0, 0.0, 0.0], [10.0, 0.0, 0.0]]])
+    backend.update_points(ref, new_segs)
+    np.testing.assert_allclose(ref.dataset.points[0], [5.0, 0.0, 0.0])
+    np.testing.assert_allclose(ref.dataset.points[1], [10.0, 0.0, 0.0])
+
+
+def test_update_points_mutates_point_cloud_in_place(backend, scene) -> None:
+    pts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    ref = backend.add_points(scene, pts)
+    backend.update_points(ref, np.array([[3.0, 3.0, 3.0], [4.0, 4.0, 4.0]]))
+    np.testing.assert_allclose(ref.dataset.points[0], [3.0, 3.0, 3.0])
+
+
+def test_update_points_raises_for_arrows(backend, scene) -> None:
+    ref = backend.add_arrows(
+        scene,
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+    )
+    with pytest.raises(BackendCapabilityError):
+        backend.update_points(ref, np.array([[1.0, 1.0, 1.0]]))
+
+
+def test_set_visible_toggles_actor_visibility(backend, scene) -> None:
+    pts = np.array([[0.0, 0.0, 0.0]])
+    ref = backend.add_points(scene, pts)
+    backend.set_visible(ref, False)
+    assert ref.actor.GetVisibility() == 0
+    backend.set_visible(ref, True)
+    assert ref.actor.GetVisibility() == 1
+
+
+def test_remove_unhooks_actor_from_scene(backend, scene) -> None:
+    ref = backend.add_points(scene, np.array([[0.0, 0.0, 0.0]]))
+    n_actors_before = len(list(scene.plotter.renderer.actors))
+    backend.remove(scene, ref)
+    n_actors_after = len(list(scene.plotter.renderer.actors))
+    assert n_actors_after < n_actors_before
+
+
+def test_unwrap_rejects_raw_actors() -> None:
+    """The protocol forbids layers from handing raw VTK actors back."""
+    b = PyVistaBackend()
+    with pytest.raises(BackendCapabilityError, match="actor reference"):
+        b.update_scalars("not-a-pvactorref", np.array([1.0]))
+
+
+# --------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------- #
+
+
+def test_snapshot_returns_rgb_array(backend, scene) -> None:
+    backend.add_points(scene, np.array([[0.0, 0.0, 0.0]]))
+    arr = backend.snapshot(scene)
+    assert arr.ndim == 3
+    assert arr.shape[-1] == 3
+    assert arr.dtype == np.uint8
+
+
+def test_save_writes_a_file(backend, scene, tmp_path) -> None:
+    backend.add_points(scene, np.array([[0.0, 0.0, 0.0]]))
+    out = tmp_path / "out.png"
+    backend.save(scene, out)
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_show_off_screen_is_noop(backend) -> None:
+    """An off-screen scene must not pop a window from show()."""
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        backend.show(handle)  # must not raise
+    finally:
+        handle.plotter.close()


### PR DESCRIPTION
## Summary

- Second concrete `Backend` per [`docs/viewer/00-roadmap.md`](docs/viewer/00-roadmap.md) Phase 3. Wraps a `pyvista.Plotter` (windowed or off-screen) and maps every primitive on the `Backend` protocol onto VTK's 3-D surface. Same scope as Phase 2.2 (MplBackend) — just the backend; 3-D layer types (`ContourLayer`, `GaussLayer`, `VolumeLayer`, `DiagramLayer`, `FiberLayer`, ...) land in Phase 3.1+.
- Gated behind the optional `[viewer-3d]` extra — the lightweight `pip install stko_to_python` path is untouched.
- All existing layers (`MeshLayer`, `DeformedMeshLayer`, `NodeLayer`, `VectorLayer`) can already render through this backend by passing `PyVistaBackend()` to the `Scene` — no layer changes needed because they were written against the protocol.

## Architecture

- **`PvSceneHandle`** wraps `(plotter, is_3d, off_screen)`. The optional `plotter=` kwarg on `make_scene` threads a caller-supplied `pyvistaqt.QtInteractor` through the scene machinery (Phase 4 Qt UI hook).
- **`_PvActorRef`** holds `(actor, dataset, scalar_field, kind)` so `update_scalars` / `update_points` mutate the underlying `PolyData`'s `point_data` / `points` in place. This is the apeGmsh perf contract — same actor lives across animation steps; only the arrays change.
- Layer code receives `_PvActorRef` as an **opaque** `ActorRef`; the backend unwraps on `update_*` / `set_visible` / `remove` and raises `BackendCapabilityError` when a raw VTK actor is handed back (guards against layers leaking VTK details).

## Primitive coverage (matches MplBackend 1-to-1)

| Primitive | PyVista implementation |
|---|---|
| `add_segments` | `pv.PolyData` with VTK `[2, i0, i1]` line topology |
| `add_points` | `pv.PolyData`; `render_points_as_spheres=True` (apeGmsh anti-z-fighting recommendation) |
| `add_polygons` | `pv.PolyData` with variable-length face encoding (heterogeneous M_i in one call) |
| `add_arrows` | `pyvista.Plotter.add_arrows` (glyph filter) |
| `update_scalars` | mutate `dataset.point_data[field]` in place; `BackendCapabilityError` on actors without a scalar field |
| `update_points` | mutate `dataset.points` in place; segments reshape `(N, 2, 3) → (2N, 3)` automatically; arrows raise (Quiver-style glyph not cheaply mutable) |
| `set_visible` / `remove` / `show` / `save` / `snapshot` | direct delegation |

Off-screen rendering uses VTK's native off-screen path (no Qt, no X server). `Plotter.theme.allow_empty_mesh = True` is set at scene creation so layers can legitimately add empty actors (a selection that filters out every element of a class, e.g.) without the plotter raising.

## Test plan

- [x] **29 new tests** in [`tests/viewer/backends/pyvista/test_backend.py`](tests/viewer/backends/pyvista/test_backend.py): protocol conformance, scene lifecycle (caller-supplied plotter extension), camera + bounds + style application, every primitive (empty / non-empty / with scalars), in-place updates for segments / points / scalars, capability error for arrows + scalar-less actors + raw-VTK actor refs, snapshot RGB shape, save-to-disk, off-screen show no-op. `pytest.importorskip` gates the module so it's silently skipped when `[viewer-3d]` isn't installed.
- [x] `opensees_venv` (pyvista 0.47.1 + VTK 9.6.1): all 29 pyvista tests pass. `tests/viewer/` overall: 326 passed.
- [x] system Python (no pyvista): **1581 passed, 40 skipped**. The pyvista test module is correctly skipped via `importorskip`; lightweight install path unaffected.

## What's next

Phase 3.0b — `ContourLayer` (port apeGmsh's five-path dispatch: nodal / GP-cell / GP-cell-averaged / GP-node-extrap / GP-node-discrete). The Gauss extrapolation kernel landed in Phase 1, so only the per-path actor builders remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)