### PR TITLE
Add GP-node-discrete contour path (Phase 3.0e)

### DIFF
--- a/src/STKO_to_python/viewer/layers/contour.py
+++ b/src/STKO_to_python/viewer/layers/contour.py
@@ -1,35 +1,47 @@
-"""``ContourLayer`` — scalar field over the mesh, cell- or nodal-topology.
+"""``ContourLayer`` — scalar field over the mesh, three topology modes.
 
 Renders filled polygons over the model surface, colored by a caller-
-supplied scalar map. Implements two of the five paths from the
-directive (per ``docs/viewer/02-porting-from-apegmsh.md`` §4 /
-apeGmsh's ``viewers/diagrams/_contour.py``):
+supplied scalar map. As of Phase 3.0e the layer covers all five
+paths of the directive (per ``docs/viewer/02-porting-from-apegmsh.md``
+§4 / apeGmsh's ``viewers/diagrams/_contour.py``) across three
+exposed topology modes:
 
 * **cell** (Phase 3.0b) — one scalar per element; rendered through
-  ``backend.add_polygons(values=...)``.
+  ``backend.add_polygons(values=...)``. Same renderer handles the
+  GP-cell-averaged path when the caller pre-aggregates per-GP
+  values to per-cell upstream.
 * **nodal** (Phase 3.0c) — one scalar per node; rendered through
   ``backend.add_polygons(point_values=...)`` for smooth Gouraud-style
-  interpolation. PyVista native; MplBackend raises
-  :class:`BackendCapabilityError` because matplotlib's
-  ``PolyCollection`` is per-cell only.
+  interpolation. Same renderer handles the GP-node-extrap-smooth
+  path via :func:`STKO_to_python.viewer.math.gauss_extrapolation.make_gp_nodal_scalars`,
+  which wraps ``extrapolate_per_element`` +
+  ``extrapolate_to_nodes_averaged`` and returns the right dict shape.
+* **nodal_discrete** (Phase 3.0e) — one scalar per ``(element_id,
+  node_id)`` pair; rendered through ``point_values=`` like ``nodal``
+  but the lookup is per-element so duplicated vertex copies of a
+  shared node hold the value of the element they belong to, not the
+  averaged value across neighbours. Preserves the field
+  discontinuity at element boundaries — useful at material
+  interfaces, plastic-hinge regions, or wherever the smoothing would
+  mislead the engineer's eye. Paired with
+  :func:`~STKO_to_python.viewer.math.gauss_extrapolation.make_gp_discrete_scalars`
+  to feed it from GP values.
 
-The remaining three paths from the directive are upstream
-aggregations of these two:
-
-* GP-cell-averaged — one scalar per element from averaged per-GP
-  values; same renderer path as ``cell``.
-* GP-node-extrap-smooth — extrapolate GPs to nodes via
-  :func:`STKO_to_python.viewer.math.gauss_extrapolation.extrapolate_to_nodes_averaged`,
-  then render as ``nodal``. Phase 3.0d.
-* GP-node-discrete — extrapolate per-element, render each element's
-  corner values as a separate discontinuous polygon. Phase 3.0e.
+PyVista renders all three modes natively. ``MplBackend`` only
+supports ``cell``; the two nodal modes raise
+:class:`BackendCapabilityError` because matplotlib's
+``PolyCollection`` is per-cell only.
 
 Scalars contract
 ----------------
 
-For ``topology="cell"``, the caller supplies scalars as
-``dict[element_id, float]``. For ``topology="nodal"``, the caller
-supplies ``dict[node_id, float]``. In both cases the input is either:
+The dict shape depends on the topology:
+
+* ``"cell"``       → ``dict[element_id, float]``.
+* ``"nodal"``      → ``dict[node_id, float]``.
+* ``"nodal_discrete"`` → ``dict[element_id, dict[node_id, float]]``.
+
+In all three the input is either:
 
 * a **static** dict — the layer is non-time-varying and
   :meth:`update_to_step` is a no-op;
@@ -37,13 +49,12 @@ supplies ``dict[node_id, float]``. In both cases the input is either:
   initial step) and at every :meth:`update_to_step` — same dict
   shape, fresh per call.
 
-Both shapes are dict-based on purpose: the caller doesn't need to
-know the renderer's element / vertex ordering, and a missing key is
-a hard error (no silent data dropouts). Nodal-mode lookups happen
-per face vertex against the **node** the vertex came from — shared
-nodes across neighbouring faces resolve to the same scalar value,
-which is what makes the rendering visually smooth despite the
-polydata storing duplicated vertices per polygon.
+Dict-based on purpose: the caller doesn't need to know the
+renderer's element / vertex ordering, and a missing key is a hard
+error (no silent data dropouts). The ``nodal`` mode resolves shared
+nodes to the same scalar value at every duplicated vertex copy
+(visually smooth); ``nodal_discrete`` resolves duplicated copies to
+**per-element** values (visually discontinuous at boundaries).
 """
 from __future__ import annotations
 
@@ -191,9 +202,10 @@ class ContourLayer(Layer):
         super().__init__(
             name=name, selection=selection, visible=visible, z_order=z_order,
         )
-        if topology not in ("cell", "nodal"):
+        if topology not in ("cell", "nodal", "nodal_discrete"):
             raise ValueError(
-                f"topology must be 'cell' or 'nodal', got {topology!r}."
+                "topology must be one of 'cell', 'nodal', or "
+                f"'nodal_discrete', got {topology!r}."
             )
         self.topology = topology
         self._scalars_input: ScalarsInput = scalars
@@ -367,10 +379,10 @@ class ContourLayer(Layer):
                     vmax = vmin + 1.0
                 self.clim = (vmin, vmax)
 
-        # Create actors. The two topologies route through different
-        # add_polygons kwargs; the backend protocol guarantees that
-        # passing both at once is a ValueError, so each entry is
-        # one-or-the-other.
+        # Create actors. The cell mode binds per-cell scalars; both
+        # nodal modes (smooth and discrete) bind per-vertex scalars
+        # and the difference lives entirely in the lookup logic
+        # below — same renderer primitive, different dict shape.
         backend = scene.backend
         handle = scene.handle
         for entry in self._classes:
@@ -383,7 +395,7 @@ class ContourLayer(Layer):
                     cmap=self.cmap,
                     edge_color=self.edge_color,
                 )
-            else:  # "nodal"
+            else:  # "nodal" | "nodal_discrete"
                 actor = backend.add_polygons(
                     handle,
                     entry["polygons"],
@@ -470,6 +482,12 @@ class ContourLayer(Layer):
         concatenated polygon vertex stream that ``backend.add_polygons``
         consumes. Shared nodes resolve to identical values, which is
         what makes the rendering visually smooth.
+
+        Nodal-discrete topology: same flattened per-vertex stream as
+        ``nodal``, but the lookup is per ``(element_id, node_id)``.
+        Duplicated vertex copies of a shared node hold the value of
+        the element they belong to, preserving the field
+        discontinuity at element boundaries.
         """
         scalars = self._scalars_dict_at(step)
         out: dict[str, np.ndarray] = {}
@@ -488,7 +506,7 @@ class ContourLayer(Layer):
                         f"{missing} (class {entry['label']!r}, step {step})."
                     ) from exc
                 out[entry["label"]] = arr
-            else:  # "nodal"
+            elif self.topology == "nodal":
                 # Flatten the per-face node_id stream and look up each
                 # vertex's scalar by node id.
                 vertices: list[float] = []
@@ -500,6 +518,36 @@ class ContourLayer(Layer):
                             raise KeyError(
                                 f"ContourLayer.scalars is missing node id "
                                 f"{int(nid)} (class {entry['label']!r}, "
+                                f"step {step})."
+                            ) from exc
+                out[entry["label"]] = np.asarray(vertices, dtype=np.float64)
+            else:  # "nodal_discrete"
+                # Same per-vertex stream, but the lookup is per
+                # (element_id, node_id) so duplicated copies of a
+                # shared node hold the element-local value.
+                vertices = []
+                src_ids = entry["source_element_ids"]
+                for face_eid, face_nids in zip(
+                    src_ids, entry["face_node_ids"],
+                ):
+                    eid_int = int(face_eid)
+                    try:
+                        per_elem = scalars[eid_int]
+                    except KeyError as exc:
+                        raise KeyError(
+                            f"ContourLayer.scalars is missing element id "
+                            f"{eid_int} (class {entry['label']!r}, "
+                            f"step {step})."
+                        ) from exc
+                    for nid in face_nids:
+                        nid_int = int(nid)
+                        try:
+                            vertices.append(float(per_elem[nid_int]))
+                        except (KeyError, TypeError) as exc:
+                            raise KeyError(
+                                f"ContourLayer.scalars is missing entry "
+                                f"for (element id {eid_int}, node id "
+                                f"{nid_int}) (class {entry['label']!r}, "
                                 f"step {step})."
                             ) from exc
                 out[entry["label"]] = np.asarray(vertices, dtype=np.float64)

--- a/src/STKO_to_python/viewer/math/gauss_extrapolation.py
+++ b/src/STKO_to_python/viewer/math/gauss_extrapolation.py
@@ -90,6 +90,7 @@ __all__ = [
     "extrapolate_per_element",
     "extrapolate_to_nodes_averaged",
     "make_gp_nodal_scalars",
+    "make_gp_discrete_scalars",
 ]
 
 
@@ -459,5 +460,114 @@ def make_gp_nodal_scalars(
         else:
             row = nodal
         return {int(nid): float(v) for nid, v in zip(node_ids, row)}
+
+    return _scalars
+
+
+def make_gp_discrete_scalars(
+    *,
+    gp_values_fn: Callable[[int], np.ndarray],
+    element_index: np.ndarray,
+    natural_coords: np.ndarray,
+    element_lookup: Mapping[int, tuple],
+) -> Callable[[int], dict[int, dict[int, float]]]:
+    """Build a step-callable that yields ``{element_id: {node_id: value}}``
+    for :class:`~STKO_to_python.viewer.layers.ContourLayer`'s
+    ``topology="nodal_discrete"`` path.
+
+    This is the **GP-node-discrete** path of the directive's five-path
+    dispatch (per ``docs/viewer/02-porting-from-apegmsh.md`` §4). Same
+    inputs as :func:`make_gp_nodal_scalars`, same per-element pinv
+    projection — but the cross-element averaging step is **skipped**.
+    Each element keeps its own corner-value copies, so visualisations
+    preserve the field discontinuity at element boundaries (useful at
+    material interfaces, plastic-hinge regions, or wherever the
+    smoothing would mislead the engineer's eye).
+
+    Args:
+        gp_values_fn: Callable ``(step) -> (n_total_gp,) ndarray``.
+            Returns per-GP values for one analysis step in the same
+            row order as ``element_index`` and ``natural_coords``.
+            Multi-step batches ``(T, n_total_gp)`` are also accepted
+            and indexed by ``step`` — see :func:`make_gp_nodal_scalars`
+            for the same affordance.
+        element_index: ``(n_total_gp,)`` int — element id per GP row.
+            Pinned at construction.
+        natural_coords: ``(n_total_gp, dim)`` float — natural-coord
+            position of each GP. Pinned at construction.
+        element_lookup: ``{element_id: (element_class,
+            corner_node_ids)}`` map. Pinned at construction.
+
+    Returns:
+        A callable ``(step: int) -> dict[int, dict[int, float]]``.
+        The outer key is the element id; the inner dict maps the
+        element's corner node ids to per-corner values. Elements not
+        present in ``element_lookup`` (or whose class is not in the
+        shape-function catalog) are silently dropped — same behaviour
+        as :func:`extrapolate_per_element`.
+
+    Example:
+        ::
+
+            from STKO_to_python.viewer.math.gauss_extrapolation import (
+                make_gp_discrete_scalars,
+            )
+            from STKO_to_python.viewer.layers import ContourLayer
+
+            scalars_fn = make_gp_discrete_scalars(
+                gp_values_fn=per_step_gp_values,
+                element_index=ip_to_element_id_array,
+                natural_coords=ip_natural_coords,
+                element_lookup={
+                    eid: ("203-ASDShellQ4", corners)
+                    for eid, corners in shell_corner_map.items()
+                },
+            )
+            layer = ContourLayer(
+                scalars=scalars_fn, topology="nodal_discrete", step=0,
+            )
+    """
+    eidx = np.asarray(element_index, dtype=np.int64)
+    nat = np.asarray(natural_coords, dtype=np.float64)
+
+    def _scalars(step: int) -> dict[int, dict[int, float]]:
+        gp = np.asarray(gp_values_fn(int(step)), dtype=np.float64)
+        if gp.ndim == 0:
+            raise ValueError(
+                "gp_values_fn must return a 1-D array; got 0-D scalar."
+            )
+        per_elem = extrapolate_per_element(
+            eidx, nat, gp, dict(element_lookup),
+        )
+        if per_elem.element_ids.size == 0:
+            return {}
+
+        # ``per_elem.values[k]`` is ``(T, n_corner_k)`` regardless of
+        # input rank. Single-step inputs land in row 0; multi-step
+        # batches index by ``step`` (with bounds-checking parallel to
+        # ``make_gp_nodal_scalars`` so callers can swap helpers
+        # without surprises).
+        T = per_elem.time_count
+        if T == 1:
+            row_idx = 0
+        elif 0 <= int(step) < T:
+            row_idx = int(step)
+        else:
+            raise IndexError(
+                f"step={step} is out of range for the multi-step "
+                f"gp_values_fn output of time_count={T}."
+            )
+
+        out: dict[int, dict[int, float]] = {}
+        for eid, corner_nids, per_corner in zip(
+            per_elem.element_ids,
+            per_elem.corner_node_ids,
+            per_elem.values,
+        ):
+            row = per_corner[row_idx]
+            out[int(eid)] = {
+                int(nid): float(v) for nid, v in zip(corner_nids, row)
+            }
+        return out
 
     return _scalars

--- a/tests/viewer/layers/test_contour_layer.py
+++ b/tests/viewer/layers/test_contour_layer.py
@@ -809,6 +809,222 @@ def test_pyvista_gp_extrap_smooth_end_to_end() -> None:
         handle.plotter.close()
 
 
+def test_topology_nodal_discrete_is_accepted() -> None:
+    """The Phase 3.0e topology must construct cleanly without attach."""
+    layer = ContourLayer(scalars={1: {10: 0.0}}, topology="nodal_discrete")
+    assert layer.topology == "nodal_discrete"
+
+
+def test_topology_unknown_value_message_lists_all_modes() -> None:
+    with pytest.raises(ValueError, match="nodal_discrete"):
+        ContourLayer(scalars={1: 0.0}, topology="bogus")
+
+
+def test_nodal_discrete_mode_on_mpl_raises_capability_error() -> None:
+    """matplotlib can't do per-vertex coloring — discrete mode hits the
+    same backend gate as smooth nodal."""
+    from STKO_to_python.viewer.core.errors import BackendCapabilityError
+
+    fake = _make_fake_dataset()
+    scene = _make_scene(fake)
+    scalars = {
+        11: {1: 1.0, 2: 1.0, 3: 1.0, 4: 1.0},
+        12: {2: 3.0, 5: 3.0, 6: 3.0, 3: 3.0},
+        13: {1: 2.0, 2: 2.0, 4: 2.0},
+    }
+    layer = ContourLayer(scalars=scalars, topology="nodal_discrete")
+    try:
+        with pytest.raises(BackendCapabilityError, match="per-vertex"):
+            scene.add(layer)
+    finally:
+        plt.close("all")
+
+
+def test_pyvista_nodal_discrete_preserves_per_element_values() -> None:
+    """Two quads sharing two corner nodes — the discrete path keeps
+    each element's own value at the duplicated vertex copies of the
+    shared nodes, instead of averaging them."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+
+        # Element 11 (1, 2, 3, 4) holds 1.0 at every corner; element 12
+        # (2, 5, 6, 3) holds 3.0 at every corner.
+        scalars = {
+            11: {1: 1.0, 2: 1.0, 3: 1.0, 4: 1.0},
+            12: {2: 3.0, 5: 3.0, 6: 3.0, 3: 3.0},
+        }
+        layer = ContourLayer(
+            scalars=scalars,
+            topology="nodal_discrete",
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        scene.add(layer)
+        q4_ref = layer.actors["203-ASDShellQ4(4n)"]
+        # Vertex stream: quad 11 (1,2,3,4) → all 1.0,
+        #                quad 12 (2,5,6,3) → all 3.0.
+        # Shared corners 2 and 3 carry DIFFERENT values per element's
+        # duplicated copy — that's the discontinuity contract.
+        np.testing.assert_allclose(
+            q4_ref.dataset.point_data["point_values"],
+            [1.0, 1.0, 1.0, 1.0,    # quad 11
+             3.0, 3.0, 3.0, 3.0],   # quad 12
+        )
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_nodal_discrete_in_place_update_keeps_same_actor() -> None:
+    """The same actor instance survives update_to_step — apeGmsh perf
+    contract holds for the discrete path too."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+
+        def scalars_at(step):
+            base = float(step)
+            return {
+                11: {1: base, 2: base, 3: base, 4: base},
+                12: {2: base + 10, 5: base + 10, 6: base + 10, 3: base + 10},
+            }
+
+        layer = ContourLayer(
+            scalars=scalars_at,
+            topology="nodal_discrete",
+            step=0,
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        scene.add(layer)
+        ref_before = layer.actors["203-ASDShellQ4(4n)"]
+        layer.update_to_step(7)
+        ref_after = layer.actors["203-ASDShellQ4(4n)"]
+        assert ref_after is ref_before
+        assert layer.current_step == 7
+        # Quad 11 → 7.0 everywhere; quad 12 → 17.0 everywhere.
+        np.testing.assert_allclose(
+            ref_after.dataset.point_data["point_values"],
+            [7.0, 7.0, 7.0, 7.0,
+             17.0, 17.0, 17.0, 17.0],
+        )
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_nodal_discrete_missing_element_raises() -> None:
+    """An element rendered by the layer but not in the scalars dict
+    fails loud with a topology-aware error message."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars={11: {1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}},  # 12 missing
+            topology="nodal_discrete",
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        with pytest.raises(KeyError, match="element id 12"):
+            scene.add(layer)
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_nodal_discrete_missing_node_in_element_raises() -> None:
+    """A corner present in the element but missing from the inner
+    dict yields a precise (element, node) error."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars={
+                11: {1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0},
+                12: {2: 0.0, 5: 0.0, 6: 0.0},  # missing node 3
+            },
+            topology="nodal_discrete",
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        with pytest.raises(KeyError, match=r"\(element id 12, node id 3\)"):
+            scene.add(layer)
+    finally:
+        handle.plotter.close()
+
+
+def test_pyvista_gp_discrete_end_to_end() -> None:
+    """make_gp_discrete_scalars → ContourLayer(topology='nodal_discrete')
+    end-to-end: two quads with constant per-element GP fields produce
+    a discontinuous contour at the shared edge."""
+    pv = pytest.importorskip("pyvista")
+    from STKO_to_python.viewer.backends.pyvista import PyVistaBackend
+    from STKO_to_python.viewer.math.gauss_extrapolation import (
+        make_gp_discrete_scalars,
+    )
+
+    g = 1.0 / np.sqrt(3.0)
+    quad_2x2 = np.array(
+        [[-g, -g], [+g, -g], [+g, +g], [-g, +g]], dtype=np.float64,
+    )
+    eidx = np.concatenate([np.full(4, 11), np.full(4, 12)]).astype(np.int64)
+    nat = np.vstack([quad_2x2, quad_2x2])
+    gp_values_const = np.concatenate(
+        [np.full(4, 1.0), np.full(4, 3.0)]
+    ).astype(np.float64)
+
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=lambda step: gp_values_const,
+        element_index=eidx,
+        natural_coords=nat,
+        element_lookup={
+            11: ("203-ASDShellQ4", np.array([1, 2, 3, 4], dtype=np.int64)),
+            12: ("203-ASDShellQ4", np.array([2, 5, 6, 3], dtype=np.int64)),
+        },
+    )
+
+    fake = _make_fake_dataset()
+    backend = PyVistaBackend()
+    handle = backend.make_scene(is_3d=True, off_screen=True)
+    try:
+        source = MPCODataSourceAdapter(fake)
+        scene = Scene(backend, source, is_3d=True, handle=handle)
+        layer = ContourLayer(
+            scalars=scalars_fn,
+            topology="nodal_discrete",
+            selection=SelectionSpec(element_type="203-ASDShellQ4"),
+        )
+        scene.add(layer)
+        q4_ref = layer.actors["203-ASDShellQ4(4n)"]
+        # Each element's vertex stream holds that element's constant
+        # value at every corner copy — INCLUDING the shared edge.
+        np.testing.assert_allclose(
+            q4_ref.dataset.point_data["point_values"],
+            [1.0, 1.0, 1.0, 1.0,
+             3.0, 3.0, 3.0, 3.0],
+        )
+    finally:
+        handle.plotter.close()
+
+
 def test_pyvista_gp_extrap_smooth_step_varying_animates() -> None:
     """A step-varying gp_values_fn drives in-place point_data mutation on
     the SAME actor across animation steps."""

--- a/tests/viewer/math/test_gauss_extrapolation.py
+++ b/tests/viewer/math/test_gauss_extrapolation.py
@@ -23,6 +23,7 @@ from STKO_to_python.viewer.math.gauss_extrapolation import (
     build_extrapolation_matrix,
     extrapolate_per_element,
     extrapolate_to_nodes_averaged,
+    make_gp_discrete_scalars,
     make_gp_nodal_scalars,
     per_element_max_gp_count,
 )
@@ -523,6 +524,151 @@ def test_make_gp_nodal_scalars_multistep_batch_out_of_range_raises() -> None:
     eidx = np.full(4, 1, dtype=np.int64)
     batch = np.stack([np.full(4, float(k)) for k in range(3)])
     scalars_fn = make_gp_nodal_scalars(
+        gp_values_fn=lambda step: batch,
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    with pytest.raises(IndexError, match="out of range"):
+        scalars_fn(99)
+
+
+# --------------------------------------------------------------------- #
+# make_gp_discrete_scalars (Phase 3.0e)                                 #
+# --------------------------------------------------------------------- #
+#
+# Closure factory parallel to :func:`make_gp_nodal_scalars`, but the
+# cross-element averaging step is skipped. Shared corners across two
+# elements receive *different* values per element — the visual
+# discontinuity is intentional and useful at material interfaces or
+# plastic-hinge regions.
+
+
+def test_make_gp_discrete_scalars_constant_field_yields_nested_dict() -> None:
+    """All GPs of one quad = 7.0 → every corner gets 7.0, keyed under
+    the element id."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=lambda step: np.full(4, 7.0, dtype=np.float64),
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    out = scalars_fn(0)
+    assert set(out.keys()) == {1}
+    assert set(out[1].keys()) == {10, 11, 12, 13}
+    for nid, value in out[1].items():
+        assert value == pytest.approx(7.0)
+
+
+def test_make_gp_discrete_scalars_shared_corners_preserve_per_element_values() -> None:
+    """Two quads sharing nodes 11 and 12 — shared corners hold the
+    element-local value, NOT the average. This is exactly the
+    behaviour ``make_gp_nodal_scalars`` smooths over."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+        2: ("203-ASDShellQ4", np.array([11, 14, 15, 12], dtype=np.int64)),
+    }
+    eidx = np.concatenate([np.full(4, 1), np.full(4, 2)]).astype(np.int64)
+    nat = np.vstack([_QUAD_GP_2x2, _QUAD_GP_2x2])
+    gp_vals = np.concatenate(
+        [np.full(4, 1.0), np.full(4, 3.0)]
+    ).astype(np.float64)
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=lambda step: gp_vals,
+        element_index=eidx,
+        natural_coords=nat,
+        element_lookup=lookup,
+    )
+    out = scalars_fn(0)
+    # Element 1 holds 1.0 at every corner, including the shared ones.
+    for nid in (10, 11, 12, 13):
+        assert out[1][nid] == pytest.approx(1.0)
+    # Element 2 holds 3.0 at every corner, including the shared ones.
+    for nid in (11, 14, 15, 12):
+        assert out[2][nid] == pytest.approx(3.0)
+    # Cross-check: a shared corner has different values per element.
+    assert out[1][11] != out[2][11]
+
+
+def test_make_gp_discrete_scalars_step_varying_callable() -> None:
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+
+    def gp_values(step):
+        return np.full(4, float(step), dtype=np.float64)
+
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=gp_values,
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    d3 = scalars_fn(3)
+    for v in d3[1].values():
+        assert v == pytest.approx(3.0)
+    d7 = scalars_fn(7)
+    for v in d7[1].values():
+        assert v == pytest.approx(7.0)
+
+
+def test_make_gp_discrete_scalars_empty_lookup_returns_empty_dict() -> None:
+    eidx = np.full(4, 1, dtype=np.int64)
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=lambda step: np.zeros(4, dtype=np.float64),
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup={},
+    )
+    assert scalars_fn(0) == {}
+
+
+def test_make_gp_discrete_scalars_rejects_scalar_input() -> None:
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=lambda step: np.asarray(1.0),
+        element_index=np.array([1], dtype=np.int64),
+        natural_coords=np.array([[0.0, 0.0]]),
+        element_lookup={
+            1: ("203-ASDShellQ4", np.array([1, 2, 3, 4], dtype=np.int64)),
+        },
+    )
+    with pytest.raises(ValueError, match="0-D scalar"):
+        scalars_fn(0)
+
+
+def test_make_gp_discrete_scalars_multistep_batch_indexes_by_step() -> None:
+    """Same multi-step batch contract as :func:`make_gp_nodal_scalars`
+    so callers can swap helpers without rewriting the gp_values_fn."""
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    batch = np.stack([np.full(4, float(k)) for k in range(3)])
+
+    scalars_fn = make_gp_discrete_scalars(
+        gp_values_fn=lambda step: batch,
+        element_index=eidx,
+        natural_coords=_QUAD_GP_2x2,
+        element_lookup=lookup,
+    )
+    for k in range(3):
+        d = scalars_fn(k)
+        for v in d[1].values():
+            assert v == pytest.approx(float(k))
+
+
+def test_make_gp_discrete_scalars_multistep_batch_out_of_range_raises() -> None:
+    lookup = {
+        1: ("203-ASDShellQ4", np.array([10, 11, 12, 13], dtype=np.int64)),
+    }
+    eidx = np.full(4, 1, dtype=np.int64)
+    batch = np.stack([np.full(4, float(k)) for k in range(3)])
+    scalars_fn = make_gp_discrete_scalars(
         gp_values_fn=lambda step: batch,
         element_index=eidx,
         natural_coords=_QUAD_GP_2x2,


### PR DESCRIPTION
## Summary

Closes the directive's five-path dispatch (per [`docs/viewer/02-porting-from-apegmsh.md`](docs/viewer/02-porting-from-apegmsh.md) §4). Each element keeps its own corner-value copies — the cross-element averaging step is **skipped**, so visualisations preserve field discontinuities at element boundaries (material interfaces, plastic-hinge regions, local-stress jumps).

## What lands

- **`make_gp_discrete_scalars`** in [`viewer/math/gauss_extrapolation.py`](src/STKO_to_python/viewer/math/gauss_extrapolation.py): parallel to `make_gp_nodal_scalars` but skips `extrapolate_to_nodes_averaged`. Returns `Callable[[step], dict[int, dict[int, float]]]` — `{element_id: {node_id: value}}`. Same multi-step batch + 0-D defensive contracts as the smooth helper.
- **`ContourLayer.topology="nodal_discrete"`**: routes through the same `backend.add_polygons(point_values=...)` call as `"nodal"` — the difference lives entirely in the per-vertex lookup. Duplicated vertex copies of a shared node hold the element-local value instead of the averaged value.
- Missing-entry error is topology-aware: `"missing element id N"` (outer key) vs `"missing entry for (element id E, node id N)"` (inner key).
- Topology validation message extended to list all three modes.

## The five paths, all done

| Path | Topology | Helper |
|---|---|---|
| nodal | `"nodal"` | (caller-supplied) |
| cell | `"cell"` | (caller-supplied) |
| GP-cell-averaged | `"cell"` | (caller pre-aggregates) |
| GP-node-extrap-smooth | `"nodal"` | `make_gp_nodal_scalars` |
| GP-node-discrete | `"nodal_discrete"` | `make_gp_discrete_scalars` |

## Test plan

- [x] **7 new gauss unit tests**: constant-field nested dict, two-quad per-element preserved (not averaged), step-varying callable, empty lookup, 0-D input rejected, multi-step batch indexing, out-of-range raises.
- [x] **6 new PyVista-gated integration tests**: discrete-topology acceptance, mpl capability error, two-quad value preservation at shared edges, in-place `update_to_step` on the SAME actor, missing-element and missing-(element,node) error messages, end-to-end via `make_gp_discrete_scalars`.
- [x] **2 new mpl-only tests**: topology validation message lists all modes; discrete mode on mpl raises `BackendCapabilityError` with the "per-vertex" hint.
- [x] system Python (no pyvista): full suite **1629 passed, 54 skipped** (+10 over the 1619 baseline; 6 new pyvista-gated tests skip correctly).
- [x] `opensees_venv` (pyvista 0.47.1 + VTK 9.6.1): combined contour + gauss suite **81 passed**, including all 6 new PyVista integration tests.

## What's next

Phase 3 contour story is complete. Followup: bump `pyproject.toml` + tag a release on `main` per [CLAUDE.md](CLAUDE.md)'s versioning policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)