### PR TITLE
Add ElementResultsPlotter.history_canonical for fiber/IP reduction

### DIFF
--- a/docs/ElementResults.md
+++ b/docs/ElementResults.md
@@ -420,12 +420,20 @@ s = er.summary()
 ## Plotting
 
 `ElementResults.plot` is a small wrapper around matplotlib for the
-three engineering views that come up most:
+four engineering views that come up most:
 
 ```python
-# Time history of a component for one or more elements
+# Time history of a single raw column for one or more elements
 ax, meta = er.plot.history("Mz_1", element_ids=[1, 2, 3])
 ax, meta = er.plot.history("P_ip2", x_axis="step")  # step instead of time
+
+# Time history of a canonical name, with fiber / IP reduction.
+# Folds every fiber*ip column into one curve per element:
+ax, meta = er.plot.history_canonical("strain_11", reduce="mean")
+# Max(|.|) over fibers at IP 0:
+ax, meta = er.plot.history_canonical(
+    "strain_11", over="fibers", ip_idx=0, reduce="abs_max",
+)
 
 # Force / moment / strain diagram along a beam (line elements only)
 ax, meta = er.plot.diagram("axial_force", element_id=1, step=100)
@@ -444,6 +452,15 @@ build your own visualization. ``diagram()`` requires the result to be a
 line element (``gp_dim == 1``); ``scatter()`` requires
 ``physical_coords()`` to resolve (so closed-form buckets and unknown
 classes raise loudly).
+
+`history_canonical` is the right tool for **fiber buckets** (e.g.
+`section.fiber.stress`, `section.fiber.strain`) where one canonical
+quantity expands to `n_fibers × n_ip` (or `n_fibers × n_layers × n_ip`
+for layered shells) columns. The `over=` knob selects which axis the
+reduction collapses (`"all"` | `"fibers"` | `"ips"` | `"layers"`) and
+the partner `fiber_idx` / `ip_idx` / `layer_idx` anchors keep the
+remaining axes pinned. `meta["columns_used"]` tells you which raw
+columns were folded in, useful for audit.
 
 ## Pickle Serialization
 

--- a/docs/nodes_elements_cuts_plotting_guide.md
+++ b/docs/nodes_elements_cuts_plotting_guide.md
@@ -1,0 +1,621 @@
+# Nodes, Elements, Section Cuts & Plotting — Usage Guide
+
+A practical, copy-pasteable guide to the four workhorses of `STKO_to_python`:
+
+1. **Nodes** — nodal result extraction (`NodalResults`)
+2. **Elements** — element result extraction (`ElementResults`)
+3. **Section cuts** — integrate internal forces over a plane (`SectionCut`, `SectionSweep`)
+4. **Plotting** — every `.plot` surface in the library
+
+Every signature below is taken from the current source. Snippets assume:
+
+```python
+from STKO_to_python import MPCODataSet
+
+ds = MPCODataSet(
+    hdf5_directory="path/to/results",   # folder with results.part-*.mpco
+    recorder_name="results",            # base name (no .part-N.mpco)
+    name="MyModel",                     # optional; defaults to folder name
+    verbose=False,                      # True → INFO logging + print_summary
+)
+```
+
+`MPCODataSet` is also a context manager — use `with MPCODataSet(...) as ds:`
+for scripts that open many datasets in sequence (closes pooled HDF5 handles
+and drops query caches at scope exit).
+
+Discover what's in the file first:
+
+```python
+ds.model_stages              # ['MODEL_STAGE[1]', ...]
+ds.node_results_names        # ['DISPLACEMENT', 'REACTION_FORCE', ...]
+ds.element_results_names     # ['force', 'section.force', ...]
+ds.unique_element_types      # ['5-ElasticBeam3d', '203-ASDShellQ4', ...]
+ds.number_of_steps           # {stage: int}
+ds.time                      # DataFrame, MultiIndex (MODEL_STAGE, STEP)
+ds.nodes_info["dataframe"]   # node_id, file_id, index, x, y, z
+ds.elements_info["dataframe"]# element_id, element_type, node_list, centroid_*
+ds.selection_set             # {set_id: {SET_NAME, NODES, ELEMENTS}} (lazy)
+
+# Logging-based summaries (need verbose=True or logging.basicConfig(INFO)):
+ds.print_summary()
+ds.print_selection_set_info()
+ds.elements.get_available_element_results()   # {part: {result: [types]}}
+```
+
+---
+
+## 1. Nodes
+
+### 1.1 Fetching nodal results
+
+```python
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT",     # str, list[str], or None = ALL results
+    model_stage="MODEL_STAGE[1]",    # str, list[str], or None = ALL stages
+    node_ids=[1, 2, 3, 4],           # int / list / nested list / ndarray
+    selection_set_id=None,           # int or list[int]
+    selection_set_name=None,         # str or list[str] (case-insensitive)
+    selector=None,                   # a NodeSelector (see 1.4)
+)
+```
+
+All arguments are keyword-only. Node sources are **unioned** (explicit
+`node_ids` + selection set + selector all merge). Omitting every filter
+returns **all nodes**.
+
+> **Stage default differs from elements.** For nodes, `model_stage=None`
+> concatenates **all** stages onto one contiguous global step axis. For
+> elements, `model_stage=None` is the **first stage only**. Be explicit if
+> it matters.
+
+Pass a list of result names to read several results in one HDF5 pass:
+
+```python
+nr = ds.nodes.get_nodal_results(
+    results_name=["DISPLACEMENT", "ACCELERATION"],
+    model_stage="MODEL_STAGE[1]",
+)
+```
+
+### 1.2 The `NodalResults` container
+
+Index is `(node_id, step)`; columns are a MultiIndex `(result, component)`.
+Components are **1-indexed** (OpenSees convention: 1=X, 2=Y, 3=Z).
+
+```python
+# Dynamic attribute views — the idiomatic accessor:
+nr.DISPLACEMENT[1]              # comp 1, all nodes        -> Series
+nr.DISPLACEMENT[1, [14, 25]]    # comp 1, nodes 14 & 25    -> Series/DataFrame
+nr.DISPLACEMENT[:]              # all comps, all nodes     -> DataFrame
+nr.DISPLACEMENT[:, [14, 25]]    # all comps, nodes 14 & 25 -> DataFrame
+
+# Explicit fetch (same engine, more options):
+nr.fetch(result_name="DISPLACEMENT", component=1, node_ids=[14, 25])
+nr.fetch(result_name="DISPLACEMENT", component=1,
+         selection_set_name="Roof")
+nr.fetch_nearest(points=[(0.5, 0.0, 30.0)], result_name="DISPLACEMENT",
+                 component=1)
+
+# Introspection:
+nr.list_results()                      # ('ACCELERATION', 'DISPLACEMENT')
+nr.list_components("DISPLACEMENT")     # ('1', '2', '3')
+nr.df                                  # the raw DataFrame
+nr.time                                # 1-D ndarray, contiguous across stages
+
+# .info sub-object:
+nr.info.nodes_ids
+nr.info.model_stages
+nr.info.stage_step_ranges              # {stage: (start, end)} global steps
+nr.info.nearest_node_id([(0.5, 0.0, 2.0)])
+
+# Pickle (gzip auto-detected from .gz suffix):
+nr.save_pickle("disp.pkl.gz")
+from STKO_to_python import NodalResults
+nr = NodalResults.load_pickle("disp.pkl.gz")
+```
+
+### 1.3 Engineering aggregations on `NodalResults`
+
+These forward to a shared `AggregationEngine`. **All keyword-only.**
+
+```python
+# Relative drift between two nodes (Series indexed by step):
+nr.drift(top=4, bottom=1, component=1)
+nr.drift(top=4, bottom=1, component=1, reduce="abs_max")    # -> float
+nr.delta_u(top=4, bottom=1, component=1)                     # raw Δ (no /h)
+
+# Residual (end-of-record) drift, averaged over the last `tail` steps:
+nr.residual_drift(top=4, bottom=1, component=1, tail=3, agg="mean")
+
+# Story-by-story envelopes (auto-groups nodes by Z within dz_tol):
+nr.interstory_drift_envelope(component=1, selection_set_name="Frame",
+                             dz_tol=1e-3)
+nr.story_pga_envelope(component=1, result_name="ACCELERATION",
+                      to_g=True, g_value=9810)
+
+# Plan/torsion/rocking:
+nr.roof_torsion(node_a_id=101, node_b_id=140)
+nr.base_rocking(node_coords_xy=[(0,0),(10,0),(0,10)], z_coord=0.0)
+nr.asce_torsional_irregularity(component=1,
+    side_a_top=(0,0,30), side_a_bottom=(0,0,0),
+    side_b_top=(20,0,30), side_b_bottom=(20,0,0))
+
+# Orbit (two-component displacement trajectory):
+sx, sy = nr.orbit(node_ids=1, x_component=1, y_component=2)
+```
+
+### 1.4 Chainable node selector
+
+`ds.nodes.select()` returns a lazy `NodeSelector`. Chain spatial primitives
+(each one AND-narrows), combine with `& | ~`, resolve with `.ids()` /
+`.mask()` / `.df()` / `.count()`:
+
+```python
+ids = (ds.nodes.select()
+       .from_selection("Roof")                       # anchor (req. for ~)
+       .within_box(min=(0, 0, 28), max=(50, 50, 32))
+       .nearest_to((25, 25, 30), k=8)
+       .ids())
+
+# Other primitives: .with_ids(...), .on_plane(...), .near_line(...),
+# .within_distance(point, radius), .coord_in(...), .at_level(z),
+# .attached_to(element_ids), .where(lambda df: ...)
+
+# Feed straight into a fetch (unions with node_ids if both given):
+nr = ds.nodes.get_nodal_results(
+    results_name="DISPLACEMENT", model_stage="MODEL_STAGE[1]",
+    selector=ds.nodes.select().at_level(30.0),
+)
+```
+
+### 1.5 Threshold / time-window masks
+
+```python
+mask = (nr.where(time=(0.0, 10.0))
+          .component("DISPLACEMENT", 1).abs_peak().gt(0.05))
+hot_nodes = nr[mask]      # a trimmed NodalResults
+ids       = mask.ids()    # int64 ndarray
+
+# magnitude across components:
+nr.where().magnitude("DISPLACEMENT").peak().gt(0.05)
+```
+
+---
+
+## 2. Elements
+
+### 2.1 Fetching element results
+
+```python
+er = ds.elements.get_element_results(
+    "force",                        # results_name (positional)
+    element_type="5-ElasticBeam3d", # REQUIRED (base type, not decorated)
+    element_ids=[1, 2, 3],          # or selection_set_id / _name / selector
+    selection_set_id=None,
+    selection_set_name=None,
+    selector=None,
+    model_stage="MODEL_STAGE[1]",   # None = FIRST stage only (see note in 1.1)
+    verbose=False,
+)
+```
+
+`element_type` is mandatory unless you pass a `selector` with `.of_type(...)`.
+Use the **base** type (`"5-ElasticBeam3d"`), not the decorated bracket form.
+Discover valid names:
+
+```python
+ds.elements.get_available_element_results()
+ds.elements.get_available_element_results(element_type="5-ElasticBeam3d")
+```
+
+### 2.2 The `ElementResults` container
+
+Index is `(element_id, step)`; columns are real engineering names parsed
+from the bucket's `META` (e.g. `Pz_1`, `Mz_ip3`, `sigma11_f0_ip0`) — only
+falling back to `val_1, val_2, ...` when no `META` is present.
+
+```python
+# Dynamic attribute views:
+er.Pz_1               # all elements -> _ElementResultView
+er.Pz_1[[1, 2]]       # elements 1 & 2 -> Series
+er.Pz_1[:]            # all elements -> Series
+
+# Explicit fetch:
+er.fetch(component="Pz_1", element_ids=[1, 2])
+
+# Introspection:
+er.list_components()          # ('Px_1', 'Py_1', ..., 'Mz_2')
+er.n_elements, er.n_steps, er.n_components
+er.df                         # raw DataFrame
+
+# Per-element time-series stats:
+er.envelope(component="Pz_1")     # min/max over steps, per element
+er.peak_abs("Mz_1")               # max(|.|) per element
+er.time_of_peak("Mz_1", abs=True) # argmax step per element
+er.cumulative_envelope("Mz_1")    # running min/max per (element, step)
+er.summary()                      # max/min/peak_abs/residual/mean per element
+
+# Snapshots:
+er.at_step(5)                     # DataFrame indexed by element_id
+er.at_time(0.5)                   # nearest recorded step
+er.to_dataframe(include_time=True)
+
+# Pickle:
+er.save_pickle("forces.pkl.gz")
+from STKO_to_python import ElementResults
+er = ElementResults.load_pickle("forces.pkl.gz")
+```
+
+### 2.3 Canonical engineering names
+
+Map element-class-specific column names to portable engineering names:
+
+```python
+er.list_canonicals()                      # ('axial_force', 'bending_moment_z', ...)
+er.canonical_columns("bending_moment_z")  # ('Mz_1', 'Mz_2') in on-disk order
+er.canonical("bending_moment_z")          # DataFrame subset (raises if no match)
+```
+
+### 2.4 Integration points & physical coordinates
+
+For line-station / Gauss-level buckets (`section.force`, fiber stress, …):
+
+```python
+er.gp_xi          # natural ξ ∈ [-1,1], 1-D (line elements) — None if closed-form
+er.gp_natural     # (n_ip, dim): dim 1=line, 2=shell, 3=solid
+er.n_ip, er.gp_dim
+er.at_ip(0)                    # columns for IP 0 -> DataFrame
+er.physical_x(length=3.0)      # ξ -> physical position along a beam of length L
+
+# Shells / solids (catalog-driven, needs node coords):
+er.physical_coords()           # (n_elements, n_ip, 3) or None
+er.jacobian_dets()             # (n_elements, n_ip) or None
+er.integrate_canonical("stress_11")   # ∫ value dΩ per (element, step) -> Series
+```
+
+Closed-form buckets (e.g. `force` on `ElasticBeam3d`) have `gp_xi is None`,
+`n_ip == 0`; `at_ip()` / `physical_x()` / `integrate_canonical()` raise with
+a clear message.
+
+### 2.5 Z-level filtering & selectors
+
+```python
+# Elements crossing horizontal planes:
+ds.elements.get_elements_at_z_levels([0.0, 3.5, 7.0])
+ds.elements.get_elements_in_selection_at_z_levels(
+    [0.0, 3.5], selection_set_name="Columns")
+
+# Results filtered by selection + Z (grouped by decorated type):
+ds.elements.get_element_results_by_selection_and_z(
+    "force", [0.0], selection_set_id=2)
+
+# Chainable element selector:
+ids = (ds.elements.select()
+       .of_type("DispBeamColumn3d")
+       .within_box(min=(0,0,0), max=(10,10,30))
+       .nearest_to((5,5,15), k=20)
+       .ids())
+er = ds.elements.get_element_results(
+    "force", selector=ds.elements.select().of_type("5-ElasticBeam3d"))
+```
+
+Element masks mirror the node side:
+
+```python
+mask = er.where(time=(0.0, 10.0)).component("Mz_ip0").abs_peak().gt(50.0)
+hot  = er[mask]
+ids  = mask.ids()
+```
+
+---
+
+## 3. Section cuts
+
+A section cut slices the model with a plane and integrates internal
+tractions over the elements it crosses, recovering a `(F, M)` resultant
+time series. Beams, shells, and solids are all composed automatically.
+
+```python
+from STKO_to_python import Plane, SectionCut, SectionCutSpec, SectionSweep, DriftSpec
+```
+
+### 3.1 Defining the plane
+
+```python
+Plane.horizontal(z=2500.0)                   # ⟂ global Z at elevation z
+Plane.vertical(axis="x", at=10.0)            # ⟂ global X at x = 10
+Plane.from_three_points(p1, p2, p3, normal_hint=(0,0,1))
+Plane.horizontal_grid([0.0, 3.0, 6.0])       # list of Planes (for sweeps)
+Plane(point=(0,0,5), normal=(0,0,1))         # general; normal auto-normalized
+```
+
+### 3.2 Computing a cut
+
+The inline form (one-shot) needs `plane`, `model_stage`, and **one element
+filter** (`element_ids`, `selection_set_id`, or `selection_set_name`):
+
+```python
+cut = ds.section_cut(
+    plane=Plane.horizontal(z=2500.0),
+    element_ids=shell_ids,            # or selection_set_name="Wall"
+    model_stage="MODEL_STAGE[1]",     # REQUIRED keyword
+    side="positive",                  # "positive" | "negative" (sign convention)
+    label="Wall @ z=2500",            # optional, used by plotters
+    bounding_polygon=None,            # optional convex clip (see 3.5)
+)
+```
+
+The reusable form takes a picklable `SectionCutSpec`:
+
+```python
+spec = SectionCutSpec(plane=Plane.horizontal(z=2500.0),
+                       selection_set_name="Wall", label="Wall")
+cut  = ds.section_cut(spec=spec, model_stage="MODEL_STAGE[1]")
+spec.save_pickle("wall_cut.spec.pkl")
+```
+
+### 3.3 Reading the result
+
+```python
+cut.F            # (n_steps, 3) force the kept side exerts on the discarded side
+cut.M            # (n_steps, 3) moment about cut.centroid
+cut.time         # (n_steps,)
+cut.centroid     # (3,) reference point for M
+cut.n_steps
+
+cut.at_step(10)             # 6-element Series Fx,Fy,Fz,Mx,My,Mz
+cut.at_time(0.5)            # nearest step
+cut.envelope()              # per-component max/min/peak_abs + when
+cut.to_dataframe()          # rows=time, cols=Fx..Mz
+cut.resultant()             # (F.copy(), M.copy())
+cut.moment_about((0,0,0))   # transfer M to another reference point
+
+# Which elements contributed:
+cut.intersections           # beams
+cut.shell_intersections     # shells
+cut.solid_intersections     # solids
+cut.per_beam_F, cut.per_shell_F, cut.per_solid_F   # {element_id: (n,3)}
+cut.contributing_element_ids
+
+cut.save_pickle("wall_cut.pkl.gz")          # no live dataset reference
+```
+
+### 3.4 Validators (no support reactions required)
+
+```python
+ok, residual = cut.consistency_check(ds)        # Newton 3rd law: side flip ≈ 0
+ok, residual = cut.compare_to(other_cut)        # two parallel cuts agree
+```
+
+`consistency_check` is free and works for DRM / PML / explicit dynamics —
+it recomputes the cut with the opposite side and verifies the sum is ~0.
+
+### 3.5 Bounding polygon (sub-region cuts)
+
+When selection sets don't pre-filter to the region of interest, restrict
+the cut to a **convex** polygon lying on the plane:
+
+```python
+right_half = ((mid_x, -big, z), (big, -big, z), (big, big, z), (mid_x, big, z))
+cut = ds.section_cut(plane=Plane.horizontal(z=z), element_ids=all_ids,
+                      model_stage="MODEL_STAGE[1]", bounding_polygon=right_half)
+```
+
+Non-convex / off-plane / degenerate polygons raise at construction.
+
+### 3.6 Layered-shell decomposition
+
+For `LayeredShell` sections (needs a `sections.tcl` next to the data,
+exposed as `ds.layered_sections`):
+
+```python
+n_layers = len(ds.layered_sections[section_id])
+
+# Per-layer contribution (shell-only; beams/solids dropped):
+layer0 = cut.per_layer_force(0, ds)
+# sum over all layers recovers the shell portion of the standard cut.
+
+# Inline shortcuts:
+top = ds.section_cut(plane=..., element_ids=..., model_stage=...,
+                      per_layer=n_layers - 1)
+fib = ds.section_cut(plane=..., element_ids=..., model_stage=...,
+                      per_layer=2, per_fiber=0)   # per_fiber requires per_layer
+```
+
+### 3.7 Section sweep (many parallel planes)
+
+The "story shear vs elevation" / depth-profile pattern:
+
+```python
+sweep = ds.section_sweep(
+    planes=Plane.horizontal_grid([0, 3, 6, 9, 12]),
+    selection_set_name="Frame",
+    model_stage="MODEL_STAGE[1]",
+)
+
+sweep.envelope()                 # one row per plane, 18 cols (6 comp × 3 stat)
+sweep.to_dataframe("Fx")         # rows=time, cols=plane index (heatmap source)
+sweep.plane_locators("z")        # elevation of each plane (axis auto-inferred)
+sweep[0]                         # the SectionCut at plane 0 (indexable/iterable)
+
+# Per-plane filters → build specs and use from_specs:
+SectionSweep.from_specs([spec_lvl1, spec_lvl2], ds, model_stage="MODEL_STAGE[1]")
+```
+
+---
+
+## 4. Plotting
+
+Every plot method returns `(ax_or_fig, meta)` where `meta` is a dict of the
+parameters that drove the plot. Pass `ax=` to compose onto an existing axes.
+
+### 4.1 Nodal X–Y plots — `nr.plot.xy` / `ds.plot.xy`
+
+> The current API is `.plot.xy(...)`. There is no `plot_roof_drift` /
+> `plot_story_drifts` / `dataset.plot.nodes.*` — use `xy` + the engineering
+> aggregations from §1.3, or `plot_TH` for raw time histories.
+
+```python
+nr = ds.nodes.get_nodal_results(results_name="DISPLACEMENT",
+                                 model_stage="MODEL_STAGE[1]")
+
+# Per-result: displacement (comp 1, max over nodes) vs time
+ax, meta = nr.plot.xy(
+    y_results_name="DISPLACEMENT", y_direction=1, y_operation="Max",
+    x_results_name="TIME",          # "TIME" | "STEP" | another result name
+)
+
+# Force–displacement (reaction sum vs roof displacement) in one shot:
+ax, meta = ds.plot.xy(
+    model_stage="MODEL_STAGE[1]",
+    results_name="REACTION_FORCE",
+    selection_set_name="Base",
+    y_direction=1, y_operation="Sum",
+    x_results_name="DISPLACEMENT",  # triggers a second fetch
+    x_direction=1, x_operation="Mean",
+)
+```
+
+`y_operation` / `x_operation` accept `Aggregator` ops — `"Sum"`, `"Mean"`,
+`"Max"`, `"Min"`, `"Std"`, `"Percentile"` (pass
+`operation_kwargs={"percentile": 95}`), `"Envelope"`, `"Cumulative"`,
+`"SignedCumulative"`, `"RunningEnvelope"` — **or** `"All"` / `"Raw"` to draw
+one curve per node (no aggregation; x must be `"TIME"` or `"STEP"`).
+For multi-stage results, stage boundaries are drawn as dashed lines and
+returned in `meta["stage_boundaries"]`.
+
+Raw time-history helper (one curve per node, optional per-node subplots):
+
+```python
+fig, meta = nr.plot.plot_TH(
+    result_name="DISPLACEMENT", component=2,
+    node_ids=[101, 120, 140],
+    split_subplots=True, sharey=True, figsize=(8, 3),
+)
+```
+
+### 4.2 Element plots — `er.plot`
+
+```python
+er = ds.elements.get_element_results("section.force",
+        element_type="5-ElasticBeam3d", model_stage="MODEL_STAGE[1]")
+
+# Time history of a single raw column for one/many elements:
+er.plot.history("Mz_ip0", element_ids=[1, 2, 3], x_axis="time")
+
+# Time history of a canonical name, with fiber/IP/layer reduction.
+# Useful for section.fiber.* buckets that expand to n_fibers * n_ip cols.
+er.plot.history_canonical("strain_11", reduce="mean")              # over all
+er.plot.history_canonical("strain_11", over="fibers", ip_idx=0,
+                           reduce="abs_max")                        # fibers @ IP 0
+er.plot.history_canonical("stress_11", over="ips", fiber_idx=0,
+                           reduce="max", element_ids=[1, 2, 3])     # IPs of fiber 0
+
+# Beam diagram (line elements only): component vs position along element:
+er.plot.diagram("bending_moment_z", element_id=1, step=10)
+er.plot.diagram("bending_moment_z", element_id=1, step=10, x_in_natural=True)
+
+# Shell/solid IP scatter colored by value at a step (lightweight contour):
+er.plot.scatter("membrane_xx", step=10, axes=("x", "y"))
+```
+
+`history_canonical` accepts `over ∈ {"all", "fibers", "ips", "layers"}`
+and `reduce ∈ {"mean", "median", "max", "min", "abs_max", "sum"}`. When
+`over` is anything but `"all"` it requires the partner anchors (e.g.
+`over="fibers"` needs `ip_idx=`) so the reduction collapses one axis at
+fixed coordinates on the others. `meta["columns_used"]` lists which raw
+columns were folded in.
+
+### 4.3 Model / mesh visualization — `ds.plot`
+
+```python
+ds.plot.undeformed_shape()
+ds.plot.deformed_shape(model_stage="MODEL_STAGE[1]", step=peak, scale=200.0)
+
+# Wireframe backdrop, then overlay an IP scatter on the same axes:
+ax, _ = ds.plot.mesh(element_type="203-ASDShellQ4")
+er.plot.scatter("membrane_xx", step=10, ax=ax)
+# …or the bundled convenience:
+ds.plot.mesh_with_contour(er, "membrane_xx", step=10)
+
+# Beams as 3-D extruded section solids (uses the .cdata profile sidecar):
+ds.plot.beam_solids(selection_set_name="Columns", edge_color=None)
+ds.plot.beam_solids_deformed(model_stage="MODEL_STAGE[1]", step=peak, scale=200.0)
+```
+
+### 4.4 Section-cut plots — `cut.plot`
+
+```python
+cut.plot.time_history("Fx")                     # one component vs time
+cut.plot.orbit("Fx", "Fy")                      # lateral force orbit
+cut.plot.envelope_bars(show_minmax=True)        # peak per component
+cut.plot.consistency_residual(ds)               # Newton-3rd diagnostic
+
+# Capacity / hysteresis: cut force vs node-pair drift
+drift = DriftSpec(top_node=140, bottom_node=1, component=1,
+                  normalize_by=30000.0, label="roof drift ratio")
+cut.plot.hysteresis("Fx", drift, ds)
+```
+
+### 4.5 Sweep plots — `sweep.plot`
+
+```python
+# Story-shear-vs-elevation profile (locator on the y-axis by default):
+sweep.plot.profile("Fx", agg="peak_abs")        # agg: max | min | peak_abs
+sweep.plot.profile("Fx", agg="max", vertical=False)
+
+# Time × plane heatmap (diverging colormap, sign-aware):
+sweep.plot.heatmap("Fx")
+```
+
+### 4.6 Multi-case cut plots — `MultiCutResult.plot`
+
+When a `SectionCutSpec` is applied across an `MPCOResults` ensemble:
+
+```python
+multi.plot.overlay_time_history("Fx")           # one trace per case
+multi.plot.case_envelope_bars("Fx", agg="peak_abs")
+multi.plot.case_scatter("Fx", "Fy", agg="peak_abs")   # biaxial demand
+```
+
+---
+
+## 5. Gotchas & quick reference
+
+| Topic | Watch out for |
+|---|---|
+| Stage default | `nodes` → all stages; `elements` → first stage only when `model_stage=None`. |
+| Components | 1-indexed (1=X, 2=Y, 3=Z), matching OpenSees. |
+| Element type | Use the **base** type (`"5-ElasticBeam3d"`); `element_type` is required. |
+| Closed-form buckets | `gp_xi is None`, `n_ip == 0`; IP/integration methods raise (by design). |
+| Plotting API | It's `nr.plot.xy(...)` / `ds.plot.xy(...)`. No `plot_roof_drift`-style methods or `ds.plot.nodes`. |
+| Section cut filter | Inline form needs a plane **and** an element filter; `model_stage` is a required keyword. |
+| `bounding_polygon` | Must be convex and lie on the cut plane (validated at construction). |
+| `per_fiber` | Requires `per_layer`; only for fiber-decomposed layered shells. |
+| Selection sets | `ds.selection_set` is parsed lazily on first access; `print_selection_set_info()` lists them. |
+| Heterogeneous layouts | Multi-stage / mixed integration-rule fetches raise `MpcoFormatError` rather than silently NaN-padding — query stages/buckets separately. |
+| Pickle | `.gz` suffix auto-enables gzip for every `save_pickle` in the library. |
+
+### Public API
+
+```python
+from STKO_to_python import (
+    MPCODataSet,                                    # entry point
+    NodalResults, ElementResults,                   # result containers
+    Plane, SectionCut, SectionCutSpec,              # section cuts
+    SectionSweep, MultiCutResult, DriftSpec,
+    Aggregator, MPCOResults, MPCO_df,               # aggregation / multi-case
+    HDF5Utils, H5RepairTool, AttrDict, PlotSettings,
+)
+```
+
+### Runnable examples in this repo
+
+| File | Covers |
+|---|---|
+| `examples/usage_tour.py` | End-to-end tour (intro → fetch → aggregate → plot → pickle). |
+| `examples/elastic_frame_example.py` | Nodes + closed-form beam elements. |
+| `examples/quad_frame_shell_example.py` | Shell elements + multi-partition. |
+| `examples/section_cut_solid_and_layered_example.py` | Solid + layered-shell section cuts and sweeps. |
+| `examples/solid_mixed_example.py` | Mixed beam/solid models. |

--- a/examples/solid_mixed_example.py
+++ b/examples/solid_mixed_example.py
@@ -20,9 +20,10 @@ Sections:
     8.  Beam fiber section — ``section.fiber.stress``, 6 fibers x 2 IPs.
     9.  ``at_ip()`` on fiber result — all 6 fibers at one station.
    10.  Why ``integrate_canonical`` is not available for fiber buckets.
-   11.  ``plot.diagram()`` — bending moment diagram along a beam element.
-   12.  ``plot.scatter()`` — Gauss-point stress scatter for a brick element.
-   13.  ElementResults pickle round-trip.
+   11.  ``plot.history_canonical()`` — mean / max over fibers and IPs.
+   12.  ``plot.diagram()`` — bending moment diagram along a beam element.
+   13.  ``plot.scatter()`` — Gauss-point stress scatter for a brick element.
+   14.  ElementResults pickle round-trip.
 
 Run with::
 
@@ -334,10 +335,54 @@ def section_10_fiber_integrate_raises(er: ElementResults) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 11. plot.diagram() — bending moment diagram along a beam element
+# 11. plot.history_canonical() — fiber/IP reduction on a fiber bucket
 # ---------------------------------------------------------------------------
-def section_11_beam_diagram(er_sf: ElementResults) -> None:
-    section("11. plot.diagram() - bending moment diagram along a beam")
+def section_11_history_canonical_fiber(er: ElementResults) -> None:
+    section("11. plot.history_canonical() - mean / max over fibers and IPs")
+
+    # Pick whatever canonical name the fiber bucket exposes (typically
+    # "stress_11" on section.fiber.stress). list_canonicals() makes the
+    # example fixture-agnostic.
+    canon = next(iter(er.list_canonicals()))
+    print(f"Reducing canonical: {canon!r}")
+    print(f"Bucket has {er.n_components} raw columns "
+          f"({er.n_ip} IPs, {er.n_components // er.n_ip} fibers).\n")
+
+    # 11a — mean over EVERY fiber and IP, one curve per element.
+    ax, meta = er.plot.history_canonical(canon, over="all", reduce="mean")
+    print(f"over='all'  reduce='mean':")
+    print(f"  curves drawn:       {len(meta['y_per_element'])}")
+    print(f"  columns folded in:  {len(meta['columns_used'])}")
+    plt.close("all")
+
+    # 11b — max(|.|) over fibers at fixed IP 0.
+    ax, meta = er.plot.history_canonical(
+        canon, over="fibers", ip_idx=0, reduce="abs_max",
+    )
+    print(f"\nover='fibers' ip_idx=0  reduce='abs_max':")
+    print(f"  columns used: {meta['columns_used']}")
+    plt.close("all")
+
+    # 11c — max over IPs of fiber 0.
+    ax, meta = er.plot.history_canonical(
+        canon, over="ips", fiber_idx=0, reduce="max",
+    )
+    print(f"\nover='ips' fiber_idx=0  reduce='max':")
+    print(f"  columns used: {meta['columns_used']}")
+    plt.close("all")
+
+    # The missing-anchor case is loud — this is the contract:
+    try:
+        er.plot.history_canonical(canon, over="fibers", reduce="mean")
+    except ValueError as exc:
+        print(f"\nover='fibers' without ip_idx -> ValueError: {str(exc)[:80]}...")
+
+
+# ---------------------------------------------------------------------------
+# 12. plot.diagram() — bending moment diagram along a beam element
+# ---------------------------------------------------------------------------
+def section_12_beam_diagram(er_sf: ElementResults) -> None:
+    section("12. plot.diagram() - bending moment diagram along a beam")
 
     # er_sf is the section.force result (n_ip=2, gp_xi=[-1, +1]).
     # diagram() requires gp_dim==1 and a canonical that maps to exactly n_ip cols.
@@ -370,10 +415,10 @@ def section_11_beam_diagram(er_sf: ElementResults) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 12. plot.scatter() — Gauss-point stress scatter for a brick element
+# 13. plot.scatter() — Gauss-point stress scatter for a brick element
 # ---------------------------------------------------------------------------
-def section_12_brick_scatter(er_brick: ElementResults) -> None:
-    section("12. plot.scatter() - stress_11 at Gauss points (x-z view)")
+def section_13_brick_scatter(er_brick: ElementResults) -> None:
+    section("13. plot.scatter() - stress_11 at Gauss points (x-z view)")
 
     step = 1
     ax, meta = er_brick.plot.scatter(
@@ -391,10 +436,10 @@ def section_12_brick_scatter(er_brick: ElementResults) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 13. Pickle round-trip
+# 14. Pickle round-trip
 # ---------------------------------------------------------------------------
-def section_13_pickle(er_brick: ElementResults) -> None:
-    section("13. ElementResults pickle round-trip")
+def section_14_pickle(er_brick: ElementResults) -> None:
+    section("14. ElementResults pickle round-trip")
 
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "brick.pkl"
@@ -436,9 +481,10 @@ def main() -> None:
     er_fiber = section_8_fiber_stress(ds, beam_ids)
     section_9_at_ip_fiber(er_fiber)
     section_10_fiber_integrate_raises(er_fiber)
-    section_11_beam_diagram(er_beam)
-    section_12_brick_scatter(er_brick)
-    section_13_pickle(er_brick)
+    section_11_history_canonical_fiber(er_fiber)
+    section_12_beam_diagram(er_beam)
+    section_13_brick_scatter(er_brick)
+    section_14_pickle(er_brick)
 
     print()
     print("solid_mixed_example complete.")

--- a/src/STKO_to_python/elements/element_results_plotting.py
+++ b/src/STKO_to_python/elements/element_results_plotting.py
@@ -1,9 +1,14 @@
 """Plotting helper bound to an :class:`ElementResults` instance.
 
-Three plot families covering the most common engineering workflows:
+Four plot families covering the most common engineering workflows:
 
-* :meth:`ElementResultsPlotter.history` — time history of a component
-  for one or more elements (and optionally a specific IP).
+* :meth:`ElementResultsPlotter.history` — time history of a single
+  column for one or more elements.
+* :meth:`ElementResultsPlotter.history_canonical` — like ``history``
+  but takes a canonical engineering name (``"strain_11"``,
+  ``"bending_moment_z"``, …) and collapses the fiber / IP / layer
+  columns it expands to with a chosen reduction (``mean``, ``max``,
+  ``abs_max``, …). One curve per element.
 * :meth:`ElementResultsPlotter.diagram` — for line elements (beams),
   plot a component as a function of physical position along the
   element at a single step. The classic moment / shear / axial
@@ -19,6 +24,7 @@ user-built figures, and return ``(ax, meta)`` like
 """
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -30,6 +36,132 @@ if TYPE_CHECKING:
 
 # Map "x"/"y"/"z" to physical_coords axis index.
 _AXIS_NAME_TO_IDX = {"x": 0, "y": 1, "z": 2, 0: 0, 1: 1, 2: 2}
+
+
+# --------------------------------------------------------------------- #
+# Private helper for history_canonical                                  #
+# --------------------------------------------------------------------- #
+
+# Allowed reductions for history_canonical. Lambdas operate row-wise
+# (axis=1) on a DataFrame of fiber / IP / layer columns and return a
+# Series indexed identically to the input.
+_CANONICAL_REDUCERS: dict[str, Any] = {
+    "mean":    lambda df: df.mean(axis=1),
+    "median":  lambda df: df.median(axis=1),
+    "max":     lambda df: df.max(axis=1),
+    "min":     lambda df: df.min(axis=1),
+    "abs_max": lambda df: df.abs().max(axis=1),
+    "sum":     lambda df: df.sum(axis=1),
+}
+
+# ``over`` modes and which anchor index they make mandatory. ``"all"``
+# requires nothing; the others require the partner axes to be pinned so
+# the reduction collapses the named axis rather than silently folding in
+# every other axis too.
+_OVER_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "all":    (),
+    "fibers": ("ip_idx",),
+    "ips":    ("fiber_idx",),
+    "layers": ("fiber_idx", "ip_idx"),
+}
+
+
+def _filter_canonical_columns(
+    columns: Sequence[str],
+    *,
+    fiber_idx: Optional[int] = None,
+    ip_idx: Optional[int] = None,
+    layer_idx: Optional[int] = None,
+) -> list[str]:
+    """Keep only columns whose ``_f<F>``, ``_l<L>``, ``_ip<K>`` tags
+    match every supplied filter.
+
+    Tag grammar (per ``io/meta_parser.py``):
+
+    * ``<comp>_f<F>_ip<K>``            — compressed fibers
+    * ``<comp>_l<L>_ip<K>``            — layered shell, no fibers
+    * ``<comp>_f<F>_l<L>_ip<K>``       — layered shell with fibers
+    * ``<comp>_ip<K>``                 — line-station / gauss-level
+
+    Anchors that aren't present in a given column simply don't match —
+    e.g. ``layer_idx=2`` on a compressed-fiber bucket drops every column
+    (which is the right answer; layers don't exist there).
+    """
+    kept: list[str] = []
+    fiber_re = re.compile(rf"_f{fiber_idx}(_|$)") if fiber_idx is not None else None
+    layer_re = re.compile(rf"_l{layer_idx}(_|$)") if layer_idx is not None else None
+    ip_re    = re.compile(rf"_ip{ip_idx}$")       if ip_idx    is not None else None
+    for c in columns:
+        s = str(c)
+        if fiber_re is not None and not fiber_re.search(s):
+            continue
+        if layer_re is not None and not layer_re.search(s):
+            continue
+        if ip_re is not None and not ip_re.search(s):
+            continue
+        kept.append(s)
+    return kept
+
+
+def _reduce_fiber_ip(
+    df: pd.DataFrame,
+    *,
+    over: str,
+    reduce: str,
+    fiber_idx: Optional[int] = None,
+    ip_idx: Optional[int] = None,
+    layer_idx: Optional[int] = None,
+) -> tuple[pd.Series, list[str]]:
+    """Filter a fiber/IP/layer DataFrame and row-reduce across its columns.
+
+    Returns ``(reduced_series, columns_used)`` where ``reduced_series``
+    has the same index as ``df`` (typically ``(element_id, step)``).
+    Pure: no plotting, no dataset access — easy to unit-test against a
+    synthetic DataFrame.
+    """
+    if over not in _OVER_REQUIREMENTS:
+        raise ValueError(
+            f"over={over!r} not in {tuple(_OVER_REQUIREMENTS)}."
+        )
+    if reduce not in _CANONICAL_REDUCERS:
+        raise ValueError(
+            f"reduce={reduce!r} not in {tuple(_CANONICAL_REDUCERS)}."
+        )
+    required = _OVER_REQUIREMENTS[over]
+    locals_map = {"fiber_idx": fiber_idx, "ip_idx": ip_idx, "layer_idx": layer_idx}
+    missing = [name for name in required if locals_map[name] is None]
+    if missing:
+        raise ValueError(
+            f"over={over!r} requires {missing}; pass them as keyword args "
+            f"so the reduction collapses {over!r} at fixed partner indices."
+        )
+
+    cols = _filter_canonical_columns(
+        df.columns,
+        fiber_idx=fiber_idx,
+        ip_idx=ip_idx,
+        layer_idx=layer_idx,
+    )
+    if not cols:
+        # Name the filters in the message so users know what wiped them.
+        anchors = {
+            k: v for k, v in (
+                ("fiber_idx", fiber_idx),
+                ("ip_idx", ip_idx),
+                ("layer_idx", layer_idx),
+            ) if v is not None
+        }
+        tag_re = re.compile(r"_f\d+|_l\d+|_ip\d+")
+        present_tags = sorted(
+            {tag for c in df.columns for tag in tag_re.findall(str(c))}
+        )
+        raise ValueError(
+            f"No columns matched anchors {anchors or '{}'}. "
+            f"Available column tail-tags: {present_tags}"
+        )
+
+    series = _CANONICAL_REDUCERS[reduce](df[cols])
+    return series, cols
 
 
 class ElementResultsPlotter:
@@ -138,6 +270,192 @@ class ElementResultsPlotter:
         # come from ``stage_step_ranges``; we map them to the chosen
         # x-axis (time or step) so the line sits on the last sample of
         # each completed stage.
+        if annotate_stage_boundaries and er.is_multi_stage:
+            ranges = er.stage_step_ranges
+            stages = er.model_stages
+            meta["stage_boundaries"] = []
+            for st in stages[:-1]:
+                end_step = ranges.get(st, (0, 0))[1]
+                if x_axis == "time":
+                    if 0 < end_step <= x_full.size:
+                        x_b = float(x_full[end_step - 1])
+                    else:
+                        continue
+                else:  # step
+                    x_b = float(end_step - 1)
+                meta["stage_boundaries"].append((st, x_b))
+                ax.axvline(
+                    x_b, color="0.5", linestyle="--",
+                    linewidth=0.8, alpha=0.6,
+                )
+
+        return ax, meta
+
+    # ------------------------------------------------------------------ #
+    # Time history of a canonical name, with fiber/IP/layer reduction    #
+    # ------------------------------------------------------------------ #
+
+    def history_canonical(
+        self,
+        canonical_name: str,
+        *,
+        over: str = "all",
+        reduce: str = "mean",
+        fiber_idx: Optional[int] = None,
+        ip_idx: Optional[int] = None,
+        layer_idx: Optional[int] = None,
+        element_ids: Union[int, Sequence[int], None] = None,
+        ax: Any = None,
+        x_axis: str = "time",
+        annotate_stage_boundaries: bool = True,
+        **plot_kwargs: Any,
+    ) -> Tuple[Any, dict]:
+        """Time history of a canonical quantity, reduced across fibers /
+        IPs / layers — one curve per element.
+
+        Sibling to :meth:`history`. Where ``history`` takes a single raw
+        column (e.g. ``"eps11_f0_ip0"``), this method takes the
+        engineering name (``"strain_11"``) which typically expands to
+        ``n_fibers × n_ip`` (or ``n_fibers × n_layers × n_ip``) columns,
+        then collapses them with the chosen reduction.
+
+        Parameters
+        ----------
+        canonical_name : str
+            Engineering name. Must be in :meth:`ElementResults.list_canonicals`.
+        over : ``"all"`` | ``"fibers"`` | ``"ips"`` | ``"layers"``
+            Which axis the reduction collapses. ``"all"`` folds every
+            fiber / IP / layer column. The other three require their
+            partner axes to be anchored so the reduction is well-defined:
+
+            * ``"fibers"`` needs ``ip_idx`` (collapses fibers at that IP).
+            * ``"ips"`` needs ``fiber_idx`` (collapses IPs of that fiber).
+            * ``"layers"`` needs both ``fiber_idx`` and ``ip_idx``
+              (collapses layers at that fiber × IP).
+        reduce : ``"mean"`` | ``"median"`` | ``"max"`` | ``"min"`` |
+                 ``"abs_max"`` | ``"sum"``
+            Row-wise reduction across the matched columns.
+        fiber_idx, ip_idx, layer_idx : int, optional
+            Anchor indices. Required where ``over`` says so; otherwise
+            optional pre-filters that further restrict the matched
+            columns (e.g. ``layer_idx=2`` with ``over="fibers"`` and
+            ``ip_idx=0`` selects fibers within layer 2 at IP 0).
+        element_ids : int or sequence of int, optional
+            Restrict to specific elements. ``None`` plots every element
+            in the result (one curve each).
+        ax : matplotlib Axes or None
+            Existing axes to draw on; new figure if ``None``.
+        x_axis : ``"time"`` | ``"step"``
+            x-axis source. ``"time"`` requires ``self._results.time``.
+        annotate_stage_boundaries : bool
+            For multi-stage results, draw a dashed vertical line at each
+            stage transition and record the positions in
+            ``meta["stage_boundaries"]``.
+        **plot_kwargs
+            Forwarded to ``ax.plot``.
+
+        Returns
+        -------
+        (ax, meta) : tuple
+            ``meta`` carries ``{"x", "y_per_element", "columns_used",
+            "series", "stage_boundaries"?}``. ``columns_used`` is the
+            list of raw fiber / IP / layer columns that were folded into
+            the curve — useful for audit and downstream labelling.
+
+        Examples
+        --------
+        Mean ε11 across every fiber and IP, one curve per element::
+
+            er.plot.history_canonical("strain_11", reduce="mean")
+
+        Max(|ε11|) across fibers at IP 0::
+
+            er.plot.history_canonical("strain_11", over="fibers",
+                                       ip_idx=0, reduce="abs_max")
+
+        Max σ11 across IPs of fiber 0, on selected elements::
+
+            er.plot.history_canonical("stress_11", over="ips",
+                                       fiber_idx=0, reduce="max",
+                                       element_ids=[1, 2, 3])
+        """
+        import matplotlib.pyplot as plt
+
+        er = self._results
+
+        # Pull the canonical slice (raises with a clear message if the
+        # name isn't present in this bucket).
+        try:
+            full = er.canonical(canonical_name)
+        except ValueError:
+            # Re-raise with the live list so users can fix the name
+            # without an extra ``list_canonicals()`` call.
+            raise ValueError(
+                f"Canonical {canonical_name!r} not in this result. "
+                f"Present canonicals: {er.list_canonicals()}"
+            ) from None
+
+        # Filter + reduce across the chosen axis. Pure helper —
+        # tested separately in tests/unit/elements/.
+        series, columns_used = _reduce_fiber_ip(
+            full,
+            over=over,
+            reduce=reduce,
+            fiber_idx=fiber_idx,
+            ip_idx=ip_idx,
+            layer_idx=layer_idx,
+        )
+
+        # Pick elements to draw.
+        if element_ids is None:
+            ids = list(er.element_ids)
+        elif isinstance(element_ids, (int, np.integer)):
+            ids = [int(element_ids)]
+        else:
+            ids = [int(e) for e in element_ids]
+
+        # x-axis source.
+        if x_axis == "time":
+            if not isinstance(er.time, np.ndarray) or er.time.size == 0:
+                raise ValueError(
+                    "x_axis='time' requested but no time array on this "
+                    "result. Use x_axis='step' instead."
+                )
+            x_full = er.time
+            x_label = "Time"
+        elif x_axis == "step":
+            x_full = np.arange(er.n_steps, dtype=np.int64)
+            x_label = "Step"
+        else:
+            raise ValueError(f"x_axis must be 'time' or 'step', got {x_axis!r}")
+
+        if ax is None:
+            fig, ax = plt.subplots()
+
+        per_element: dict[int, np.ndarray] = {}
+        for eid in ids:
+            try:
+                y = series.xs(eid, level="element_id").sort_index().to_numpy()
+            except KeyError:
+                continue
+            x = x_full[: y.size]
+            label = plot_kwargs.pop("label", None) if len(ids) == 1 else f"e{eid}"
+            ax.plot(x, y, label=label, **plot_kwargs)
+            per_element[eid] = y
+
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(f"{reduce}({canonical_name})")
+        if len(ids) > 1 and len(ids) <= 12:
+            ax.legend()
+
+        meta: dict[str, Any] = {
+            "x": x_full,
+            "y_per_element": per_element,
+            "columns_used": columns_used,
+            "series": series,
+        }
+
+        # Stage-boundary annotation, mirroring ``history``.
         if annotate_stage_boundaries and er.is_multi_stage:
             ranges = er.stage_step_ranges
             stages = er.model_stages

--- a/tests/integration/test_element_plotting.py
+++ b/tests/integration/test_element_plotting.py
@@ -83,6 +83,119 @@ def test_history_unknown_component_raises(elastic_frame_dir: Path):
 
 
 # ---------------------------------------------------------------------- #
+# history_canonical()  — fiber / IP reduction                             #
+# ---------------------------------------------------------------------- #
+
+
+def _first_dispbeam_fiber_eids(ds, max_n: int = 3) -> list[int]:
+    """Pick a few DispBeamColumn3d elements from the index."""
+    df = ds.elements_info["dataframe"]
+    eids = df.loc[
+        df["element_type"].str.startswith("64-DispBeamColumn3d"),
+        "element_id",
+    ].head(max_n).tolist()
+    return [int(e) for e in eids]
+
+
+def test_history_canonical_over_all_mean(solid_partition_dir: Path):
+    """End-to-end fiber bucket: mean over every fiber*IP, one curve per
+    element, asserts on the returned meta."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    eids = _first_dispbeam_fiber_eids(ds, max_n=3)
+    if not eids:
+        pytest.skip("no 64-DispBeamColumn3d elements in fixture")
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        element_ids=eids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    # Pick the first canonical the bucket actually carries — robust
+    # against catalog edits.
+    canon = next(iter(er.list_canonicals()))
+    ax, meta = er.plot.history_canonical(canon, over="all", reduce="mean")
+    assert ax is not None
+    assert sorted(meta["y_per_element"].keys()) == sorted(eids)
+    # Every curve has n_steps samples.
+    for y in meta["y_per_element"].values():
+        assert y.shape == (er.n_steps,)
+    # columns_used should be n_fibers * n_ip non-empty.
+    assert len(meta["columns_used"]) >= 1
+    assert "series" in meta
+
+
+def test_history_canonical_over_fibers_at_ip0(solid_partition_dir: Path):
+    """Reduce across fibers at a fixed IP — column subset should be
+    smaller than the full bucket."""
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    eids = _first_dispbeam_fiber_eids(ds, max_n=2)
+    if not eids:
+        pytest.skip("no 64-DispBeamColumn3d elements in fixture")
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        element_ids=eids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    canon = next(iter(er.list_canonicals()))
+    _, meta_all = er.plot.history_canonical(canon, over="all", reduce="mean")
+    _, meta_ip0 = er.plot.history_canonical(
+        canon, over="fibers", ip_idx=0, reduce="abs_max"
+    )
+    # Anchored at one IP -> strictly fewer columns than the full fold.
+    assert 0 < len(meta_ip0["columns_used"]) < len(meta_all["columns_used"])
+    # Every column in the anchored subset ends with _ip0.
+    assert all(c.endswith("_ip0") for c in meta_ip0["columns_used"])
+
+
+def test_history_canonical_missing_anchor_raises(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    eids = _first_dispbeam_fiber_eids(ds, max_n=1)
+    if not eids:
+        pytest.skip("no 64-DispBeamColumn3d elements in fixture")
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        element_ids=eids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    canon = next(iter(er.list_canonicals()))
+    with pytest.raises(ValueError, match="requires.*ip_idx"):
+        er.plot.history_canonical(canon, over="fibers", reduce="mean")
+
+
+def test_history_canonical_unknown_canonical_raises(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    eids = _first_dispbeam_fiber_eids(ds, max_n=1)
+    if not eids:
+        pytest.skip("no 64-DispBeamColumn3d elements in fixture")
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        element_ids=eids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    with pytest.raises(ValueError, match="Present canonicals"):
+        er.plot.history_canonical("not_a_real_canonical", reduce="mean")
+
+
+def test_history_canonical_x_axis_step(solid_partition_dir: Path):
+    ds = MPCODataSet(str(solid_partition_dir), "Recorder", verbose=False)
+    eids = _first_dispbeam_fiber_eids(ds, max_n=1)
+    if not eids:
+        pytest.skip("no 64-DispBeamColumn3d elements in fixture")
+    er = ds.elements.get_element_results(
+        results_name="section.fiber.stress",
+        element_type="64-DispBeamColumn3d",
+        element_ids=eids,
+        model_stage="MODEL_STAGE[1]",
+    )
+    canon = next(iter(er.list_canonicals()))
+    _, meta = er.plot.history_canonical(canon, reduce="mean", x_axis="step")
+    np.testing.assert_array_equal(meta["x"], np.arange(er.n_steps))
+
+
+# ---------------------------------------------------------------------- #
 # diagram()  — line elements                                              #
 # ---------------------------------------------------------------------- #
 

--- a/tests/unit/elements/test_history_canonical_reduce.py
+++ b/tests/unit/elements/test_history_canonical_reduce.py
@@ -1,0 +1,218 @@
+"""Unit tests for the private ``_reduce_fiber_ip`` / ``_filter_canonical_columns``
+helpers that back :meth:`ElementResultsPlotter.history_canonical`.
+
+Pure-pandas — no HDF5 fixture, no plot rendering. Each reduction is
+checked against hand-computed expected values so a regression in the
+column-filter regex or the reduction dispatch fails loudly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from STKO_to_python.elements.element_results_plotting import (
+    _filter_canonical_columns,
+    _reduce_fiber_ip,
+)
+
+
+# ---------------------------------------------------------------------- #
+# Synthetic frames
+# ---------------------------------------------------------------------- #
+
+def _make_fiber_df() -> pd.DataFrame:
+    """2 elements × 3 steps; 2 fibers × 2 IPs (compressed-fiber pattern)."""
+    idx = pd.MultiIndex.from_product(
+        [[1, 2], [0, 1, 2]], names=["element_id", "step"]
+    )
+    cols = [f"sigma_f{f}_ip{ip}" for f in (0, 1) for ip in (0, 1)]
+    return pd.DataFrame(
+        np.arange(24, dtype=float).reshape(6, 4), index=idx, columns=cols
+    )
+
+
+def _make_layered_fiber_df() -> pd.DataFrame:
+    """2 elements × 3 steps; 2 fibers × 2 layers × 2 IPs (layered+fiber)."""
+    idx = pd.MultiIndex.from_product(
+        [[1, 2], [0, 1, 2]], names=["element_id", "step"]
+    )
+    cols = [
+        f"sigma_f{f}_l{l}_ip{ip}"
+        for f in (0, 1) for l in (0, 1) for ip in (0, 1)
+    ]
+    return pd.DataFrame(
+        np.arange(48, dtype=float).reshape(6, 8), index=idx, columns=cols
+    )
+
+
+def _make_no_fiber_layered_df() -> pd.DataFrame:
+    """Layered shell, no fibers — 2 elements × 3 steps; 2 layers × 2 IPs."""
+    idx = pd.MultiIndex.from_product(
+        [[1, 2], [0, 1, 2]], names=["element_id", "step"]
+    )
+    cols = [f"d+_l{l}_ip{ip}" for l in (0, 1) for ip in (0, 1)]
+    return pd.DataFrame(
+        np.arange(24, dtype=float).reshape(6, 4), index=idx, columns=cols
+    )
+
+
+# ---------------------------------------------------------------------- #
+# _filter_canonical_columns
+# ---------------------------------------------------------------------- #
+
+class TestFilterCanonicalColumns:
+    def test_no_anchors_keeps_everything(self):
+        df = _make_fiber_df()
+        assert _filter_canonical_columns(df.columns) == list(df.columns)
+
+    def test_ip_anchor(self):
+        df = _make_fiber_df()
+        kept = _filter_canonical_columns(df.columns, ip_idx=0)
+        assert kept == ["sigma_f0_ip0", "sigma_f1_ip0"]
+
+    def test_fiber_anchor(self):
+        df = _make_fiber_df()
+        kept = _filter_canonical_columns(df.columns, fiber_idx=1)
+        assert kept == ["sigma_f1_ip0", "sigma_f1_ip1"]
+
+    def test_layered_with_layer_anchor(self):
+        df = _make_layered_fiber_df()
+        kept = _filter_canonical_columns(df.columns, layer_idx=1, ip_idx=0)
+        # fibers 0 and 1, layer 1, ip 0
+        assert kept == ["sigma_f0_l1_ip0", "sigma_f1_l1_ip0"]
+
+    def test_anchor_that_does_not_exist_wipes(self):
+        """A layer_idx on a compressed-fiber bucket (no layers) drops all."""
+        df = _make_fiber_df()
+        assert _filter_canonical_columns(df.columns, layer_idx=0) == []
+
+    def test_fiber_anchor_disambiguates_substrings(self):
+        """``_f1`` must not match ``_f11``. Regex anchors the next char."""
+        df = pd.DataFrame(
+            np.zeros((1, 3)),
+            columns=["c_f1_ip0", "c_f10_ip0", "c_f11_ip0"],
+        )
+        assert _filter_canonical_columns(df.columns, fiber_idx=1) == ["c_f1_ip0"]
+
+
+# ---------------------------------------------------------------------- #
+# _reduce_fiber_ip — correctness
+# ---------------------------------------------------------------------- #
+
+class TestReduceCorrectness:
+    def test_over_all_mean(self):
+        df = _make_fiber_df()
+        s, used = _reduce_fiber_ip(df, over="all", reduce="mean")
+        # Row 0 = [0, 1, 2, 3] -> mean 1.5; rows step by 4.
+        assert list(s) == [1.5, 5.5, 9.5, 13.5, 17.5, 21.5]
+        assert len(used) == 4
+
+    def test_over_fibers_at_ip0_max(self):
+        df = _make_fiber_df()
+        s, used = _reduce_fiber_ip(
+            df, over="fibers", ip_idx=0, reduce="max"
+        )
+        # cols sigma_f0_ip0 and sigma_f1_ip0; row 0 = [0, 2] -> max 2
+        assert list(s) == [2.0, 6.0, 10.0, 14.0, 18.0, 22.0]
+        assert used == ["sigma_f0_ip0", "sigma_f1_ip0"]
+
+    def test_over_ips_for_fiber1_mean(self):
+        df = _make_fiber_df()
+        s, used = _reduce_fiber_ip(
+            df, over="ips", fiber_idx=1, reduce="mean"
+        )
+        # cols sigma_f1_ip0 and sigma_f1_ip1; row 0 = [2, 3] -> mean 2.5
+        assert list(s) == [2.5, 6.5, 10.5, 14.5, 18.5, 22.5]
+        assert used == ["sigma_f1_ip0", "sigma_f1_ip1"]
+
+    def test_layered_over_layers_at_fiber0_ip0(self):
+        df = _make_layered_fiber_df()
+        s, used = _reduce_fiber_ip(
+            df, over="layers", fiber_idx=0, ip_idx=0, reduce="mean"
+        )
+        assert used == ["sigma_f0_l0_ip0", "sigma_f0_l1_ip0"]
+        # row 0 columns: sigma_f0_l0_ip0=0, sigma_f0_l1_ip0=2 -> mean 1
+        assert list(s) == [1.0, 9.0, 17.0, 25.0, 33.0, 41.0]
+
+    def test_extra_pre_filter_on_layered(self):
+        """``over="fibers"`` at IP 0 with ``layer_idx=1`` selects only
+        fibers within layer 1 at IP 0 — orthogonal pre-filter."""
+        df = _make_layered_fiber_df()
+        s, used = _reduce_fiber_ip(
+            df, over="fibers", ip_idx=0, layer_idx=1, reduce="mean"
+        )
+        assert used == ["sigma_f0_l1_ip0", "sigma_f1_l1_ip0"]
+
+    def test_layered_no_fibers_over_all(self):
+        df = _make_no_fiber_layered_df()
+        s, used = _reduce_fiber_ip(df, over="all", reduce="sum")
+        assert len(used) == 4
+        # row 0 = [0, 1, 2, 3] -> sum 6
+        assert list(s) == [6.0, 22.0, 38.0, 54.0, 70.0, 86.0]
+
+    @pytest.mark.parametrize(
+        "op,expected_row0",
+        [
+            ("mean",    1.5),
+            ("median",  1.5),
+            ("max",     3.0),
+            ("min",     0.0),
+            ("sum",     6.0),
+        ],
+    )
+    def test_all_reduce_ops_on_row0(self, op, expected_row0):
+        df = _make_fiber_df()
+        s, _ = _reduce_fiber_ip(df, over="all", reduce=op)
+        assert s.iloc[0] == expected_row0
+
+    def test_abs_max_returns_magnitude(self):
+        """abs_max must return the *magnitude* (positive), not the signed
+        peak — distinguishes from plain max when negatives dominate."""
+        df = _make_fiber_df()
+        df.iloc[0] = [-5.0, 2.0, -3.0, 1.0]   # |max| = 5, signed max = 2
+        s, _ = _reduce_fiber_ip(df, over="all", reduce="abs_max")
+        assert s.iloc[0] == 5.0
+
+
+# ---------------------------------------------------------------------- #
+# _reduce_fiber_ip — validation
+# ---------------------------------------------------------------------- #
+
+class TestReduceValidation:
+    def test_over_fibers_requires_ip_idx(self):
+        df = _make_fiber_df()
+        with pytest.raises(ValueError, match="requires.*ip_idx"):
+            _reduce_fiber_ip(df, over="fibers", reduce="mean")
+
+    def test_over_ips_requires_fiber_idx(self):
+        df = _make_fiber_df()
+        with pytest.raises(ValueError, match="requires.*fiber_idx"):
+            _reduce_fiber_ip(df, over="ips", reduce="mean")
+
+    def test_over_layers_requires_both(self):
+        df = _make_layered_fiber_df()
+        with pytest.raises(ValueError, match="requires.*ip_idx"):
+            _reduce_fiber_ip(
+                df, over="layers", fiber_idx=0, reduce="mean"
+            )
+
+    def test_unknown_over_lists_valid(self):
+        df = _make_fiber_df()
+        with pytest.raises(ValueError, match="over=.*not in"):
+            _reduce_fiber_ip(df, over="bogus", reduce="mean")
+
+    def test_unknown_reduce_lists_valid(self):
+        df = _make_fiber_df()
+        with pytest.raises(ValueError, match="reduce=.*not in"):
+            _reduce_fiber_ip(df, over="all", reduce="bogus")
+
+    def test_filter_wipes_everything_lists_present_tags(self):
+        df = _make_fiber_df()
+        with pytest.raises(ValueError) as exc:
+            _reduce_fiber_ip(df, over="all", reduce="mean", layer_idx=99)
+        msg = str(exc.value)
+        assert "layer_idx" in msg
+        # Tail-tags listing should include all axes that actually exist.
+        assert "_f0" in msg and "_f1" in msg
+        assert "_ip0" in msg and "_ip1" in msg


### PR DESCRIPTION
## Summary

Adds `er.plot.history_canonical(...)` — a sibling to the existing
`er.plot.history(...)` that takes a **canonical engineering name** (e.g.
`"strain_11"`) and collapses the matching fiber / IP / layer columns
with a chosen reduction. One curve per element on the time axis.

## Motivation

Fiber buckets (`section.fiber.stress`, `section.fiber.strain`) expand
a single quantity into `n_fibers × n_ip` (or `n_fibers × n_layers ×
n_ip` for layered shells) raw columns. Until now the only way to plot
one was to pick a single fiber/IP column by name:

```python
er.plot.history("eps11_f3_ip0", element_ids=ids)
```

That's awkward when you actually want the **mean over fibers**, the
**peak across IPs**, or the **max(|.|) across the whole cross-section**.

## What lands

```python
ax, meta = er.plot.history_canonical(
    canonical_name,                     # "strain_11", "stress_11", ...
    *,
    over="all",                         # "all" | "fibers" | "ips" | "layers"
    reduce="mean",                      # mean | median | max | min | abs_max | sum
    fiber_idx=None, ip_idx=None, layer_idx=None,
    element_ids=None,
    ax=None, x_axis="time",
    annotate_stage_boundaries=True,
    **plot_kwargs,
)
```

* `over` declares which axis the reduction collapses; the partner
  anchors become required when `over != "all"` (e.g. `over="fibers"`
  needs `ip_idx=` so the reduction collapses fibers at a fixed IP
  rather than silently folding in every IP too).
* `meta["columns_used"]` lists the raw columns folded in — useful for
  audit and downstream labelling.
* `meta` otherwise mirrors `history()`: `x`, `y_per_element`, plus a
  reduced `series` and `stage_boundaries` on multi-stage results.

The reduction logic lives in two private module-level helpers
(`_filter_canonical_columns`, `_reduce_fiber_ip`) so the regex matching
and the dispatch table are unit-testable in isolation — no HDF5
fixture needed.

## Examples

```python
# Mean ε11 over every fiber and IP, one curve per element:
er.plot.history_canonical("strain_11", reduce="mean")

# Max(|σ11|) over fibers at IP 0:
er.plot.history_canonical("stress_11", over="fibers", ip_idx=0,
                           reduce="abs_max")

# Max over IPs of fiber 0:
er.plot.history_canonical("stress_11", over="ips", fiber_idx=0,
                           reduce="max", element_ids=[1, 2, 3])
```

## Design decisions (locked with the user up front)

| Choice | Picked | Why |
|---|---|---|
| API shape | New sibling method (not extending `history`) | Keeps the existing `history(component=...)` signature unambiguous; no canonical/raw name collision. |
| Reduction scope | Within-element only | Matches the stated need; keeps signature small. Across-elements reduction can land later if needed. |
| Public data reducer | No (private helpers only) | Sibling-method-only path was the explicit pick. |

## Tests

* `tests/unit/elements/test_history_canonical_reduce.py` — **24 new tests**:
  every `over=` mode against three column-naming patterns (compressed
  fibers, layered no-fibers, layered with fibers), all six reduce ops
  with hand-computed expected values, fiber-anchor substring
  disambiguation (`_f1` vs `_f10`), every validation path.
* `tests/integration/test_element_plotting.py` — 5 new end-to-end tests
  against the `solid_partition_dir` `section.fiber.stress` bucket;
  auto-skip in environments without the heavy fixture (per existing
  conftest conventions).

Locally: **125 passed, 6 skipped** (skips are the new integration
tests on a fixture-less environment; everything else green).

## Docs

* [`docs/ElementResults.md`](docs/ElementResults.md) — Plotting section
  updated; the new method gets two example calls and a paragraph on
  the `over=` / anchor pattern.
* [`docs/nodes_elements_cuts_plotting_guide.md`](docs/nodes_elements_cuts_plotting_guide.md)
  — new comprehensive usage guide covering nodes, elements, section
  cuts, and plotting (written earlier in the same session; includes
  `history_canonical` in §4.2).

## Example

* [`examples/solid_mixed_example.py`](examples/solid_mixed_example.py)
  — new **section 11** slotted in right after the
  "`integrate_canonical` doesn't work for fibers" section (the natural
  narrative complement), demonstrating all three `over=` modes and the
  missing-anchor error path. Old 11/12/13 renumbered to 12/13/14;
  module docstring and `main()` updated.

## Versioning

This is a backward-compatible feature (MINOR per the repo's semver
policy). Not bumping `pyproject.toml` here — past PRs (#95, #96) merged
without bumps and the version was rolled in a dedicated release PR
(#97). Same pattern applies here.

## Follow-up flagged separately

While auditing docs I noticed [`docs/elements_guide.md`](docs/elements_guide.md)
calls `er.plot.xy(...)` in three places — but `xy()` only exists on
`NodalResults`, not `ElementResults`. That predates this PR and is
out of scope; flagged as its own task chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)