### PR TITLE
Add GP→nodal extrapolation helper for ContourLayer (Phase 3.0d)

### DIFF
--- a/src/STKO_to_python/viewer/math/gauss_extrapolation.py
+++ b/src/STKO_to_python/viewer/math/gauss_extrapolation.py
@@ -60,7 +60,7 @@ entries; add one entry per future higher-order class.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Mapping, Optional
 
 import numpy as np
 
@@ -89,6 +89,7 @@ __all__ = [
     "build_extrapolation_matrix",
     "extrapolate_per_element",
     "extrapolate_to_nodes_averaged",
+    "make_gp_nodal_scalars",
 ]
 
 
@@ -348,3 +349,115 @@ def extrapolate_to_nodes_averaged(
     for j, nid in enumerate(node_ids):
         nodal[:, j] = sums[int(nid)] / counts[int(nid)]
     return node_ids, nodal
+
+
+def make_gp_nodal_scalars(
+    *,
+    gp_values_fn: Callable[[int], np.ndarray],
+    element_index: np.ndarray,
+    natural_coords: np.ndarray,
+    element_lookup: Mapping[int, tuple],
+) -> Callable[[int], dict[int, float]]:
+    """Build a step-callable that yields ``{node_id: value}`` for
+    :class:`~STKO_to_python.viewer.layers.ContourLayer`'s
+    ``topology="nodal"`` path.
+
+    This is the **GP-node-extrap-smooth** path of the directive's
+    five-path dispatch (per
+    ``docs/viewer/02-porting-from-apegmsh.md`` §4). Wraps
+    :func:`extrapolate_per_element` and
+    :func:`extrapolate_to_nodes_averaged` into a single closure that
+    feeds ContourLayer's nodal scalars contract.
+
+    Args:
+        gp_values_fn: Callable ``(step) -> (n_total_gp,) ndarray``.
+            Returns per-GP values for one analysis step in the same
+            row order as ``element_index`` and ``natural_coords``.
+            The query engine's LRU cache typically makes per-step
+            calls cheap after the first.
+        element_index: ``(n_total_gp,)`` int — element id per GP row.
+            Pinned at construction; layers can't move GPs across
+            elements mid-animation.
+        natural_coords: ``(n_total_gp, dim)`` float — natural-coord
+            position of each GP in its parent element. Pinned at
+            construction.
+        element_lookup: ``{element_id: (element_class,
+            corner_node_ids)}`` map. ``element_class`` is a STKO class
+            key (e.g. ``"203-ASDShellQ4"``); ``corner_node_ids`` is a
+            ``(n_corner,)`` int array. Pinned at construction.
+
+    Returns:
+        A callable ``(step: int) -> dict[int, float]`` that
+        :class:`ContourLayer` consumes as its ``scalars=`` argument.
+        Each call evaluates the extrapolation pipeline at one step;
+        shared corners across neighbouring elements get the
+        arithmetic mean per
+        :func:`extrapolate_to_nodes_averaged`. The dict is empty
+        when no element survives ``element_lookup`` filtering at
+        the given step.
+
+    Example:
+        ::
+
+            from STKO_to_python.viewer.math.gauss_extrapolation import (
+                make_gp_nodal_scalars,
+            )
+            from STKO_to_python.viewer.layers import ContourLayer
+
+            def per_step_gp_values(step):
+                # Pull a (n_total_gp,) array from your ElementResults
+                # at ``step`` — order must match ``element_index``.
+                ...
+
+            scalars_fn = make_gp_nodal_scalars(
+                gp_values_fn=per_step_gp_values,
+                element_index=ip_to_element_id_array,
+                natural_coords=ip_natural_coords,
+                element_lookup={
+                    eid: ("203-ASDShellQ4", corners)
+                    for eid, corners in shell_corner_map.items()
+                },
+            )
+            layer = ContourLayer(
+                scalars=scalars_fn, topology="nodal", step=0,
+            )
+    """
+    eidx = np.asarray(element_index, dtype=np.int64)
+    nat = np.asarray(natural_coords, dtype=np.float64)
+
+    def _scalars(step: int) -> dict[int, float]:
+        gp = np.asarray(gp_values_fn(int(step)), dtype=np.float64)
+        if gp.ndim == 0:
+            raise ValueError(
+                "gp_values_fn must return a 1-D array; got 0-D scalar."
+            )
+        # ``extrapolate_per_element`` accepts both ``(n_total_gp,)`` and
+        # ``(T, n_total_gp)``; we pass through unchanged so a caller
+        # who wants T>1 batches can opt in by returning a 2-D array.
+        per_elem = extrapolate_per_element(
+            eidx, nat, gp, dict(element_lookup),
+        )
+        node_ids, nodal = extrapolate_to_nodes_averaged(per_elem)
+        if node_ids.size == 0:
+            return {}
+        # ``nodal`` is always ``(T, N)``. For the typical T=1 case we
+        # take the row directly; the 2-D path covers the batch case.
+        if nodal.ndim == 2 and nodal.shape[0] == 1:
+            row = nodal[0]
+        elif nodal.ndim == 2:
+            # Multi-step batch: take the row whose index matches ``step``
+            # if it's a valid index, else error. This is the affordance
+            # that lets a caller precompute every step once and re-index
+            # cheaply afterward — useful for animation export.
+            if 0 <= int(step) < nodal.shape[0]:
+                row = nodal[int(step)]
+            else:
+                raise IndexError(
+                    f"step={step} is out of range for the multi-step "
+                    f"gp_values_fn output of shape {nodal.shape}."
+                )
+        else:
+            row = nodal
+        return {int(nid): float(v) for nid, v in zip(node_ids, row)}
+
+    return _scalars

--- a/tests/viewer/layers/test_contour_layer.py
+++ b/tests/viewer/layers/test_contour_layer.py
@@ -727,3 +727,158 @@ def test_pyvista_backend_polygons_both_values_and_point_values_raises() -> None:
             )
     finally:
         handle.plotter.close()
+
+
+# --------------------------------------------------------------------- #
+# GP-node-extrap-smooth (Phase 3.0d) — end-to-end via make_gp_nodal_scalars
+# --------------------------------------------------------------------- #
+
+
+def test_pyvista_gp_extrap_smooth_end_to_end() -> None:
+    """The Phase 3.0d wiring: GP scalars → make_gp_nodal_scalars →
+    ContourLayer(topology="nodal"). The shared edge between the two quads
+    must carry a single value at each shared corner, even though the two
+    quads contribute different GP fields."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+    from STKO_to_python.viewer.math.gauss_extrapolation import (
+        make_gp_nodal_scalars,
+    )
+
+    # Two quads sharing nodes 2 and 3, with constant GP fields per element.
+    # Quad 11 corners: (1, 2, 3, 4) — every GP at value 1.0
+    # Quad 12 corners: (2, 5, 6, 3) — every GP at value 3.0
+    # Shared corners (2, 3) expect (1.0 + 3.0) / 2 = 2.0.
+    g = 1.0 / np.sqrt(3.0)
+    quad_2x2 = np.array(
+        [
+            [-g, -g],
+            [+g, -g],
+            [+g, +g],
+            [-g, +g],
+        ],
+        dtype=np.float64,
+    )
+    eidx = np.concatenate([np.full(4, 11), np.full(4, 12)]).astype(np.int64)
+    nat = np.vstack([quad_2x2, quad_2x2])
+    gp_values_const = np.concatenate(
+        [np.full(4, 1.0), np.full(4, 3.0)]
+    ).astype(np.float64)
+
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: gp_values_const,
+        element_index=eidx,
+        natural_coords=nat,
+        element_lookup={
+            11: ("203-ASDShellQ4", np.array([1, 2, 3, 4], dtype=np.int64)),
+            12: ("203-ASDShellQ4", np.array([2, 5, 6, 3], dtype=np.int64)),
+        },
+    )
+
+    # Pre-flight: the closure produces the expected dict at step 0.
+    nodal_dict = scalars_fn(0)
+    assert nodal_dict[1] == pytest.approx(1.0)
+    assert nodal_dict[4] == pytest.approx(1.0)
+    assert nodal_dict[5] == pytest.approx(3.0)
+    assert nodal_dict[6] == pytest.approx(3.0)
+    assert nodal_dict[2] == pytest.approx(2.0)
+    assert nodal_dict[3] == pytest.approx(2.0)
+
+    # End-to-end: drive a PyVista ContourLayer through the closure.
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars=scalars_fn,
+            topology="nodal",
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        scene.add(layer)
+        q4_ref = layer.actors["203-ASDShellQ4(4n)"]
+        # Vertex stream: quad 11 (1,2,3,4) then quad 12 (2,5,6,3).
+        # Expected per-vertex values: 1, 2, 2, 1, 2, 3, 3, 2.
+        np.testing.assert_allclose(
+            q4_ref.dataset.point_data["point_values"],
+            [1.0, 2.0, 2.0, 1.0,    # quad 11
+             2.0, 3.0, 3.0, 2.0],   # quad 12
+        )
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_gp_extrap_smooth_step_varying_animates() -> None:
+    """A step-varying gp_values_fn drives in-place point_data mutation on
+    the SAME actor across animation steps."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+    from STKO_to_python.viewer.math.gauss_extrapolation import (
+        make_gp_nodal_scalars,
+    )
+
+    g = 1.0 / np.sqrt(3.0)
+    quad_2x2 = np.array(
+        [
+            [-g, -g],
+            [+g, -g],
+            [+g, +g],
+            [-g, +g],
+        ],
+        dtype=np.float64,
+    )
+    eidx = np.concatenate([np.full(4, 11), np.full(4, 12)]).astype(np.int64)
+    nat = np.vstack([quad_2x2, quad_2x2])
+
+    # All GPs of element 11 hold value ``step``; element 12 holds
+    # ``step + 10``. Lets us verify the layer's point_data tracks
+    # update_to_step.
+    def gp_values_at(step):
+        return np.concatenate(
+            [np.full(4, float(step)), np.full(4, float(step) + 10.0)]
+        ).astype(np.float64)
+
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=gp_values_at,
+        element_index=eidx,
+        natural_coords=nat,
+        element_lookup={
+            11: ("203-ASDShellQ4", np.array([1, 2, 3, 4], dtype=np.int64)),
+            12: ("203-ASDShellQ4", np.array([2, 5, 6, 3], dtype=np.int64)),
+        },
+    )
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars=scalars_fn,
+            topology="nodal",
+            step=0,
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        scene.add(layer)
+        ref_before = layer.actors["203-ASDShellQ4(4n)"]
+        # At step 0 the layer fetched ``gp_values_at(0)``; verify the
+        # corner-1 value (unique to element 11) is 0.0.
+        assert ref_before.dataset.point_data["point_values"][0] == pytest.approx(0.0)
+
+        layer.update_to_step(5)
+        ref_after = layer.actors["203-ASDShellQ4(4n)"]
+        # Same actor instance (apeGmsh perf contract).
+        assert ref_after is ref_before
+        assert layer.current_step == 5
+        # Corner-1 (element 11 only): value at step 5 is 5.0.
+        # Corner-5 (element 12 only): value at step 5 is 15.0.
+        # Corners 2 and 3 (shared): mean = (5.0 + 15.0) / 2 = 10.0.
+        np.testing.assert_allclose(
+            ref_after.dataset.point_data["point_values"],
+            [5.0, 10.0, 10.0, 5.0,
+             10.0, 15.0, 15.0, 10.0],
+        )
+    finally:
+        handle.plotter.close()

--- a/tests/viewer/math/test_gauss_extrapolation.py
+++ b/tests/viewer/math/test_gauss_extrapolation.py
@@ -23,6 +23,7 @@ from STKO_to_python.viewer.math.gauss_extrapolation import (
     build_extrapolation_matrix,
     extrapolate_per_element,
     extrapolate_to_nodes_averaged,
+    make_gp_nodal_scalars,
     per_element_max_gp_count,
 )
 
@@ -360,3 +361,172 @@ def test_constant_field_round_trips_for_any_constant(c: float) -> None:
     )
     _, nodal = extrapolate_to_nodes_averaged(per_elem)
     np.testing.assert_allclose(nodal, c, atol=1e-9)
+
+
+# --------------------------------------------------------------------- #
+# make_gp_nodal_scalars (Phase 3.0d)                                    #
+# --------------------------------------------------------------------- #
+#
+# Closure factory that adapts the GP-extrapolation pipeline to the
+# scalars contract :class:`ContourLayer` consumes in ``topology="nodal"``
+# mode. The tests below pin three properties:
+#
+#   1. A constant per-step GP field projects to a constant nodal dict.
+#   2. Two elements sharing two nodes have those shared nodes averaged.
+#   3. A step-varying ``gp_values_fn`` produces step-varying dicts via the
+#      same closure — no recompute of the static layout required.
+
+
+# 2×2 Gauss points on the parent quad (n_gp == n_corner == 4 so pinv is
+# the exact inverse).
+_QUAD_GP_2x2 = np.array(
+    [
+        [-_G, -_G],
+        [+_G, -_G],
+        [+_G, +_G],
+        [-_G, +_G],
+    ],
+    dtype=np.float64,
+)
+
+
+def test_make_gp_nodal_scalars_constant_field_yields_constant_dict() -> None:
+    """All four GPs = 7.0 → every corner gets 7.0."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: np.full(4, 7.0, dtype=np.float64),
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    out = scalars_fn(0)
+    assert set(out.keys()) == {10, 11, 12, 13}
+    for nid, value in out.items():
+        assert value == pytest.approx(7.0)
+
+
+def test_make_gp_nodal_scalars_shared_corners_averaged() -> None:
+    """Two quads sharing nodes 11 and 12 — shared corners get the mean."""
+    # Element 1 corners: 10, 11, 12, 13
+    # Element 2 corners: 11, 14, 15, 12
+    # Constant fields per element: e1 = 1.0, e2 = 3.0
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+        2: ("203-ASDShellQ4", np.array([11, 14, 15, 12], dtype=np.int64)),
+    }
+    eidx = np.concatenate([np.full(4, 1), np.full(4, 2)]).astype(np.int64)
+    nat = np.vstack([_QUAD_GP_2x2, _QUAD_GP_2x2])
+    gp_vals = np.concatenate([np.full(4, 1.0), np.full(4, 3.0)]).astype(np.float64)
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: gp_vals,
+        element_index=eidx,
+        natural_coords=nat,
+        element_lookup=lookup,
+    )
+    out = scalars_fn(0)
+    assert out[10] == pytest.approx(1.0)
+    assert out[13] == pytest.approx(1.0)
+    assert out[14] == pytest.approx(3.0)
+    assert out[15] == pytest.approx(3.0)
+    # Shared corners average the two contributing element values.
+    assert out[11] == pytest.approx(2.0)
+    assert out[12] == pytest.approx(2.0)
+
+
+def test_make_gp_nodal_scalars_step_varying_callable() -> None:
+    """The closure invokes gp_values_fn every call — step → step yields
+    independent dicts."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    calls = []
+
+    def gp_values(step):
+        calls.append(int(step))
+        return np.full(4, float(step), dtype=np.float64)
+
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=gp_values,
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    d0 = scalars_fn(0)
+    d5 = scalars_fn(5)
+    for v in d0.values():
+        assert v == pytest.approx(0.0)
+    for v in d5.values():
+        assert v == pytest.approx(5.0)
+    # The closure forwards the step int exactly to the gp_values_fn.
+    assert calls == [0, 5]
+
+
+def test_make_gp_nodal_scalars_empty_lookup_returns_empty_dict() -> None:
+    """An element-lookup that filters every GP out yields an empty dict."""
+    eidx = np.full(4, 1, dtype=np.int64)
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: np.zeros(4, dtype=np.float64),
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup={},  # no entry → every GP is dropped
+    )
+    assert scalars_fn(0) == {}
+
+
+def test_make_gp_nodal_scalars_rejects_scalar_input() -> None:
+    """gp_values_fn returning a 0-D scalar is a malformed-input error."""
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: np.asarray(1.0),
+        element_index=np.array([1], dtype=np.int64),
+        natural_coords=np.array([[0.0, 0.0]]),
+        element_lookup={
+            1: ("203-ASDShellQ4", np.array([1, 2, 3, 4], dtype=np.int64)),
+        },
+    )
+    with pytest.raises(ValueError, match="0-D scalar"):
+        scalars_fn(0)
+
+
+def test_make_gp_nodal_scalars_supports_multistep_batch() -> None:
+    """When gp_values_fn returns a (T, n_total_gp) batch, the closure
+    indexes into it by ``step`` so animations can precompute once and
+    re-index cheaply."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    # 3 timesteps; step k has all GPs at value k.
+    batch = np.stack([np.full(4, float(k)) for k in range(3)])  # (3, 4)
+
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: batch,
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    for k in range(3):
+        d = scalars_fn(k)
+        for v in d.values():
+            assert v == pytest.approx(float(k))
+
+
+def test_make_gp_nodal_scalars_multistep_batch_out_of_range_raises() -> None:
+    """Step outside the precomputed batch range is a hard error, not
+    silent wrap-around."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    batch = np.stack([np.full(4, float(k)) for k in range(3)])
+    scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: batch,
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    with pytest.raises(IndexError, match="out of range"):
+        scalars_fn(99)


### PR DESCRIPTION
## Summary

Thin wrapper that adapts the Phase 1 Gauss-extrapolation kernel into the `{node_id: value}` scalars contract `ContourLayer`'s `topology="nodal"` mode consumes. Closes the **GP-node-extrap-smooth** path of apeGmsh's five-path dispatch.

The kernel from Phase 1 already did the heavy lifting — `extrapolate_per_element` projects GPs onto each element's corners via shape-function pinv, and `extrapolate_to_nodes_averaged` collapses duplicated corner contributions into a single mesh-wide nodal field. This PR just packages those two into a `Callable[[step], dict[int, float]]` factory.

## Helper API

```python
from STKO_to_python.viewer.math.gauss_extrapolation import make_gp_nodal_scalars
from STKO_to_python.viewer.layers import ContourLayer

scalars_fn = make_gp_nodal_scalars(
    gp_values_fn=lambda step: my_fetch(step),  # (n_total_gp,) per step
    element_index=ip_to_element_id_array,
    natural_coords=ip_natural_coords,
    element_lookup={
        eid: ("203-ASDShellQ4", corners)
        for eid, corners in shell_corner_map.items()
    },
)
layer = ContourLayer(scalars=scalars_fn, topology="nodal", step=0)
```

- `gp_values_fn(step)` may return `(n_total_gp,)` (single-step, canonical) **or** `(T, n_total_gp)` (multi-step batch — closure indexes by `step`; out-of-range raises `IndexError`). Useful for animation export where every step is precomputed once and playback re-indexes cheaply.
- `element_index` / `natural_coords` / `element_lookup` are pinned at construction; layers can't move GPs mid-animation.
- 0-D scalar input is rejected with `ValueError` (defensive against "I forgot to return an array").

## Test plan

- [x] **7 new unit tests** in [`tests/viewer/math/test_gauss_extrapolation.py`](tests/viewer/math/test_gauss_extrapolation.py): constant-field → constant dict; two-quad shared-corners averaged to `(e1 + e2) / 2`; step-varying callable forwards `step` exactly; empty lookup → empty dict; 0-D scalar → `ValueError`; multi-step batch path indexes by step; out-of-range step → `IndexError`.
- [x] **2 new PyVista-gated integration tests** in [`tests/viewer/layers/test_contour_layer.py`](tests/viewer/layers/test_contour_layer.py): end-to-end smooth contour across two quads (shared corners carry identical `point_values` at duplicated vertex copies → visually continuous); step-varying `gp_values_fn` drives **in-place** `point_data` mutation on the SAME actor across `update_to_step` calls.
- [x] system Python (no pyvista): `tests/viewer/` overall **334 passed, 12 skipped**. Full suite **1619 passed, 49 skipped**.
- [x] `opensees_venv` (pyvista 0.47.1 + VTK 9.6.1): combined contour + gauss_extrapolation suite **66 passed**, including both new PyVista integration tests.

## What's next

Phase 3.0e — **GP-node-discrete** (each element keeps its own corner copies, no cross-element averaging). The existing `ContourLayer.nodal` path already duplicates vertices in the polydata — we just need to skip the `extrapolate_to_nodes_averaged` step and feed `PerElementCornerValues` directly to `point_values=`. That closes the directive's five-path dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)