### PR TITLE
Add ContourLayer — cell-topology path (Phase 3.0b)

### DIFF
--- a/src/STKO_to_python/viewer/layers/__init__.py
+++ b/src/STKO_to_python/viewer/layers/__init__.py
@@ -26,8 +26,15 @@ contracts are exercised in unit tests ahead of the 3-D work.
 """
 from __future__ import annotations
 
+from .contour import ContourLayer
 from .deformed_mesh import DeformedMeshLayer
 from .mesh import MeshLayer
 from .node import NodeLayer, VectorLayer
 
-__all__ = ["DeformedMeshLayer", "MeshLayer", "NodeLayer", "VectorLayer"]
+__all__ = [
+    "ContourLayer",
+    "DeformedMeshLayer",
+    "MeshLayer",
+    "NodeLayer",
+    "VectorLayer",
+]

--- a/src/STKO_to_python/viewer/layers/contour.py
+++ b/src/STKO_to_python/viewer/layers/contour.py
@@ -1,0 +1,448 @@
+"""``ContourLayer`` — per-cell scalar field over the mesh.
+
+Renders one filled polygon per element, colored by a caller-supplied
+scalar map. This is the **cell-topology** path of the directive's
+five-path dispatch (per
+``docs/viewer/02-porting-from-apegmsh.md`` §4 / apeGmsh's
+``viewers/diagrams/_contour.py``):
+
+* **cell** (this layer, Phase 3.0b) — one scalar per element.
+* nodal — one scalar per node; **not yet implemented** (Phase 3.0c
+  with a ``Backend.add_polygons(point_values=...)`` extension).
+* GP-cell-averaged — one scalar per element, computed by averaging
+  per-GP values upstream; same renderer path as ``cell`` here.
+* GP-node-extrap-smooth — extrapolate GPs to nodes via
+  :func:`STKO_to_python.viewer.math.gauss_extrapolation.extrapolate_to_nodes_averaged`,
+  then render as nodal. Phase 3.0c.
+* GP-node-discrete — extrapolate per-element, render with
+  discontinuous nodes (each element keeps its own corner copies).
+  Phase 3.0d.
+
+By keeping the layer cell-topology-only this PR avoids extending the
+``Backend.add_polygons`` protocol and bypasses the
+nodal-coloring divergence between matplotlib (no ``PolyCollection``
+per-vertex coloring) and PyVista (native ``point_data``). The
+follow-up PRs add the missing paths once the protocol extension is
+proven on PyVista.
+
+Scalars contract
+----------------
+
+The caller supplies scalars as either:
+
+* a **static** ``dict[int, float]`` mapping ``element_id → value`` —
+  the layer is non-time-varying and :meth:`update_to_step` is a
+  no-op;
+* a **callable** ``(step: int) -> dict[int, float]`` invoked at
+  attach (with the initial step) and at every
+  :meth:`update_to_step` — same dict shape, fresh per call.
+
+Both shapes are dict-based on purpose: the caller doesn't need to
+know the renderer's element ordering, and a missing key is a hard
+error (no silent data dropouts).
+"""
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Tuple
+
+import numpy as np
+import pandas as pd
+
+from ..core.errors import LayerAttachError
+from ..core.layer import Layer
+
+if TYPE_CHECKING:
+    from ..core.datasource import DataSource
+    from ..core.scene import Scene
+    from ..core.selection import SelectionSpec
+
+
+# ---------------------------------------------------------------------- #
+# Face topology — which corner indices form a filled face per element class
+# ---------------------------------------------------------------------- #
+
+
+# Tri / quad / hex face encoding. Each element class maps to a tuple of
+# faces; each face is a tuple of corner indices in CCW (or VTK-compatible)
+# winding.
+_FACE_TOPOLOGY: dict[int, Tuple[Tuple[int, ...], ...]] = {
+    3: ((0, 1, 2),),
+    4: ((0, 1, 2, 3),),
+    # 8-node hex — six quad faces of the cube. Winding here is
+    # outward-facing in the standard OpenSees node ordering; for
+    # filled-color contour rendering only the closed-loop is required
+    # so the winding direction isn't load-bearing.
+    8: (
+        (0, 1, 2, 3),
+        (4, 7, 6, 5),
+        (0, 3, 7, 4),
+        (1, 5, 6, 2),
+        (0, 4, 5, 1),
+        (2, 6, 7, 3),
+    ),
+}
+
+
+def _face_topology(num_nodes: int) -> Tuple[Tuple[int, ...], ...] | None:
+    """Face topology for an element of ``num_nodes`` corners. ``None`` if
+    unsupported (e.g. line elements)."""
+    return _FACE_TOPOLOGY.get(int(num_nodes))
+
+
+def _class_label(element_type: str, num_nodes: int) -> str:
+    """Bucket label matching MeshLayer's convention."""
+    base = str(element_type).split("[", 1)[0]
+    return f"{base}({num_nodes}n)"
+
+
+# ---------------------------------------------------------------------- #
+# ContourLayer
+# ---------------------------------------------------------------------- #
+
+
+ScalarsInput = Mapping[int, float] | Callable[[int], Mapping[int, float]]
+
+
+class ContourLayer(Layer):
+    """Per-cell scalar contour over the model surface.
+
+    Parameters
+    ----------
+    scalars:
+        Either a static ``dict[int, float]`` mapping ``element_id →
+        value`` or a callable ``(step) -> dict[int, float]``. Each
+        rendered element must have an entry; missing keys raise
+        :class:`KeyError`.
+    step:
+        Initial step. Only consulted when ``scalars`` is a callable —
+        the static-dict path ignores it.
+    cmap:
+        Colormap name forwarded to the backend.
+    clim:
+        ``(vmin, vmax)`` color limits. When ``None`` the layer auto-
+        determines limits from the attach-step data and **freezes**
+        them so the colorbar means the same thing across animation
+        steps. Set explicitly for predictable color comparisons.
+    edge_color:
+        Optional edge color drawn on top of the filled faces.
+    name, selection, visible, z_order:
+        Forwarded to :class:`Layer`.
+    mpl_zorder:
+        matplotlib z-order applied post-hoc via ``actor.set_zorder``.
+        Default ``1.5`` sits between :class:`MeshLayer` (1.0) and
+        scatter / diagram overlays (≥ 2.0) so the contour fills are
+        visible without obscuring later passes.
+
+    Skipped element classes
+    -----------------------
+
+    Line elements (2-node) and any class without a face topology in
+    :data:`_FACE_TOPOLOGY` are skipped with a ``RuntimeWarning``.
+    Their labels surface as :attr:`skipped_classes`. Solids (8-node
+    bricks) are rendered as six quad faces per cell — the same
+    scalar repeated across each face, which is geometrically
+    correct (the brick interior is a single field value) but wastes
+    fragment work on hidden interior faces. The Phase 3.X
+    boundary-extraction layer reduces this.
+
+    Per-step contract
+    -----------------
+
+    When ``scalars`` is callable, :meth:`update_to_step` re-invokes
+    it, re-indexes into the rendered-element order, and calls
+    ``backend.update_scalars`` on the existing actors — no actor
+    recreation, satisfies the apeGmsh perf contract. When
+    ``scalars`` is a static dict, :meth:`update_to_step` is a no-op.
+    """
+
+    kind: str = "contour"
+
+    def __init__(
+        self,
+        *,
+        scalars: ScalarsInput,
+        step: int = 0,
+        cmap: str = "viridis",
+        clim: tuple[float, float] | None = None,
+        edge_color: Any = None,
+        name: str | None = None,
+        selection: "SelectionSpec | None" = None,
+        visible: bool = True,
+        z_order: int = 0,
+        mpl_zorder: float = 1.5,
+    ) -> None:
+        super().__init__(
+            name=name, selection=selection, visible=visible, z_order=z_order,
+        )
+        self._scalars_input: ScalarsInput = scalars
+        self._initial_step = int(step) if step is not None else 0
+        self._current_step: int | None = None
+        self.cmap = cmap
+        self.clim = clim
+        self.edge_color = edge_color
+        self.mpl_zorder = mpl_zorder
+
+        # Populated at attach.
+        # Each entry: (label, polygon_vertex_arrays, source_element_ids,
+        # actor). source_element_ids parallels the polygon list per class —
+        # one entry per drawn face. A brick contributes 6 polygon entries
+        # all pointing at its element id.
+        self._classes: list[dict[str, Any]] = []
+        self._skipped_classes: list[str] = []
+
+    # ------------------------------------------------------------------ #
+    # Read-only summary surface
+    # ------------------------------------------------------------------ #
+    @property
+    def is_time_varying(self) -> bool:
+        """``True`` if ``scalars`` was given as a callable."""
+        return callable(self._scalars_input)
+
+    @property
+    def current_step(self) -> int | None:
+        """Step the layer is currently rendering, or ``None`` before attach."""
+        return self._current_step
+
+    @property
+    def skipped_classes(self) -> list[str]:
+        """Class labels skipped because their topology isn't supported."""
+        return list(self._skipped_classes)
+
+    @property
+    def rendered_element_ids(self) -> dict[str, np.ndarray]:
+        """``{class_label: element_ids that contributed at least one face}``."""
+        out: dict[str, np.ndarray] = {}
+        for entry in self._classes:
+            ids = entry["source_element_ids"]
+            # Each element can contribute multiple faces (bricks=6); pull the
+            # unique set in insertion order.
+            unique, idx = np.unique(ids, return_index=True)
+            out[entry["label"]] = unique[np.argsort(idx)]
+        return out
+
+    @property
+    def n_faces(self) -> int:
+        """Total polygon faces drawn across every class."""
+        return sum(len(entry["polygons"]) for entry in self._classes)
+
+    @property
+    def actors(self) -> dict[str, Any]:
+        """``{class_label: backend actor}`` mapping. For inspection only."""
+        return {entry["label"]: entry["actor"] for entry in self._classes}
+
+    # ------------------------------------------------------------------ #
+    # Layer lifecycle
+    # ------------------------------------------------------------------ #
+    def attach(self, scene: "Scene", source: "DataSource") -> None:
+        if self.is_attached:
+            raise LayerAttachError(f"Layer {self.name!r} is already attached.")
+        self._scene = scene
+        self._source = source
+
+        ds = source.dataset
+        df_nodes = ds.nodes_info["dataframe"]
+        df_elements = ds.elements_info["dataframe"]
+        if df_nodes.empty or df_elements.empty:
+            raise LayerAttachError(
+                "Dataset has no nodes or no elements to draw."
+            )
+
+        # Resolve selection → element subset (parallel to MeshLayer).
+        if self.selection.is_empty():
+            df_filtered = df_elements
+        else:
+            kept = source.resolve_element_ids(self.selection)
+            if kept.size == 0:
+                raise LayerAttachError(
+                    f"No elements remain after filtering for {self.selection!r}."
+                )
+            kept_set = {int(i) for i in kept}
+            df_filtered = df_elements[df_elements["element_id"].isin(kept_set)]
+            if df_filtered.empty:
+                raise LayerAttachError(
+                    f"No elements remain after filtering for {self.selection!r}."
+                )
+
+        coord_lookup = {
+            int(row.node_id): np.array([row.x, row.y, row.z], dtype=np.float64)
+            for row in df_nodes.itertuples(index=False)
+        }
+
+        # Build per-class polygon buckets.
+        skipped: list[str] = []
+        classes: list[dict[str, Any]] = []
+        for (etype, n_nodes), group in df_filtered.groupby(
+            ["element_type", "num_nodes"], sort=False,
+        ):
+            topo = _face_topology(int(n_nodes))
+            label = _class_label(str(etype), int(n_nodes))
+            if topo is None:
+                skipped.append(label)
+                continue
+
+            polygons: list[np.ndarray] = []
+            src_ids: list[int] = []
+            for row in group.itertuples(index=False):
+                node_list = row.node_list
+                try:
+                    pts = np.array(
+                        [coord_lookup[int(nid)] for nid in node_list],
+                        dtype=np.float64,
+                    )
+                except KeyError:
+                    # Element references an unknown node — skip.
+                    continue
+                if pts.shape[0] != int(n_nodes):
+                    continue
+                for face_idx in topo:
+                    polygons.append(pts[list(face_idx)])
+                    src_ids.append(int(row.element_id))
+
+            if not polygons:
+                continue
+            classes.append(
+                {
+                    "label": label,
+                    "polygons": polygons,
+                    "source_element_ids": np.asarray(src_ids, dtype=np.int64),
+                    "actor": None,  # filled below
+                }
+            )
+        self._classes = classes
+        self._skipped_classes = skipped
+
+        if not self._classes:
+            raise LayerAttachError(
+                "ContourLayer has no renderable element classes "
+                "(line elements are skipped; need shells or solids)."
+            )
+
+        # Initial scalars for every drawn face, in the same class /
+        # polygon order as the geometry. Auto-frozen clim when not given.
+        initial_values = self._values_at_step(self._initial_step)
+        if self.clim is None:
+            global_values = np.concatenate(
+                [arr for arr in initial_values.values() if arr.size]
+            ) if initial_values else np.asarray([], dtype=np.float64)
+            if global_values.size:
+                vmin = float(np.nanmin(global_values))
+                vmax = float(np.nanmax(global_values))
+                # Avoid a degenerate single-value clim — colormaps need a
+                # non-zero range.
+                if vmin == vmax:
+                    vmax = vmin + 1.0
+                self.clim = (vmin, vmax)
+
+        # Create actors.
+        backend = scene.backend
+        handle = scene.handle
+        for entry in self._classes:
+            values = initial_values[entry["label"]]
+            actor = backend.add_polygons(
+                handle,
+                entry["polygons"],
+                values=values,
+                cmap=self.cmap,
+                edge_color=self.edge_color,
+            )
+            entry["actor"] = actor
+            self._apply_post_hoc(actor)
+
+        if not self.visible:
+            for entry in self._classes:
+                backend.set_visible(entry["actor"], False)
+
+        if skipped:
+            warnings.warn(
+                "[contour] Skipped element classes with unsupported "
+                f"topology: {skipped}",
+                RuntimeWarning,
+            )
+
+        # Track step only for the callable-binding mode — static layers
+        # have a single fixed value per element and ``current_step`` is
+        # meaningless for them. ``update_to_step`` is a no-op in static
+        # mode either way; gating on None here keeps the public state
+        # honest.
+        if self.is_time_varying:
+            self._current_step = self._initial_step
+
+    def update_to_step(self, step: int) -> None:
+        """Re-fetch scalars at ``step`` (no-op for the static-dict mode)."""
+        if not self.is_attached:
+            return
+        if not self.is_time_varying:
+            return
+        if step == self._current_step:
+            return
+        values_per_class = self._values_at_step(step)
+        backend = self._scene.backend  # type: ignore[union-attr]
+        for entry in self._classes:
+            actor = entry["actor"]
+            if actor is None:
+                continue
+            backend.update_scalars(actor, values_per_class[entry["label"]])
+        self._current_step = step
+
+    def detach(self) -> None:
+        scene = self._scene
+        if scene is not None:
+            for entry in self._classes:
+                actor = entry["actor"]
+                if actor is not None:
+                    scene.backend.remove(scene.handle, actor)
+        self._classes = []
+        self._skipped_classes = []
+        self._current_step = None
+        self._scene = None
+        self._source = None
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    def _scalars_dict_at(self, step: int) -> Mapping[int, float]:
+        if callable(self._scalars_input):
+            result = self._scalars_input(int(step))
+        else:
+            result = self._scalars_input
+        if not isinstance(result, Mapping):
+            raise TypeError(
+                f"ContourLayer.scalars must be a Mapping or callable returning "
+                f"a Mapping; got {type(result).__name__}."
+            )
+        return result
+
+    def _values_at_step(self, step: int) -> dict[str, np.ndarray]:
+        """``{class_label: (n_faces,) float64 array}`` for ``step``.
+
+        Each face copies the source element's scalar — bricks have
+        six faces but a single per-element value.
+        """
+        scalars = self._scalars_dict_at(step)
+        out: dict[str, np.ndarray] = {}
+        for entry in self._classes:
+            src_ids = entry["source_element_ids"]
+            try:
+                arr = np.asarray(
+                    [scalars[int(eid)] for eid in src_ids],
+                    dtype=np.float64,
+                )
+            except KeyError as exc:
+                missing = int(exc.args[0]) if exc.args else None
+                raise KeyError(
+                    f"ContourLayer.scalars is missing element id {missing} "
+                    f"(class {entry['label']!r}, step {step})."
+                ) from exc
+            out[entry["label"]] = arr
+        return out
+
+    def _apply_post_hoc(self, actor: Any) -> None:
+        """Apply renderer-specific styling that doesn't fit the protocol."""
+        if hasattr(actor, "set_zorder"):
+            actor.set_zorder(self.mpl_zorder)
+        if self.clim is not None and hasattr(actor, "set_clim"):
+            actor.set_clim(*self.clim)
+
+
+__all__ = ["ContourLayer"]

--- a/tests/viewer/layers/test_contour_layer.py
+++ b/tests/viewer/layers/test_contour_layer.py
@@ -1,0 +1,550 @@
+"""Tests for :class:`ContourLayer`.
+
+Three flavours of coverage:
+
+1. **Unit tests** with a tiny fake :class:`MPCODataSet` — exercise
+   attach, class-bucketing, skipped classes, clim auto-derivation,
+   static vs callable scalar binding, and lookup-failure errors.
+2. **Backend-integration tests** that drive the real :class:`Scene`
+   + :class:`MplBackend` to confirm actor types
+   (:class:`~matplotlib.collections.PolyCollection`), zorder, clim,
+   and in-place ``update_scalars`` on the same actor instance.
+3. **Real-fixture parity** against the multi-partition QuadFrame —
+   proves the layer renders shells from a live ``MPCODataSet``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import PolyCollection
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+from STKO_to_python.viewer.backends.mpl.backend import MplBackend
+from STKO_to_python.viewer.core import (
+    MPCODataSourceAdapter,
+    Scene,
+    SelectionSpec,
+)
+from STKO_to_python.viewer.core.errors import LayerAttachError
+from STKO_to_python.viewer.layers import ContourLayer
+
+
+# --------------------------------------------------------------------- #
+# Fake-dataset helpers
+# --------------------------------------------------------------------- #
+
+
+def _make_fake_dataset(
+    *,
+    node_rows=None,
+    elem_rows=None,
+):
+    if node_rows is None:
+        node_rows = [
+            (1, 0.0, 0.0, 0.0),
+            (2, 1.0, 0.0, 0.0),
+            (3, 1.0, 1.0, 0.0),
+            (4, 0.0, 1.0, 0.0),
+            (5, 2.0, 0.0, 0.0),
+            (6, 2.0, 1.0, 0.0),
+        ]
+    if elem_rows is None:
+        elem_rows = [
+            # (id, type, num_nodes, node_list)
+            (10, "5-ElasticBeam3d", 2, (1, 2)),  # skipped (line)
+            (11, "203-ASDShellQ4", 4, (1, 2, 3, 4)),
+            (12, "203-ASDShellQ4", 4, (2, 5, 6, 3)),
+            (13, "204-ASDShellT3", 3, (1, 2, 4)),
+        ]
+    nodes_df = pd.DataFrame(node_rows, columns=["node_id", "x", "y", "z"])
+    elements_df = pd.DataFrame(
+        elem_rows,
+        columns=["element_id", "element_type", "num_nodes", "node_list"],
+    )
+    fake = SimpleNamespace(
+        nodes_info={"dataframe": nodes_df},
+        elements_info={"dataframe": elements_df},
+        model_stages=["STAGE_0"],
+        number_of_steps={"STAGE_0": 5},
+        time=pd.DataFrame(
+            [{"MODEL_STAGE": "STAGE_0", "STEP": i, "TIME": float(i) * 0.1}
+             for i in range(5)]
+        ).set_index(["MODEL_STAGE", "STEP"]),
+    )
+    fake._selection_resolver = None
+    return fake
+
+
+def _make_scene(fake_dataset, *, is_3d=False):
+    backend = MplBackend()
+    handle = backend.make_scene(is_3d=is_3d)
+    source = MPCODataSourceAdapter(fake_dataset)
+    return Scene(backend, source, is_3d=is_3d, handle=handle)
+
+
+# --------------------------------------------------------------------- #
+# Construction
+# --------------------------------------------------------------------- #
+
+
+def test_kind_is_contour() -> None:
+    assert ContourLayer.kind == "contour"
+
+
+def test_is_time_varying_reflects_input() -> None:
+    layer_static = ContourLayer(scalars={11: 1.0, 12: 2.0, 13: 3.0})
+    assert layer_static.is_time_varying is False
+    layer_dynamic = ContourLayer(scalars=lambda step: {11: 1.0})
+    assert layer_dynamic.is_time_varying is True
+
+
+def test_summary_is_empty_before_attach() -> None:
+    layer = ContourLayer(scalars={11: 1.0})
+    assert layer.current_step is None
+    assert layer.skipped_classes == []
+    assert layer.n_faces == 0
+    assert layer.actors == {}
+
+
+# --------------------------------------------------------------------- #
+# Attach lifecycle
+# --------------------------------------------------------------------- #
+
+
+def test_attach_buckets_renderable_elements_per_class() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    scalars = {11: 1.0, 12: 2.0, 13: 3.0}
+    layer = ContourLayer(scalars=scalars)
+    try:
+        scene.add(layer)
+        # Two quads + one tri = 3 faces drawn.
+        assert layer.n_faces == 3
+        actors = layer.actors
+        assert "203-ASDShellQ4(4n)" in actors
+        assert "204-ASDShellT3(3n)" in actors
+        # Beams (2-node) are skipped.
+        assert layer.skipped_classes == ["5-ElasticBeam3d(2n)"]
+    finally:
+        plt.close("all")
+
+
+def test_attach_emits_warning_for_skipped_lines() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 1.0, 12: 2.0, 13: 3.0})
+    try:
+        with pytest.warns(RuntimeWarning, match="ElasticBeam3d"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_attach_raises_when_no_renderable_classes() -> None:
+    """A line-only dataset has nothing to fill — must raise."""
+    elem_rows = [(10, "5-ElasticBeam3d", 2, (1, 2))]
+    fake = _make_fake_dataset(elem_rows=elem_rows)
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={10: 0.0})
+    try:
+        with pytest.raises(LayerAttachError, match="no renderable element classes"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_attach_raises_when_dataset_is_empty() -> None:
+    fake = _make_fake_dataset(node_rows=[], elem_rows=[])
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={})
+    try:
+        with pytest.raises(LayerAttachError, match="no nodes or no elements"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_attach_twice_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 0.0, 12: 0.0, 13: 0.0})
+    try:
+        scene.add(layer)
+        with pytest.raises(LayerAttachError, match="already attached"):
+            layer.attach(scene, scene.source)
+    finally:
+        plt.close("all")
+
+
+def test_attach_missing_element_in_scalar_dict_raises() -> None:
+    """A rendered element with no scalar entry must fail loud, not silent."""
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 1.0})  # 12 and 13 missing
+    try:
+        with pytest.raises(KeyError, match="element id 1[23]"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_attach_clim_auto_freezes_to_initial_data() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 1.0, 12: 5.0, 13: 3.0})
+    try:
+        scene.add(layer)
+        assert layer.clim == (1.0, 5.0)
+    finally:
+        plt.close("all")
+
+
+def test_attach_clim_explicit_overrides_auto() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(
+        scalars={11: 1.0, 12: 5.0, 13: 3.0}, clim=(0.0, 10.0),
+    )
+    try:
+        scene.add(layer)
+        assert layer.clim == (0.0, 10.0)
+    finally:
+        plt.close("all")
+
+
+def test_attach_clim_handles_constant_field() -> None:
+    """A degenerate single-value field gets a non-zero range so colormaps work."""
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 7.0, 12: 7.0, 13: 7.0})
+    try:
+        scene.add(layer)
+        vmin, vmax = layer.clim
+        assert vmin == 7.0
+        assert vmax > vmin
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Backend interaction (matplotlib)
+# --------------------------------------------------------------------- #
+
+
+def test_2d_attach_emits_polycollection_per_class() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake, is_3d=False)
+    layer = ContourLayer(scalars={11: 1.0, 12: 2.0, 13: 3.0})
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert isinstance(actor, PolyCollection)
+            assert not isinstance(actor, Poly3DCollection)
+    finally:
+        plt.close("all")
+
+
+def test_3d_attach_emits_poly3dcollection_per_class() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake, is_3d=True)
+    layer = ContourLayer(scalars={11: 1.0, 12: 2.0, 13: 3.0})
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert isinstance(actor, Poly3DCollection)
+    finally:
+        plt.close("all")
+
+
+def test_attach_applies_mpl_zorder() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(
+        scalars={11: 1.0, 12: 2.0, 13: 3.0}, mpl_zorder=3.0,
+    )
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            assert actor.get_zorder() == pytest.approx(3.0)
+    finally:
+        plt.close("all")
+
+
+def test_attach_applies_clim_to_actor() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(
+        scalars={11: 1.0, 12: 5.0, 13: 3.0}, clim=(0.0, 10.0),
+    )
+    try:
+        scene.add(layer)
+        for actor in layer.actors.values():
+            vmin, vmax = actor.get_clim()
+            assert vmin == pytest.approx(0.0)
+            assert vmax == pytest.approx(10.0)
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# update_to_step
+# --------------------------------------------------------------------- #
+
+
+def test_static_scalars_update_is_noop() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 1.0, 12: 2.0, 13: 3.0})
+    try:
+        scene.add(layer)
+        assert layer.current_step is None  # static layer never tracks step
+        layer.update_to_step(3)
+        assert layer.current_step is None
+    finally:
+        plt.close("all")
+
+
+def test_callable_scalars_update_mutates_in_place() -> None:
+    """Same actor across step changes — apeGmsh perf contract."""
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+
+    def scalars_at(step):
+        # Linear ramp so we can verify values change.
+        return {11: float(step) + 1.0,
+                12: float(step) + 2.0,
+                13: float(step) + 3.0}
+
+    layer = ContourLayer(scalars=scalars_at, step=0)
+    try:
+        scene.add(layer)
+        actor_q4_before = layer.actors["203-ASDShellQ4(4n)"]
+        layer.update_to_step(5)
+        actor_q4_after = layer.actors["203-ASDShellQ4(4n)"]
+        # Same actor object — no recreation.
+        assert actor_q4_after is actor_q4_before
+        assert layer.current_step == 5
+        # Scalar array reflects step 5 values.
+        np.testing.assert_allclose(
+            actor_q4_after.get_array(), [6.0, 7.0],  # 11→6.0, 12→7.0
+        )
+    finally:
+        plt.close("all")
+
+
+def test_callable_update_same_step_is_noop() -> None:
+    call_log = {"n": 0}
+
+    def scalars_at(step):
+        call_log["n"] += 1
+        return {11: 1.0, 12: 2.0, 13: 3.0}
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars=scalars_at, step=0)
+    try:
+        scene.add(layer)
+        n_attach = call_log["n"]
+        layer.update_to_step(0)
+        assert call_log["n"] == n_attach
+    finally:
+        plt.close("all")
+
+
+def test_pre_attach_update_is_silent() -> None:
+    layer = ContourLayer(scalars=lambda s: {11: 1.0})
+    layer.update_to_step(5)
+    assert layer.current_step is None
+
+
+# --------------------------------------------------------------------- #
+# Selection + detach
+# --------------------------------------------------------------------- #
+
+
+def test_selection_subsets_rendered_elements() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    # Only request element 11.
+    layer = ContourLayer(
+        scalars={11: 1.0},
+        selection=SelectionSpec(element_ids=(11,)),
+    )
+    try:
+        scene.add(layer)
+        assert layer.n_faces == 1
+        assert layer.skipped_classes == []  # beam wasn't part of the selection
+    finally:
+        plt.close("all")
+
+
+def test_empty_selection_raises() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(
+        scalars={}, selection=SelectionSpec(element_ids=(9999,)),
+    )
+    try:
+        with pytest.raises(LayerAttachError, match="No elements remain"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_detach_clears_state_and_removes_actors() -> None:
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    layer = ContourLayer(scalars={11: 1.0, 12: 2.0, 13: 3.0})
+    try:
+        scene.add(layer)
+        assert layer.n_faces > 0
+        scene.remove(layer)
+        assert not layer.is_attached
+        assert layer.n_faces == 0
+        assert layer.skipped_classes == []
+        assert layer.actors == {}
+        assert layer.current_step is None
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Solid element coverage — bricks render 6 faces each
+# --------------------------------------------------------------------- #
+
+
+def test_brick_emits_six_faces_per_element() -> None:
+    """An 8-node brick contributes 6 quad faces, all sharing the cell value."""
+    node_rows = [
+        (1, 0.0, 0.0, 0.0),
+        (2, 1.0, 0.0, 0.0),
+        (3, 1.0, 1.0, 0.0),
+        (4, 0.0, 1.0, 0.0),
+        (5, 0.0, 0.0, 1.0),
+        (6, 1.0, 0.0, 1.0),
+        (7, 1.0, 1.0, 1.0),
+        (8, 0.0, 1.0, 1.0),
+    ]
+    elem_rows = [(100, "Brick", 8, (1, 2, 3, 4, 5, 6, 7, 8))]
+    fake = _make_fake_dataset(node_rows=node_rows, elem_rows=elem_rows)
+    scene = _make_scene(fake, is_3d=True)
+    layer = ContourLayer(scalars={100: 0.5})
+    try:
+        scene.add(layer)
+        assert layer.n_faces == 6
+        # rendered_element_ids reports the unique element ids, not faces.
+        rendered = layer.rendered_element_ids
+        assert rendered["Brick(8n)"].tolist() == [100]
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# Real-fixture parity
+# --------------------------------------------------------------------- #
+
+
+def test_contour_layer_renders_quad_frame(quad_frame_dir: Path) -> None:
+    from STKO_to_python import MPCODataSet
+
+    ds = MPCODataSet(str(quad_frame_dir), "results", verbose=False)
+    try:
+        # QuadFrame has 625 ASDShellQ4 + 75 beams. Provide a dummy scalar
+        # per shell — the test only verifies the renderer wires up.
+        df_elements = ds.elements_info["dataframe"]
+        shell_ids = df_elements.loc[
+            df_elements["element_type"] == "203-ASDShellQ4", "element_id"
+        ].to_numpy(dtype=np.int64)
+        scalars = {int(eid): float(i) for i, eid in enumerate(shell_ids)}
+
+        backend = MplBackend()
+        handle = backend.make_scene(is_3d=True)
+        source = MPCODataSourceAdapter(ds)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars=scalars,
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        scene.add(layer)
+        # One face per shell.
+        assert layer.n_faces == 625
+        # Beams aren't in the selection so they're not flagged as skipped.
+        assert layer.skipped_classes == []
+    finally:
+        plt.close("all")
+
+
+# --------------------------------------------------------------------- #
+# PyVista backend integration (gated on the [viewer-3d] extra)
+# --------------------------------------------------------------------- #
+
+
+def test_contour_layer_renders_through_pyvista_backend() -> None:
+    """The layer is backend-agnostic — same Scene + layer code, just a
+    different backend instance."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars={11: 1.0, 12: 2.0, 13: 3.0},
+            cmap="viridis",
+        )
+        scene.add(layer)
+        # Three faces total — two quads + one tri.
+        assert layer.n_faces == 3
+        # PyVista's add_polygons produces a _PvActorRef per class. Verify
+        # the cell_data scalars are bound to the dataset for the quad class.
+        from STKO_to_python.viewer.backends.pyvista.backend import _PvActorRef
+
+        for ref in layer.actors.values():
+            assert isinstance(ref, _PvActorRef)
+            assert ref.scalar_field == "values"
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_contour_in_place_update_keeps_same_actor() -> None:
+    """apeGmsh perf contract on PyVista: update_scalars mutates the same
+    cell_data array — actor instance is preserved across steps."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+
+        def scalars_at(step):
+            return {11: float(step) + 1.0,
+                    12: float(step) + 2.0,
+                    13: float(step) + 3.0}
+
+        layer = ContourLayer(scalars=scalars_at, step=0)
+        scene.add(layer)
+        ref_before = layer.actors["203-ASDShellQ4(4n)"]
+        layer.update_to_step(5)
+        ref_after = layer.actors["203-ASDShellQ4(4n)"]
+        assert ref_after is ref_before  # actor not recreated
+        # Step 5 values: 11 -> 6.0, 12 -> 7.0
+        np.testing.assert_allclose(
+            ref_after.dataset.cell_data["values"], [6.0, 7.0],
+        )
+    finally:
+        handle.plotter.close()


### PR DESCRIPTION
## Summary

- First contour layer per [`docs/viewer/02-porting-from-apegmsh.md`](docs/viewer/02-porting-from-apegmsh.md) §4. Ships the **cell-topology path** of apeGmsh's five-path dispatch — one filled polygon per element, colored by a caller-supplied scalar.
- **Backend-agnostic** by design: same Scene + layer code runs on both `MplBackend` (2-D / 3-D `Poly[3D]Collection`) and `PyVistaBackend` (PolyData with cell_data). Two PyVista-gated integration tests pin that contract.
- Honours the apeGmsh perf contract: `update_to_step` re-invokes the scalars callable and mutates each actor's per-cell array **in place** — same actor instance across steps on both backends.

## Scope rationale

The remaining four paths from the directive (nodal, GP-cell-averaged, GP-node-extrap-smooth, GP-node-discrete) either:
1. feed back through this same cell renderer (GP-cell-averaged is just upstream aggregation), or
2. require a `Backend.add_polygons(point_values=...)` protocol extension for per-vertex coloring.

This cell-only PR avoids the protocol extension and bypasses the per-vertex coloring divergence between matplotlib (no `PolyCollection` per-vertex path) and PyVista (native `point_data`). Phase 3.0c adds the extension and the nodal-smooth path; 3.0d picks up GP-node-extrap-smooth, with the Phase 1 [Gauss extrapolation kernel](src/STKO_to_python/viewer/math/gauss_extrapolation.py) plugging straight in.

## Design notes

- **Scalars contract**: dict-based — `dict[int, float]` (`element_id → value`) for static, or `callable(step) -> dict[int, float]` for time-varying. Missing keys raise `KeyError` so silent data dropouts are impossible. Caller doesn't need to know the layer's element ordering.
- **Face topology**: tris (1 face), quads (1 face), bricks (6 quad faces with the same cell value). Lines and any class without a topology entry are skipped with a `RuntimeWarning`, surfaced as `skipped_classes`.
- **Auto-frozen `clim`** from the attach-step data so the colorbar means the same thing across animation steps. Explicit `clim=(vmin, vmax)` overrides. Degenerate single-value fields get a non-zero range so colormaps still work.
- `mpl_zorder=1.5` sits between `MeshLayer` (1.0) and scatter / diagram overlays (≥ 2.0).
- Static mode leaves `current_step=None` (it's meaningless for a fixed field); `update_to_step` is a no-op. Time-varying mode tracks step honestly.

## Test plan

- [x] **27 new tests** in [`tests/viewer/layers/test_contour_layer.py`](tests/viewer/layers/test_contour_layer.py): construction (static vs callable), class bucketing, skipped-class warnings, dataset-empty / no-renderable-class / missing-scalar-key errors, clim auto-derivation + override + degenerate-field handling, 2-D `PolyCollection` / 3-D `Poly3DCollection` actor types, mpl_zorder application, brick 6-faces-per-element bookkeeping, selection subsetting, detach cleanup, and **two PyVista-gated integration tests** that prove the same scene + layer code runs against `PyVistaBackend` with `cell_data` bound and in-place update preserved across steps.
- [x] system Python (no pyvista): `tests/viewer/` 321 passed, 5 skipped (pyvista-gated + extras smoke). Full suite: **1606 passed, 42 skipped**.
- [x] `opensees_venv` (pyvista 0.47.1 + VTK 9.6.1): all 27 ContourLayer tests pass including both PyVista integration tests.

## What's next

Phase 3.0c — extend `Backend.add_polygons` with a `point_values=` kwarg for per-vertex coloring, then add the **nodal-smooth** topology to `ContourLayer`. The GP-node-extrap-smooth path follows once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)