### PR TITLE
Add nodal-topology ContourLayer + point_values protocol (Phase 3.0c)

### DIFF
--- a/src/STKO_to_python/viewer/backends/mpl/backend.py
+++ b/src/STKO_to_python/viewer/backends/mpl/backend.py
@@ -215,6 +215,7 @@ class MplBackend:
         polygons: Any,
         *,
         values: np.ndarray | None = None,
+        point_values: np.ndarray | None = None,
         cmap: str | None = None,
         edge_color: Any = None,
     ) -> ActorRef:
@@ -223,7 +224,29 @@ class MplBackend:
         ``polygons`` is a sequence of ``(M_i, 3)`` (or ``(M_i, 2)``)
         vertex arrays — one ``M_i``-sided polygon per entry. Matplotlib
         accepts heterogeneous M, so we do not reshape into a tensor.
+
+        Matplotlib's ``PolyCollection`` colors per cell, not per
+        vertex. Supplying ``point_values`` raises
+        :class:`BackendCapabilityError` — per-vertex (Gouraud-style)
+        coloring requires either ``tripcolor`` (2-D triangle mesh
+        only) or a different backend (e.g. PyVista). The 2-D
+        ``tripcolor`` path is a follow-up; callers who need
+        per-vertex coloring on matplotlib today should pre-aggregate
+        to per-cell scalars and pass ``values=`` instead.
         """
+        if values is not None and point_values is not None:
+            raise ValueError(
+                "add_polygons accepts either values= or point_values=, "
+                "not both."
+            )
+        if point_values is not None:
+            raise BackendCapabilityError(
+                "MplBackend.add_polygons does not support per-vertex "
+                "coloring (point_values=). matplotlib's PolyCollection is "
+                "per-cell only; use a different backend (e.g. PyVista) for "
+                "smooth nodal contours, or aggregate the per-node scalars "
+                "to per-cell before calling."
+            )
         kwargs: dict[str, Any] = {}
         if edge_color is not None:
             kwargs["edgecolors"] = edge_color

--- a/src/STKO_to_python/viewer/backends/pyvista/backend.py
+++ b/src/STKO_to_python/viewer/backends/pyvista/backend.py
@@ -290,6 +290,7 @@ class PyVistaBackend:
         polygons: Any,
         *,
         values: np.ndarray | None = None,
+        point_values: np.ndarray | None = None,
         cmap: str | None = None,
         edge_color: Any = None,
     ) -> ActorRef:
@@ -298,9 +299,19 @@ class PyVistaBackend:
         ``polygons`` is a sequence of ``(M_i, 3)`` vertex arrays —
         one M-sided polygon per entry. Heterogeneous ``M_i`` is
         supported via VTK's variable-length face encoding.
-        Per-cell ``values`` are stored in ``cell_data["values"]``;
-        :meth:`update_scalars` writes into the same name.
+
+        ``values`` (per-cell) is stored in ``cell_data["values"]``;
+        ``point_values`` (per-vertex, in the same flattened order as
+        the concatenated polygon vertex stream) is stored in
+        ``point_data["point_values"]``. Passing both is a
+        ``ValueError``. :meth:`update_scalars` writes into whichever
+        field is bound — caller doesn't need to remember which.
         """
+        if values is not None and point_values is not None:
+            raise ValueError(
+                "add_polygons accepts either values= or point_values=, "
+                "not both."
+            )
         polys_list = list(polygons) if not isinstance(polygons, list) else polygons
         if not polys_list:
             poly = pv.PolyData()
@@ -341,6 +352,16 @@ class PyVistaBackend:
             scalar_field = "values"
             poly.cell_data[scalar_field] = np.asarray(values, dtype=np.float64)
             kwargs["scalars"] = scalar_field
+            kwargs["preference"] = "cell"
+            if cmap is not None:
+                kwargs["cmap"] = cmap
+        elif point_values is not None and poly.n_points > 0:
+            scalar_field = "point_values"
+            poly.point_data[scalar_field] = np.asarray(
+                point_values, dtype=np.float64,
+            )
+            kwargs["scalars"] = scalar_field
+            kwargs["preference"] = "point"
             if cmap is not None:
                 kwargs["cmap"] = cmap
         actor = scene.plotter.add_mesh(poly, **kwargs)
@@ -392,9 +413,13 @@ class PyVistaBackend:
     def update_scalars(self, actor: ActorRef, scalars: np.ndarray) -> None:
         """Mutate an actor's scalar field in place.
 
-        Requires the actor was created with a ``scalars=`` argument
-        (which bound the field name at creation time). Arrows have
-        no scalar field — they raise :class:`BackendCapabilityError`.
+        Requires the actor was created with a ``scalars=`` /
+        ``values=`` / ``point_values=`` argument (which bound the
+        field name at creation time). Arrows have no scalar field —
+        they raise :class:`BackendCapabilityError`. The write is
+        dispatched to ``point_data`` or ``cell_data`` explicitly
+        based on where the field was originally bound, so length-
+        equal point and cell arrays never collide.
         """
         ref = self._unwrap(actor)
         if ref.dataset is None or ref.scalar_field is None:
@@ -402,7 +427,17 @@ class PyVistaBackend:
                 f"Actor (kind={ref.kind!r}) does not support scalar updates "
                 "— no scalar field was bound at creation."
             )
-        ref.dataset[ref.scalar_field] = np.asarray(scalars, dtype=np.float64)
+        arr = np.asarray(scalars, dtype=np.float64)
+        field = ref.scalar_field
+        if field in ref.dataset.point_data:
+            ref.dataset.point_data[field] = arr
+        elif field in ref.dataset.cell_data:
+            ref.dataset.cell_data[field] = arr
+        else:
+            # First-time binding via the dataset's __setitem__ dispatch.
+            # Used for the ``points`` kind, whose scalars live on
+            # ``point_data`` from creation.
+            ref.dataset[field] = arr
         ref.dataset.Modified()
 
     def update_points(self, actor: ActorRef, points: np.ndarray) -> None:

--- a/src/STKO_to_python/viewer/core/backend.py
+++ b/src/STKO_to_python/viewer/core/backend.py
@@ -91,11 +91,21 @@ class Backend(Protocol):
         polygons: np.ndarray,
         *,
         values: np.ndarray | None = None,
+        point_values: np.ndarray | None = None,
         cmap: str | None = None,
         edge_color: Any = None,
     ) -> ActorRef:
         """Add filled polygons. ``polygons`` is a ``(N, M, 3)`` array
-        of M-sided polygon vertices, or backend-specific equivalent."""
+        of M-sided polygon vertices, or backend-specific equivalent.
+
+        Exactly one of ``values`` (one scalar per cell) or
+        ``point_values`` (one scalar per vertex of the flattened
+        polygon vertex stream) may be supplied; passing both raises a
+        ``ValueError``. ``point_values`` drives smooth per-vertex
+        coloring (Gouraud-style) and may not be supported by every
+        backend — implementations that lack a per-vertex path raise
+        :class:`STKO_to_python.viewer.core.errors.BackendCapabilityError`.
+        """
 
     def add_arrows(
         self,

--- a/src/STKO_to_python/viewer/layers/contour.py
+++ b/src/STKO_to_python/viewer/layers/contour.py
@@ -1,45 +1,49 @@
-"""``ContourLayer`` — per-cell scalar field over the mesh.
+"""``ContourLayer`` — scalar field over the mesh, cell- or nodal-topology.
 
-Renders one filled polygon per element, colored by a caller-supplied
-scalar map. This is the **cell-topology** path of the directive's
-five-path dispatch (per
-``docs/viewer/02-porting-from-apegmsh.md`` §4 / apeGmsh's
-``viewers/diagrams/_contour.py``):
+Renders filled polygons over the model surface, colored by a caller-
+supplied scalar map. Implements two of the five paths from the
+directive (per ``docs/viewer/02-porting-from-apegmsh.md`` §4 /
+apeGmsh's ``viewers/diagrams/_contour.py``):
 
-* **cell** (this layer, Phase 3.0b) — one scalar per element.
-* nodal — one scalar per node; **not yet implemented** (Phase 3.0c
-  with a ``Backend.add_polygons(point_values=...)`` extension).
-* GP-cell-averaged — one scalar per element, computed by averaging
-  per-GP values upstream; same renderer path as ``cell`` here.
+* **cell** (Phase 3.0b) — one scalar per element; rendered through
+  ``backend.add_polygons(values=...)``.
+* **nodal** (Phase 3.0c) — one scalar per node; rendered through
+  ``backend.add_polygons(point_values=...)`` for smooth Gouraud-style
+  interpolation. PyVista native; MplBackend raises
+  :class:`BackendCapabilityError` because matplotlib's
+  ``PolyCollection`` is per-cell only.
+
+The remaining three paths from the directive are upstream
+aggregations of these two:
+
+* GP-cell-averaged — one scalar per element from averaged per-GP
+  values; same renderer path as ``cell``.
 * GP-node-extrap-smooth — extrapolate GPs to nodes via
   :func:`STKO_to_python.viewer.math.gauss_extrapolation.extrapolate_to_nodes_averaged`,
-  then render as nodal. Phase 3.0c.
-* GP-node-discrete — extrapolate per-element, render with
-  discontinuous nodes (each element keeps its own corner copies).
-  Phase 3.0d.
-
-By keeping the layer cell-topology-only this PR avoids extending the
-``Backend.add_polygons`` protocol and bypasses the
-nodal-coloring divergence between matplotlib (no ``PolyCollection``
-per-vertex coloring) and PyVista (native ``point_data``). The
-follow-up PRs add the missing paths once the protocol extension is
-proven on PyVista.
+  then render as ``nodal``. Phase 3.0d.
+* GP-node-discrete — extrapolate per-element, render each element's
+  corner values as a separate discontinuous polygon. Phase 3.0e.
 
 Scalars contract
 ----------------
 
-The caller supplies scalars as either:
+For ``topology="cell"``, the caller supplies scalars as
+``dict[element_id, float]``. For ``topology="nodal"``, the caller
+supplies ``dict[node_id, float]``. In both cases the input is either:
 
-* a **static** ``dict[int, float]`` mapping ``element_id → value`` —
-  the layer is non-time-varying and :meth:`update_to_step` is a
-  no-op;
-* a **callable** ``(step: int) -> dict[int, float]`` invoked at
-  attach (with the initial step) and at every
-  :meth:`update_to_step` — same dict shape, fresh per call.
+* a **static** dict — the layer is non-time-varying and
+  :meth:`update_to_step` is a no-op;
+* a **callable** ``(step: int) -> dict`` invoked at attach (with the
+  initial step) and at every :meth:`update_to_step` — same dict
+  shape, fresh per call.
 
 Both shapes are dict-based on purpose: the caller doesn't need to
-know the renderer's element ordering, and a missing key is a hard
-error (no silent data dropouts).
+know the renderer's element / vertex ordering, and a missing key is
+a hard error (no silent data dropouts). Nodal-mode lookups happen
+per face vertex against the **node** the vertex came from — shared
+nodes across neighbouring faces resolve to the same scalar value,
+which is what makes the rendering visually smooth despite the
+polydata storing duplicated vertices per polygon.
 """
 from __future__ import annotations
 
@@ -105,15 +109,26 @@ ScalarsInput = Mapping[int, float] | Callable[[int], Mapping[int, float]]
 
 
 class ContourLayer(Layer):
-    """Per-cell scalar contour over the model surface.
+    """Scalar contour over the model surface, cell- or nodal-topology.
 
     Parameters
     ----------
     scalars:
-        Either a static ``dict[int, float]`` mapping ``element_id →
-        value`` or a callable ``(step) -> dict[int, float]``. Each
-        rendered element must have an entry; missing keys raise
-        :class:`KeyError`.
+        Either a static ``dict[int, float]`` or a callable
+        ``(step) -> dict[int, float]``. The dict keys are
+        **element ids** when ``topology="cell"`` and **node ids**
+        when ``topology="nodal"``. Each rendered element / node must
+        have an entry; missing keys raise :class:`KeyError`.
+    topology:
+        ``"cell"`` (default) for one scalar per element, rendered
+        through ``backend.add_polygons(values=...)``. ``"nodal"`` for
+        one scalar per node, rendered through
+        ``backend.add_polygons(point_values=...)`` for smooth
+        Gouraud-style interpolation. The nodal path is supported by
+        :class:`~STKO_to_python.viewer.backends.pyvista.PyVistaBackend`;
+        :class:`~STKO_to_python.viewer.backends.mpl.MplBackend` raises
+        :class:`BackendCapabilityError` because
+        ``PolyCollection`` is per-cell only.
     step:
         Initial step. Only consulted when ``scalars`` is a callable —
         the static-dict path ignores it.
@@ -150,7 +165,7 @@ class ContourLayer(Layer):
     -----------------
 
     When ``scalars`` is callable, :meth:`update_to_step` re-invokes
-    it, re-indexes into the rendered-element order, and calls
+    it, re-indexes into the rendered-face order, and calls
     ``backend.update_scalars`` on the existing actors — no actor
     recreation, satisfies the apeGmsh perf contract. When
     ``scalars`` is a static dict, :meth:`update_to_step` is a no-op.
@@ -162,6 +177,7 @@ class ContourLayer(Layer):
         self,
         *,
         scalars: ScalarsInput,
+        topology: str = "cell",
         step: int = 0,
         cmap: str = "viridis",
         clim: tuple[float, float] | None = None,
@@ -175,6 +191,11 @@ class ContourLayer(Layer):
         super().__init__(
             name=name, selection=selection, visible=visible, z_order=z_order,
         )
+        if topology not in ("cell", "nodal"):
+            raise ValueError(
+                f"topology must be 'cell' or 'nodal', got {topology!r}."
+            )
+        self.topology = topology
         self._scalars_input: ScalarsInput = scalars
         self._initial_step = int(step) if step is not None else 0
         self._current_step: int | None = None
@@ -184,10 +205,14 @@ class ContourLayer(Layer):
         self.mpl_zorder = mpl_zorder
 
         # Populated at attach.
-        # Each entry: (label, polygon_vertex_arrays, source_element_ids,
-        # actor). source_element_ids parallels the polygon list per class —
-        # one entry per drawn face. A brick contributes 6 polygon entries
-        # all pointing at its element id.
+        # Each entry: (label, polygons, source_element_ids,
+        # face_node_ids, actor).
+        # - source_element_ids parallels ``polygons`` per class — one
+        #   entry per drawn face. A brick contributes 6 polygon entries
+        #   all pointing at its element id.
+        # - face_node_ids is a length-n_faces list of (M,) int64 arrays:
+        #   the node ids associated with each face vertex, used to look
+        #   scalars up by node id in the nodal-topology path.
         self._classes: list[dict[str, Any]] = []
         self._skipped_classes: list[str] = []
 
@@ -283,6 +308,7 @@ class ContourLayer(Layer):
 
             polygons: list[np.ndarray] = []
             src_ids: list[int] = []
+            face_node_ids: list[np.ndarray] = []
             for row in group.itertuples(index=False):
                 node_list = row.node_list
                 try:
@@ -295,9 +321,14 @@ class ContourLayer(Layer):
                     continue
                 if pts.shape[0] != int(n_nodes):
                     continue
+                node_list_arr = np.asarray(
+                    [int(nid) for nid in node_list], dtype=np.int64,
+                )
                 for face_idx in topo:
-                    polygons.append(pts[list(face_idx)])
+                    idx = list(face_idx)
+                    polygons.append(pts[idx])
                     src_ids.append(int(row.element_id))
+                    face_node_ids.append(node_list_arr[idx])
 
             if not polygons:
                 continue
@@ -306,6 +337,7 @@ class ContourLayer(Layer):
                     "label": label,
                     "polygons": polygons,
                     "source_element_ids": np.asarray(src_ids, dtype=np.int64),
+                    "face_node_ids": face_node_ids,
                     "actor": None,  # filled below
                 }
             )
@@ -318,8 +350,9 @@ class ContourLayer(Layer):
                 "(line elements are skipped; need shells or solids)."
             )
 
-        # Initial scalars for every drawn face, in the same class /
-        # polygon order as the geometry. Auto-frozen clim when not given.
+        # Initial scalars for every drawn face / per-vertex stream, in
+        # the same class / polygon order as the geometry. Auto-frozen
+        # clim when not given.
         initial_values = self._values_at_step(self._initial_step)
         if self.clim is None:
             global_values = np.concatenate(
@@ -334,18 +367,30 @@ class ContourLayer(Layer):
                     vmax = vmin + 1.0
                 self.clim = (vmin, vmax)
 
-        # Create actors.
+        # Create actors. The two topologies route through different
+        # add_polygons kwargs; the backend protocol guarantees that
+        # passing both at once is a ValueError, so each entry is
+        # one-or-the-other.
         backend = scene.backend
         handle = scene.handle
         for entry in self._classes:
-            values = initial_values[entry["label"]]
-            actor = backend.add_polygons(
-                handle,
-                entry["polygons"],
-                values=values,
-                cmap=self.cmap,
-                edge_color=self.edge_color,
-            )
+            scalars = initial_values[entry["label"]]
+            if self.topology == "cell":
+                actor = backend.add_polygons(
+                    handle,
+                    entry["polygons"],
+                    values=scalars,
+                    cmap=self.cmap,
+                    edge_color=self.edge_color,
+                )
+            else:  # "nodal"
+                actor = backend.add_polygons(
+                    handle,
+                    entry["polygons"],
+                    point_values=scalars,
+                    cmap=self.cmap,
+                    edge_color=self.edge_color,
+                )
             entry["actor"] = actor
             self._apply_post_hoc(actor)
 
@@ -414,27 +459,50 @@ class ContourLayer(Layer):
         return result
 
     def _values_at_step(self, step: int) -> dict[str, np.ndarray]:
-        """``{class_label: (n_faces,) float64 array}`` for ``step``.
+        """Resolve the per-class scalar arrays for ``step``.
 
-        Each face copies the source element's scalar — bricks have
-        six faces but a single per-element value.
+        Cell topology: ``{class_label: (n_faces,) float64 array}`` — one
+        value per face, looked up by ``source_element_ids``. Bricks have
+        six faces but a single per-element value broadcast across all six.
+
+        Nodal topology: ``{class_label: (sum_face_M,) float64 array}`` —
+        the flattened per-vertex stream in the same order as the
+        concatenated polygon vertex stream that ``backend.add_polygons``
+        consumes. Shared nodes resolve to identical values, which is
+        what makes the rendering visually smooth.
         """
         scalars = self._scalars_dict_at(step)
         out: dict[str, np.ndarray] = {}
         for entry in self._classes:
-            src_ids = entry["source_element_ids"]
-            try:
-                arr = np.asarray(
-                    [scalars[int(eid)] for eid in src_ids],
-                    dtype=np.float64,
-                )
-            except KeyError as exc:
-                missing = int(exc.args[0]) if exc.args else None
-                raise KeyError(
-                    f"ContourLayer.scalars is missing element id {missing} "
-                    f"(class {entry['label']!r}, step {step})."
-                ) from exc
-            out[entry["label"]] = arr
+            if self.topology == "cell":
+                src_ids = entry["source_element_ids"]
+                try:
+                    arr = np.asarray(
+                        [scalars[int(eid)] for eid in src_ids],
+                        dtype=np.float64,
+                    )
+                except KeyError as exc:
+                    missing = int(exc.args[0]) if exc.args else None
+                    raise KeyError(
+                        f"ContourLayer.scalars is missing element id "
+                        f"{missing} (class {entry['label']!r}, step {step})."
+                    ) from exc
+                out[entry["label"]] = arr
+            else:  # "nodal"
+                # Flatten the per-face node_id stream and look up each
+                # vertex's scalar by node id.
+                vertices: list[float] = []
+                for face_nids in entry["face_node_ids"]:
+                    for nid in face_nids:
+                        try:
+                            vertices.append(float(scalars[int(nid)]))
+                        except KeyError as exc:
+                            raise KeyError(
+                                f"ContourLayer.scalars is missing node id "
+                                f"{int(nid)} (class {entry['label']!r}, "
+                                f"step {step})."
+                            ) from exc
+                out[entry["label"]] = np.asarray(vertices, dtype=np.float64)
         return out
 
     def _apply_post_hoc(self, actor: Any) -> None:

--- a/tests/viewer/backends/mpl/test_backend.py
+++ b/tests/viewer/backends/mpl/test_backend.py
@@ -251,6 +251,29 @@ def test_add_polygons_with_values_sets_array(
     np.testing.assert_array_equal(actor.get_array(), values)
 
 
+def test_add_polygons_with_point_values_raises_capability_error(
+    backend: MplBackend, scene_2d: MplSceneHandle,
+) -> None:
+    """matplotlib's PolyCollection is per-cell only — per-vertex coloring
+    must fail loud, not silently swallow the request."""
+    polys = [np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float64)]
+    with pytest.raises(BackendCapabilityError, match="per-vertex"):
+        backend.add_polygons(scene_2d, polys, point_values=np.array([0.0, 1.0, 2.0, 3.0]))
+
+
+def test_add_polygons_with_both_values_and_point_values_raises(
+    backend: MplBackend, scene_2d: MplSceneHandle,
+) -> None:
+    """Passing both forms is a protocol-level error, regardless of backend."""
+    polys = [np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float64)]
+    with pytest.raises(ValueError, match="not both"):
+        backend.add_polygons(
+            scene_2d, polys,
+            values=np.array([1.0]),
+            point_values=np.array([0.0, 1.0, 2.0, 3.0]),
+        )
+
+
 # --------------------------------------------------------------------- #
 # add_arrows                                                            #
 # --------------------------------------------------------------------- #

--- a/tests/viewer/layers/test_contour_layer.py
+++ b/tests/viewer/layers/test_contour_layer.py
@@ -548,3 +548,182 @@ def test_pyvista_contour_in_place_update_keeps_same_actor() -> None:
         )
     finally:
         handle.plotter.close()
+
+
+# --------------------------------------------------------------------- #
+# Nodal topology (Phase 3.0c)
+# --------------------------------------------------------------------- #
+
+
+def test_topology_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="topology must be"):
+        ContourLayer(scalars={1: 0.0}, topology="bogus")
+
+
+def test_topology_default_is_cell() -> None:
+    layer = ContourLayer(scalars={11: 0.0})
+    assert layer.topology == "cell"
+
+
+def test_nodal_mode_on_mpl_raises_backend_capability_error() -> None:
+    """MplBackend doesn't support per-vertex polygon coloring —
+    nodal contour on mpl must fail loud with a clear message."""
+    from STKO_to_python.viewer.core.errors import BackendCapabilityError
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    # One value per node in the fake dataset (6 nodes).
+    nodal_scalars = {1: 0.0, 2: 0.5, 3: 1.0, 4: 0.5, 5: 0.7, 6: 0.9}
+    layer = ContourLayer(scalars=nodal_scalars, topology="nodal")
+    try:
+        with pytest.raises(BackendCapabilityError, match="per-vertex"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_nodal_mode_missing_node_in_scalar_dict_raises() -> None:
+    """Same loud-failure contract as cell mode, but for node ids."""
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    # Leaves out one of the nodes a rendered face references.
+    nodal_scalars = {1: 0.0, 2: 0.5}  # missing 3, 4, 5, 6
+    layer = ContourLayer(scalars=nodal_scalars, topology="nodal")
+    try:
+        # On mpl the BackendCapabilityError from add_polygons fires first
+        # at the call site; the KeyError contract is exercised by the
+        # PyVista nodal tests below where the path can actually proceed
+        # far enough to evaluate scalars.
+        with pytest.raises(Exception):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_pyvista_nodal_contour_binds_point_data() -> None:
+    """PyVista path stores per-vertex scalars in point_data, not cell_data."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+    from STKO_to_python.viewer.backends.pyvista.backend import _PvActorRef
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+
+        nodal = {1: 0.0, 2: 1.0, 3: 2.0, 4: 3.0, 5: 4.0, 6: 5.0}
+        layer = ContourLayer(scalars=nodal, topology="nodal")
+        scene.add(layer)
+
+        # The Q4 class: two quads share an edge (nodes 2,3). Vertex stream
+        # is the flattened concat of each face's 4 corners.
+        # Quad 11 (1,2,3,4) -> [0.0, 1.0, 2.0, 3.0]
+        # Quad 12 (2,5,6,3) -> [1.0, 4.0, 5.0, 2.0]
+        q4_ref = layer.actors["203-ASDShellQ4(4n)"]
+        assert isinstance(q4_ref, _PvActorRef)
+        assert q4_ref.scalar_field == "point_values"
+        np.testing.assert_allclose(
+            q4_ref.dataset.point_data["point_values"],
+            [0.0, 1.0, 2.0, 3.0,    # quad 11
+             1.0, 4.0, 5.0, 2.0],   # quad 12
+        )
+        # Shared corner node 2 contributed identical values (1.0) to both
+        # quads — that's what makes the rendering visually continuous.
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_nodal_contour_in_place_update() -> None:
+    """update_scalars must dispatch to point_data, not cell_data."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+
+        def scalars_at(step):
+            base = float(step)
+            return {1: base, 2: base + 1, 3: base + 2,
+                    4: base + 3, 5: base + 4, 6: base + 5}
+
+        layer = ContourLayer(scalars=scalars_at, topology="nodal", step=0)
+        scene.add(layer)
+        ref_before = layer.actors["203-ASDShellQ4(4n)"]
+        layer.update_to_step(10)
+        ref_after = layer.actors["203-ASDShellQ4(4n)"]
+        assert ref_after is ref_before  # actor preserved
+        assert layer.current_step == 10
+        # cell_data MUST be untouched; point_data has the new step-10 values.
+        assert "values" not in ref_after.dataset.cell_data
+        # Step 10 quad 11 (1,2,3,4): 10, 11, 12, 13
+        np.testing.assert_allclose(
+            ref_after.dataset.point_data["point_values"][:4],
+            [10.0, 11.0, 12.0, 13.0],
+        )
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_nodal_contour_clim_autofreezes_to_data_range() -> None:
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        nodal = {1: -2.0, 2: 0.0, 3: 5.0, 4: 1.0, 5: 3.0, 6: 7.0}
+        layer = ContourLayer(scalars=nodal, topology="nodal")
+        scene.add(layer)
+        vmin, vmax = layer.clim
+        assert vmin == pytest.approx(-2.0)
+        assert vmax == pytest.approx(7.0)
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_nodal_contour_missing_node_raises() -> None:
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars={1: 0.0, 2: 1.0},  # 3-6 missing
+            topology="nodal",
+        )
+        with pytest.raises(KeyError, match="node id"):
+            scene.add(layer)
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_backend_polygons_both_values_and_point_values_raises() -> None:
+    """The protocol forbids supplying both at once."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        tri = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        with pytest.raises(ValueError, match="not both"):
+            backend.add_polygons(
+                handle, [tri],
+                values=np.array([1.0]),
+                point_values=np.array([0.0, 1.0, 2.0]),
+            )
+    finally:
+        handle.plotter.close()


### PR DESCRIPTION
## Summary

- Extends [`Backend.add_polygons`](src/STKO_to_python/viewer/core/backend.py) with a `point_values=` kwarg for per-vertex (Gouraud-style) coloring.
- Wires `ContourLayer.topology="nodal"` through it: scalars dict keyed by **node id**, one value per node, rendered smoothly on PyVista.
- `MplBackend` honestly raises `BackendCapabilityError` — matplotlib's `PolyCollection` is per-cell only; the directive's "no silent fallback" rule applies.
- `PyVistaBackend.update_scalars` now dispatches **explicitly** to `point_data` or `cell_data` based on the field's historical home, so length-equal point/cell arrays no longer collide in `__setitem__`.

## Design notes

- **Vertex duplication is fine for smoothness.** Each polygon's vertices get unique indices in the PolyData (per-polygon, not shared). The layer looks up each vertex's scalar by `node_id` from the user's `{node_id: value}` dict — so shared nodes across neighbouring faces resolve to the **same** value at their duplicated vertex copies. VTK / GL interpolation within each polygon then matches at the shared edges, giving visually continuous contours.
- **Protocol contract.** Passing both `values=` and `point_values=` is a `ValueError` on every backend. This keeps the API unambiguous and the layer code simple.
- **Missing-key errors carry topology-aware messages**: `"missing element id N"` for cell mode, `"missing node id N"` for nodal mode.

## Test plan

- [x] **7 new ContourLayer tests**: topology rejects unknown values, defaults to `"cell"`; nodal on mpl raises `BackendCapabilityError`; PyVista nodal binds `point_data` with the right flattened ordering (two quads sharing an edge get identical values at the two shared corners); PyVista nodal `update_to_step` mutates `point_data` in place, leaves `cell_data` untouched; auto-clim spans the nodal range; missing-node raises `KeyError`.
- [x] **2 new MplBackend protocol tests**: `point_values` raises `BackendCapabilityError` with a precise message; both-supplied raises `ValueError`.
- [x] system Python (no pyvista): `tests/viewer/` overall **327 passed, 10 skipped**. Full suite **1612 passed, 47 skipped**.
- [x] `opensees_venv` (pyvista 0.47.1 + VTK 9.6.1): `tests/viewer/` overall **364 passed** (the unrelated qtpy/PySide6 env-quirk smoke is deselected). All 7 PyVista-gated nodal tests + 27 prior cell-mode tests pass.

## What's next

Phase 3.0d — **GP-node-extrap-smooth**. The [`extrapolate_to_nodes_averaged`](src/STKO_to_python/viewer/math/gauss_extrapolation.py) kernel from Phase 1 produces exactly the `{node_id: value}` dict shape that `ContourLayer`'s nodal mode consumes, so the layer change is small (a thin wrapper that takes a GP scalar source + element layout and feeds the kernel's output into a callable scalars closure). Phase 3.0e then picks up GP-node-discrete (per-element corner copies, no cross-element averaging — different polygon geometry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)